### PR TITLE
Convert bindgen `rustified_enum` to `newtype_enum`

### DIFF
--- a/napi/src/js_values/arraybuffer.rs
+++ b/napi/src/js_values/arraybuffer.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+use std::convert::TryInto;
 use std::mem;
 use std::ops::Deref;
 use std::os::raw::c_void;
@@ -5,7 +7,7 @@ use std::ptr;
 
 use super::{Value, ValueType};
 use crate::error::check_status;
-use crate::{sys, JsUnknown, NapiValue, Ref, Result};
+use crate::{sys, Error, JsUnknown, NapiValue, Ref, Result, Status};
 
 #[repr(transparent)]
 #[derive(Debug)]
@@ -59,22 +61,25 @@ pub enum TypedArrayType {
   BigUint64,
 }
 
-impl From<sys::napi_typedarray_type> for TypedArrayType {
-  fn from(value: sys::napi_typedarray_type) -> Self {
+impl TryFrom<sys::napi_typedarray_type> for TypedArrayType {
+  type Error = Error;
+
+  fn try_from(value: sys::napi_typedarray_type) -> Result<Self> {
     match value {
-      sys::napi_typedarray_type::napi_int8_array => Self::Int8,
-      sys::napi_typedarray_type::napi_uint8_array => Self::Uint8,
-      sys::napi_typedarray_type::napi_uint8_clamped_array => Self::Uint8Clamped,
-      sys::napi_typedarray_type::napi_int16_array => Self::Int16,
-      sys::napi_typedarray_type::napi_uint16_array => Self::Uint16,
-      sys::napi_typedarray_type::napi_int32_array => Self::Int32,
-      sys::napi_typedarray_type::napi_uint32_array => Self::Uint32,
-      sys::napi_typedarray_type::napi_float32_array => Self::Float32,
-      sys::napi_typedarray_type::napi_float64_array => Self::Float64,
+      sys::napi_typedarray_type::napi_int8_array => Ok(Self::Int8),
+      sys::napi_typedarray_type::napi_uint8_array => Ok(Self::Uint8),
+      sys::napi_typedarray_type::napi_uint8_clamped_array => Ok(Self::Uint8Clamped),
+      sys::napi_typedarray_type::napi_int16_array => Ok(Self::Int16),
+      sys::napi_typedarray_type::napi_uint16_array => Ok(Self::Uint16),
+      sys::napi_typedarray_type::napi_int32_array => Ok(Self::Int32),
+      sys::napi_typedarray_type::napi_uint32_array => Ok(Self::Uint32),
+      sys::napi_typedarray_type::napi_float32_array => Ok(Self::Float32),
+      sys::napi_typedarray_type::napi_float64_array => Ok(Self::Float64),
       #[cfg(napi6)]
-      sys::napi_typedarray_type::napi_bigint64_array => Self::BigInt64,
+      sys::napi_typedarray_type::napi_bigint64_array => Ok(Self::BigInt64),
       #[cfg(napi6)]
-      sys::napi_typedarray_type::napi_biguint64_array => Self::BigUint64,
+      sys::napi_typedarray_type::napi_biguint64_array => Ok(Self::BigUint64),
+      _ => Err(Error::from_status(Status::Unknown)),
     }
   }
 }
@@ -234,7 +239,7 @@ impl JsTypedArray {
       data,
       length: len,
       byte_offset,
-      typedarray_type: typedarray_type.into(),
+      typedarray_type: typedarray_type.try_into()?,
       arraybuffer: JsArrayBuffer::from_raw_unchecked(self.0.env, arraybuffer_value),
     })
   }

--- a/napi/src/js_values/mod.rs
+++ b/napi/src/js_values/mod.rs
@@ -78,7 +78,7 @@ pub(crate) fn type_of(env: sys::napi_env, raw_value: sys::napi_value) -> Result<
   unsafe {
     let mut value_type = sys::napi_valuetype::napi_undefined;
     check_status(sys::napi_typeof(env, raw_value, &mut value_type))?;
-    Ok(ValueType::from(value_type))
+    ValueType::try_from(value_type)
   }
 }
 

--- a/napi/src/js_values/object.rs
+++ b/napi/src/js_values/object.rs
@@ -1,5 +1,7 @@
 use super::Value;
 use crate::sys;
+use crate::{Error, Result, Status};
+use std::convert::TryFrom;
 
 #[repr(transparent)]
 #[derive(Debug)]
@@ -12,11 +14,14 @@ pub enum KeyCollectionMode {
 }
 
 #[cfg(napi6)]
-impl From<sys::napi_key_collection_mode> for KeyCollectionMode {
-  fn from(value: sys::napi_key_collection_mode) -> Self {
+impl TryFrom<sys::napi_key_collection_mode> for KeyCollectionMode {
+  type Error = Error;
+
+  fn try_from(value: sys::napi_key_collection_mode) -> Result<Self> {
     match value {
-      sys::napi_key_collection_mode::napi_key_include_prototypes => Self::IncludePrototypes,
-      sys::napi_key_collection_mode::napi_key_own_only => Self::OwnOnly,
+      sys::napi_key_collection_mode::napi_key_include_prototypes => Ok(Self::IncludePrototypes),
+      sys::napi_key_collection_mode::napi_key_own_only => Ok(Self::OwnOnly),
+      _ => Err(Error::from_status(Status::Unknown)),
     }
   }
 }
@@ -44,15 +49,18 @@ pub enum KeyFilter {
 }
 
 #[cfg(napi6)]
-impl From<sys::napi_key_filter> for KeyFilter {
-  fn from(value: sys::napi_key_filter) -> Self {
+impl TryFrom<sys::napi_key_filter> for KeyFilter {
+  type Error = Error;
+
+  fn try_from(value: sys::napi_key_filter) -> Result<Self> {
     match value {
-      sys::napi_key_filter::napi_key_all_properties => Self::AllProperties,
-      sys::napi_key_filter::napi_key_writable => Self::Writable,
-      sys::napi_key_filter::napi_key_enumerable => Self::Enumerable,
-      sys::napi_key_filter::napi_key_configurable => Self::Configurable,
-      sys::napi_key_filter::napi_key_skip_strings => Self::SkipStrings,
-      sys::napi_key_filter::napi_key_skip_symbols => Self::SkipSymbols,
+      sys::napi_key_filter::napi_key_all_properties => Ok(Self::AllProperties),
+      sys::napi_key_filter::napi_key_writable => Ok(Self::Writable),
+      sys::napi_key_filter::napi_key_enumerable => Ok(Self::Enumerable),
+      sys::napi_key_filter::napi_key_configurable => Ok(Self::Configurable),
+      sys::napi_key_filter::napi_key_skip_strings => Ok(Self::SkipStrings),
+      sys::napi_key_filter::napi_key_skip_symbols => Ok(Self::SkipSymbols),
+      _ => Err(Error::from_status(Status::Unknown)),
     }
   }
 }
@@ -78,11 +86,14 @@ pub enum KeyConversion {
 }
 
 #[cfg(napi6)]
-impl From<sys::napi_key_conversion> for KeyConversion {
-  fn from(value: sys::napi_key_conversion) -> Self {
+impl TryFrom<sys::napi_key_conversion> for KeyConversion {
+  type Error = Error;
+
+  fn try_from(value: sys::napi_key_conversion) -> Result<Self> {
     match value {
-      sys::napi_key_conversion::napi_key_keep_numbers => Self::KeepNumbers,
-      sys::napi_key_conversion::napi_key_numbers_to_strings => Self::NumbersToStrings,
+      sys::napi_key_conversion::napi_key_keep_numbers => Ok(Self::KeepNumbers),
+      sys::napi_key_conversion::napi_key_numbers_to_strings => Ok(Self::NumbersToStrings),
+      _ => Err(Error::from_status(Status::Unknown)),
     }
   }
 }

--- a/napi/src/js_values/object_property.rs
+++ b/napi/src/js_values/object_property.rs
@@ -13,11 +13,11 @@ pub struct Property<'env> {
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum PropertyAttributes {
-  Default = sys::napi_property_attributes::napi_default as _,
-  Writable = sys::napi_property_attributes::napi_writable as _,
-  Enumerable = sys::napi_property_attributes::napi_enumerable as _,
-  Configurable = sys::napi_property_attributes::napi_configurable as _,
-  Static = sys::napi_property_attributes::napi_static as _,
+  Default = sys::napi_property_attributes::napi_default.0 as _,
+  Writable = sys::napi_property_attributes::napi_writable.0 as _,
+  Enumerable = sys::napi_property_attributes::napi_enumerable.0 as _,
+  Configurable = sys::napi_property_attributes::napi_configurable.0 as _,
+  Static = sys::napi_property_attributes::napi_static.0 as _,
 }
 
 impl From<PropertyAttributes> for sys::napi_property_attributes {

--- a/napi/src/js_values/value_type.rs
+++ b/napi/src/js_values/value_type.rs
@@ -1,3 +1,4 @@
+use std::convert::TryFrom;
 use std::convert::TryInto;
 
 use crate::{sys, Error, Result, Status};
@@ -22,39 +23,40 @@ impl TryInto<sys::napi_valuetype> for ValueType {
   type Error = Error;
 
   fn try_into(self) -> Result<sys::napi_valuetype> {
-    use sys::napi_valuetype::*;
     match self {
       ValueType::Unknown => Err(Error::from_status(Status::Unknown)),
       #[cfg(napi6)]
-      ValueType::Bigint => Ok(napi_bigint),
-      ValueType::Boolean => Ok(napi_boolean),
-      ValueType::External => Ok(napi_external),
-      ValueType::Function => Ok(napi_function),
-      ValueType::Null => Ok(napi_null),
-      ValueType::Number => Ok(napi_number),
-      ValueType::Object => Ok(napi_object),
-      ValueType::String => Ok(napi_string),
-      ValueType::Symbol => Ok(napi_symbol),
-      ValueType::Undefined => Ok(napi_undefined),
+      ValueType::Bigint => Ok(sys::napi_valuetype::napi_bigint),
+      ValueType::Boolean => Ok(sys::napi_valuetype::napi_boolean),
+      ValueType::External => Ok(sys::napi_valuetype::napi_external),
+      ValueType::Function => Ok(sys::napi_valuetype::napi_function),
+      ValueType::Null => Ok(sys::napi_valuetype::napi_null),
+      ValueType::Number => Ok(sys::napi_valuetype::napi_number),
+      ValueType::Object => Ok(sys::napi_valuetype::napi_object),
+      ValueType::String => Ok(sys::napi_valuetype::napi_string),
+      ValueType::Symbol => Ok(sys::napi_valuetype::napi_symbol),
+      ValueType::Undefined => Ok(sys::napi_valuetype::napi_undefined),
     }
   }
 }
 
-impl From<sys::napi_valuetype> for ValueType {
-  fn from(value: sys::napi_valuetype) -> Self {
-    use sys::napi_valuetype::*;
+impl TryFrom<sys::napi_valuetype> for ValueType {
+  type Error = Error;
+
+  fn try_from(value: sys::napi_valuetype) -> Result<Self> {
     match value {
       #[cfg(napi6)]
-      napi_bigint => ValueType::Bigint,
-      napi_boolean => ValueType::Boolean,
-      napi_external => ValueType::External,
-      napi_function => ValueType::Function,
-      napi_null => ValueType::Null,
-      napi_number => ValueType::Number,
-      napi_object => ValueType::Object,
-      napi_string => ValueType::String,
-      napi_symbol => ValueType::Symbol,
-      napi_undefined => ValueType::Undefined,
+      sys::napi_valuetype::napi_bigint => Ok(ValueType::Bigint),
+      sys::napi_valuetype::napi_boolean => Ok(ValueType::Boolean),
+      sys::napi_valuetype::napi_external => Ok(ValueType::External),
+      sys::napi_valuetype::napi_function => Ok(ValueType::Function),
+      sys::napi_valuetype::napi_null => Ok(ValueType::Null),
+      sys::napi_valuetype::napi_number => Ok(ValueType::Number),
+      sys::napi_valuetype::napi_object => Ok(ValueType::Object),
+      sys::napi_valuetype::napi_string => Ok(ValueType::String),
+      sys::napi_valuetype::napi_symbol => Ok(ValueType::Symbol),
+      sys::napi_valuetype::napi_undefined => Ok(ValueType::Undefined),
+      _ => Err(Error::from_status(Status::Unknown)),
     }
   }
 }

--- a/napi/src/status.rs
+++ b/napi/src/status.rs
@@ -28,31 +28,30 @@ pub enum Status {
 
 impl From<napi_status> for Status {
   fn from(code: napi_status) -> Self {
-    use self::napi_status::*;
     use Status::*;
 
     match code {
-      napi_ok => Ok,
-      napi_invalid_arg => InvalidArg,
-      napi_object_expected => ObjectExpected,
-      napi_string_expected => StringExpected,
-      napi_name_expected => NameExpected,
-      napi_function_expected => FunctionExpected,
-      napi_number_expected => NumberExpected,
-      napi_boolean_expected => BooleanExpected,
-      napi_array_expected => ArrayExpected,
-      napi_generic_failure => GenericFailure,
-      napi_pending_exception => PendingException,
-      napi_cancelled => Cancelled,
-      napi_escape_called_twice => EscapeCalledTwice,
-      napi_handle_scope_mismatch => HandleScopeMismatch,
-      napi_callback_scope_mismatch => CallbackScopeMismatch,
+      napi_status::napi_ok => Ok,
+      napi_status::napi_invalid_arg => InvalidArg,
+      napi_status::napi_object_expected => ObjectExpected,
+      napi_status::napi_string_expected => StringExpected,
+      napi_status::napi_name_expected => NameExpected,
+      napi_status::napi_function_expected => FunctionExpected,
+      napi_status::napi_number_expected => NumberExpected,
+      napi_status::napi_boolean_expected => BooleanExpected,
+      napi_status::napi_array_expected => ArrayExpected,
+      napi_status::napi_generic_failure => GenericFailure,
+      napi_status::napi_pending_exception => PendingException,
+      napi_status::napi_cancelled => Cancelled,
+      napi_status::napi_escape_called_twice => EscapeCalledTwice,
+      napi_status::napi_handle_scope_mismatch => HandleScopeMismatch,
+      napi_status::napi_callback_scope_mismatch => CallbackScopeMismatch,
       #[cfg(napi4)]
-      napi_queue_full => QueueFull,
+      napi_status::napi_queue_full => QueueFull,
       #[cfg(napi4)]
-      napi_closing => Closing,
+      napi_status::napi_closing => Closing,
       #[cfg(napi6)]
-      napi_bigint_expected => BigintExpected,
+      napi_status::napi_bigint_expected => BigintExpected,
       _ => Unknown,
     }
   }

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -62,7 +62,7 @@ fn main() {
   }
 
   bindgen_builder
-    .rustified_enum("(napi_|uv_).+")
+    .newtype_enum("(napi_|uv_).+")
     .whitelist_function("(napi_|uv_|extras_).+")
     .whitelist_type("(napi_|uv_|extras_).+")
     .generate()


### PR DESCRIPTION
Fixes #277. I switched from `rustifed_enum` to `newtype_enum` in `bindgen`. I then replaced all instances of `From` with `TryFrom` where applicable. The conversion uses the library error type with only a status of `Status::Unknown`, which I thought fit here. I will edit if changes are needed.