### PR TITLE
chore: make bindgen::Builder derive default

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -44,6 +44,7 @@ fn main() {
   sys_bindigs_path.push("bindings.h");
 
   bindgen::Builder::default()
+    .derive_default(true)
     .header(sys_bindigs_path.to_str().unwrap().to_owned())
     .clang_arg(String::from("-I") + node_include_path.to_str().unwrap())
     .rustified_enum("(napi_|uv_).+")


### PR DESCRIPTION
It's cumbersome to use the api from `uv.h` as we have to assign values of each fields for `structs` manually. 

`derive_default(true)` would help a lot(although providing api from `uv.h` might not be what `napi-rs` want to deliver). 