### PR TITLE
Removed unshifted null from arguments of threadsafe callbacks

### DIFF
--- a/napi/src/threadsafe_function.rs
+++ b/napi/src/threadsafe_function.rs
@@ -202,21 +202,17 @@ unsafe extern "C" fn call_js_cb<T: ToJs>(
 
   let status;
 
-  // Follow the convention of Node.js async callback.
   if ret.is_ok() {
     let values = ret.unwrap();
-    let js_null = env.get_null().unwrap();
-    let mut raw_values: Vec<sys::napi_value> = vec![];
-    raw_values.push(js_null.0.value);
+    let mut raw_values: Vec<sys::napi_value> = Vec::with_capacity(values.len());
     for item in values.iter() {
       raw_values.push(item.0.value)
     }
-
     status = sys::napi_call_function(
       raw_env,
       recv,
       js_callback,
-      (values.len() + 1) as u64,
+      values.len() as u64,
       raw_values.as_ptr(),
       ptr::null_mut(),
     );

--- a/test_module/__test__/napi4/threadsafe_function.spec.js
+++ b/test_module/__test__/napi4/threadsafe_function.spec.js
@@ -15,7 +15,7 @@ test('should get js function called from a thread', async (t) => {
     bindings.testThreadsafeFunction((...args) => {
       called += 1
       try {
-        t.deepEqual(args, [null, 42, 1, 2, 3])
+        t.deepEqual(args, [42, 1, 2, 3])
       } catch (err) {
         reject(err)
       }

--- a/test_module/src/napi4/tsfn.rs
+++ b/test_module/src/napi4/tsfn.rs
@@ -72,8 +72,9 @@ impl ToJs for HandleBuffer {
   type Output = Vec<u8>;
 
   fn resolve(&self, env: &mut Env, output: Self::Output) -> Result<Vec<JsUnknown>> {
+    let null_error = env.get_null()?.into_unknown()?;
     let value = env.create_buffer_with_data(output.to_vec())?.into_unknown()?;
-    Ok(vec![value])
+    Ok(vec![null_error, value])
   }
 }
 


### PR DESCRIPTION
Hello,

This PR removes the prepended arguments to threadsafe node callbacks. I've tested it with both arguments and a lack of arguments passed to the callback.