### PR TITLE
fix(napi): throw out raw JavaScript error in tsfn

### DIFF
--- a/test_module/__test__/napi4/threadsafe_function.spec.ts
+++ b/test_module/__test__/napi4/threadsafe_function.spec.ts
@@ -1,3 +1,6 @@
+import { execSync } from 'child_process'
+import { join } from 'path'
+
 import test from 'ava'
 
 import { napiVersion } from '../napi-version'
@@ -71,4 +74,15 @@ test('should work with napi ref', (t) => {
       }, obj)
     })
   }
+})
+
+test('should be able to throw error in tsfn', (t) => {
+  if (napiVersion < 4) {
+    t.is(bindings.testThreadsafeFunction, undefined)
+    return
+  }
+
+  t.throws(() => {
+    execSync(`node ${join(__dirname, 'tsfn-throw.js')}`)
+  })
 })

--- a/test_module/__test__/napi4/tsfn-throw.js
+++ b/test_module/__test__/napi4/tsfn-throw.js
@@ -1,0 +1,5 @@
+const bindings = require('../../index.node')
+
+bindings.testThreadsafeFunction(() => {
+  throw Error('Throw in thread safe function')
+})


### PR DESCRIPTION
```
Error: Throw in thread safe function
    at /Users/longyinan/workspace/github/napi-rs/test_module/__test__/napi4/tsfn-throw.js:4:9
```

Close https://github.com/napi-rs/napi-rs/issues/437