### PR TITLE
chore: add into_unknown; refactor tsfn api; add tests for js function

### DIFF
--- a/napi/src/js_values/buffer.rs
+++ b/napi/src/js_values/buffer.rs
@@ -2,7 +2,7 @@ use std::ops::{Deref, DerefMut};
 use std::ptr;
 use std::slice;
 
-use super::{JsObject, NapiValue, Value, ValueType};
+use super::{JsObject, JsUnknown, NapiValue, Value, ValueType};
 use crate::error::check_status;
 use crate::{sys, Result};
 
@@ -11,6 +11,12 @@ pub struct JsBuffer {
   pub value: JsObject,
   pub data: *const u8,
   pub len: u64,
+}
+
+impl JsBuffer {
+  pub fn into_unknown(self) -> Result<JsUnknown> {
+    self.value.into_unknown()
+  }
 }
 
 impl NapiValue for JsBuffer {

--- a/napi/src/js_values/function.rs
+++ b/napi/src/js_values/function.rs
@@ -8,7 +8,22 @@ use crate::{sys, Env, Error, JsObject, JsUnknown, NapiValue, Result, Status};
 #[derive(Clone, Copy, Debug)]
 pub struct JsFunction(pub(crate) Value);
 
+/// See [Working with JavaScript Functions](https://nodejs.org/api/n-api.html#n_api_working_with_javascript_functions).
+///
+/// Example:
+/// ```
+/// use napi::{JsFunction, CallContext, JsNull, Result};
+///
+/// #[js_function(1)]
+/// pub fn call_function(ctx: CallContext) -> Result<JsNull> {
+///   let js_func = ctx.get::<JsFunction>(0)?;
+///   let js_string = ctx.env.create_string("hello".as_ref())?.into_unknown()?;
+///   js_func.call(None, &[js_string])?;
+///   Ok(ctx.env.get_null()?)
+/// }
+/// ```
 impl JsFunction {
+  /// [napi_call_function](https://nodejs.org/api/n-api.html#n_api_napi_call_function)
   pub fn call(&self, this: Option<&JsObject>, args: &[JsUnknown]) -> Result<JsUnknown> {
     let raw_this = this
       .map(|v| v.into_raw())

--- a/napi/src/js_values/mod.rs
+++ b/napi/src/js_values/mod.rs
@@ -98,6 +98,9 @@ macro_rules! impl_js_value_methods {
       pub fn into_raw(self) -> sys::napi_value {
         self.0.value
       }
+      pub fn into_unknown(self) -> Result<JsUnknown> {
+        JsUnknown::from_raw(self.0.env, self.0.value)
+      }
       pub fn coerce_to_number(self) -> Result<JsNumber> {
         let mut new_raw_value = ptr::null_mut();
         let status =

--- a/test_module/__test__/function.spec.js
+++ b/test_module/__test__/function.spec.js
@@ -1,0 +1,22 @@
+const test = require('ava')
+
+const bindings = require('../index.node')
+
+test('should call the function', async (t) => {
+  const ret = await new Promise((resolve) => {
+    bindings.testCallFunction((arg1, arg2) => {
+      resolve(`${arg1} ${arg2}`)
+    })
+  })
+  t.is(ret, 'hello world')
+})
+
+test('should set "this" properly', async (t) => {
+  const obj = {}
+  const ret = await new Promise((resolve) => {
+    bindings.testCallFunctionWithThis(obj, function () {
+      resolve(this)
+    })
+  })
+  t.is(ret, obj)
+})

--- a/test_module/__test__/threadsafe_function.spec.js
+++ b/test_module/__test__/threadsafe_function.spec.js
@@ -5,11 +5,10 @@ test('should get js function called from a thread', async (t) => {
   let called = 0
 
   return new Promise((resolve, reject) => {
-    bindings.testThreadsafeFunction((err, ret) => {
+    bindings.testThreadsafeFunction((...args) => {
       called += 1
       try {
-        t.is(err, null)
-        t.is(ret, 42)
+        t.deepEqual(args, [null, 42, 1, 2, 3])
       } catch (err) {
         reject(err)
       }

--- a/test_module/src/function.rs
+++ b/test_module/src/function.rs
@@ -1,0 +1,22 @@
+use napi::{JsFunction, CallContext, JsNull, Result, JsObject};
+
+#[js_function(1)]
+pub fn call_function(ctx: CallContext) -> Result<JsNull> {
+  let js_func = ctx.get::<JsFunction>(0)?;
+  let js_string_hello = ctx.env.create_string("hello".as_ref())?.into_unknown()?;
+  let js_string_world = ctx.env.create_string("world".as_ref())?.into_unknown()?;
+
+  js_func.call(None, &[js_string_hello, js_string_world])?;
+
+  Ok(ctx.env.get_null()?)
+}
+
+#[js_function(2)]
+pub fn call_function_with_this(ctx: CallContext) -> Result<JsNull> {
+  let js_this = ctx.get::<JsObject>(0)?;
+  let js_func = ctx.get::<JsFunction>(1)?;
+
+  js_func.call(Some(&js_this), &[])?;
+
+  Ok(ctx.env.get_null()?)
+}

--- a/test_module/src/lib.rs
+++ b/test_module/src/lib.rs
@@ -9,12 +9,14 @@ use napi::{CallContext, Error, JsString, JsUnknown, Module, Result, Status};
 mod napi5;
 
 mod buffer;
+mod function;
 mod external;
 mod symbol;
 mod task;
 mod tsfn;
 
 use buffer::{buffer_to_string, get_buffer_length};
+use function::{call_function, call_function_with_this};
 use external::{create_external, get_external_count};
 #[cfg(napi5)]
 use napi5::is_date::test_object_is_date;
@@ -38,6 +40,8 @@ fn init(module: &mut Module) -> Result<()> {
   module.create_named_method("testTsfnError", test_tsfn_error)?;
   module.create_named_method("testThreadsafeFunction", test_threadsafe_function)?;
   module.create_named_method("testTokioReadfile", test_tokio_readfile)?;
+  module.create_named_method("testCallFunction", call_function)?;
+  module.create_named_method("testCallFunctionWithThis", call_function_with_this)?;
   #[cfg(napi5)]
   module.create_named_method("testObjectIsDate", test_object_is_date)?;
   Ok(())


### PR DESCRIPTION
Just found that `ctx.get::<Function>(0)` is not implemented in the previous version. 

`JsFunction::call()` accept `JsUnknown` as its arguments but it seems that there is no simple way to create a `JsUnknown` from other js types, like `JsString` in the example. We might want to add a api for that?