### PR TITLE
Fixed documentation of threadsafe functions

### DIFF
--- a/napi/src/threadsafe_function.rs
+++ b/napi/src/threadsafe_function.rs
@@ -45,12 +45,10 @@ pub trait ToJs: Copy + Clone {
 ///
 /// impl ToJs for HandleNumber {
 ///   type Output = u8;
-///   type JsValue = JsNumber;
 ///
-///   fn resolve(&self, env: &mut Env, output: Self::Output) -> Result<(u64, Self::JsValue)> {
-///     let argv: u64 = 1;
-///     let value = env.create_uint32(output as u32)?;
-///     Ok((argv, value))
+///   fn resolve(&self, env: &mut Env, output: Self::Output) -> Result<Vec<JsUnknown>> {
+///     let value = env.create_uint32(output as u32)?.into_unknown()?;
+///     Ok(vec![value])
 ///   }
 /// }
 ///


### PR DESCRIPTION
Hello,

This fixes the inline documentation to match the current API of threadsafe functions, since the number of arguments is no longer passed as a u64, but inferred from the length of the Vector.

It also adds notes about the intended argument convention, passing an Error or null as the first argument depending on the Result.

https://nodejs.org/en/knowledge/errors/what-are-the-error-conventions/

Thanks!

Closes #107