### PR TITLE
refactor(napi): use get_uv_event_loop instead of uv_default_loop

### DIFF
--- a/test_module/__test__/napi4/uv.spec.js
+++ b/test_module/__test__/napi4/uv.spec.js
@@ -25,20 +25,19 @@ test('should execute future on libuv thread pool', async (t) => {
   t.deepEqual(readFileSync(filepath), fileContent)
 })
 
-test('should execute future on libuv thread pool of "Worker"', async (t) => {
-  // Test in threads if current Node.js supports "worker_threads".`
-  if (!threadMod || napiVersion < 4) {
-    return
-  }
+if (threadMod && napiVersion >= 4) {
+  test('should execute future on libuv thread pool of "Worker"', async (t) => {
+    // Test in threads if current Node.js supports "worker_threads".`
 
-  const { Worker } = threadMod
-  const script = resolve(__dirname, './uv_worker.js')
-  const worker = new Worker(script)
-  const success = await new Promise((resolve) => {
-    worker.on('message', (success) => {
-      resolve(success)
+    const { Worker } = threadMod
+    const script = resolve(__dirname, './uv_worker.js')
+    const worker = new Worker(script)
+    const success = await new Promise((resolve) => {
+      worker.on('message', (success) => {
+        resolve(success)
+      })
     })
-  })
 
-  t.is(success, true)
-})
+    t.is(success, true)
+  })
+}

--- a/test_module/__test__/napi4/uv.spec.js
+++ b/test_module/__test__/napi4/uv.spec.js
@@ -1,9 +1,17 @@
 const test = require('ava')
-const { join } = require('path')
+const { join, resolve } = require('path')
 const { readFileSync } = require('fs')
 
 const bindings = require('../../index.node')
 const napiVersion = require('../napi-version')
+
+let threadMod
+
+try {
+  threadMod = require('worker_threads')
+} catch (err) {
+  //
+}
 
 const filepath = join(__dirname, './example.txt')
 
@@ -15,4 +23,22 @@ test('should execute future on libuv thread pool', async (t) => {
   const fileContent = await bindings.uvReadFile(filepath)
   t.true(Buffer.isBuffer(fileContent))
   t.deepEqual(readFileSync(filepath), fileContent)
+})
+
+test('should execute future on libuv thread pool of "Worker"', async (t) => {
+  // Test in threads if current Node.js supports "worker_threads".`
+  if (!threadMod || napiVersion < 4) {
+    return
+  }
+
+  const { Worker } = threadMod
+  const script = resolve(__dirname, './uv_worker.js')
+  const worker = new Worker(script)
+  const success = await new Promise((resolve) => {
+    worker.on('message', (success) => {
+      resolve(success)
+    })
+  })
+
+  t.is(success, true)
 })

--- a/test_module/__test__/napi4/uv_worker.js
+++ b/test_module/__test__/napi4/uv_worker.js
@@ -1,0 +1,16 @@
+const { isMainThread, parentPort } = require('worker_threads')
+const { join } = require('path')
+const { readFileSync } = require('fs')
+const bindings = require('../../index.node')
+
+const filepath = join(__dirname, './example.txt')
+
+if (!isMainThread) {
+  ;(async () => {
+    const fileContent = await bindings.uvReadFile(filepath)
+    const success =
+      Buffer.isBuffer(fileContent) &&
+      readFileSync(filepath).toString('utf8') === fileContent.toString('utf8')
+    parentPort.postMessage(success)
+  })()
+}


### PR DESCRIPTION
Using the`uv_loop_s` from `napi_env` is safer as it's possible that
there are multiple Workers, and therefore multiple uv_loop_s.