### PR TITLE
Add a way to convert stateful (Rust) closures into `JsFunction`s.

### DIFF
--- a/napi-derive/src/lib.rs
+++ b/napi-derive/src/lib.rs
@@ -114,7 +114,7 @@ pub fn js_function(attr: TokenStream, input: TokenStream) -> TokenStream {
       }
 
       let mut env = unsafe { Env::from_raw(raw_env) };
-      let ctx = CallContext::new(&mut env, cb_info, raw_this, &raw_args, #arg_len_span, argc);
+      let ctx = CallContext::new(&mut env, cb_info, raw_this, &raw_args, argc);
       #execute_js_function
     }
   };

--- a/napi/src/js_values/value_ref.rs
+++ b/napi/src/js_values/value_ref.rs
@@ -18,14 +18,9 @@ impl<T> Ref<T> {
   #[inline]
   pub(crate) fn new(js_value: Value, ref_count: u32, inner: T) -> Result<Ref<T>> {
     let mut raw_ref = ptr::null_mut();
-    let initial_ref_count = 1;
+    assert_ne!(ref_count, 0, "Initial `ref_count` must be > 0");
     check_status!(unsafe {
-      sys::napi_create_reference(
-        js_value.env,
-        js_value.value,
-        initial_ref_count,
-        &mut raw_ref,
-      )
+      sys::napi_create_reference(js_value.env, js_value.value, ref_count, &mut raw_ref)
     })?;
     Ok(Ref {
       raw_ref,


### PR DESCRIPTION
Preview of the mainly added function (under `impl Env`):

![Screen Shot 2021-03-18 at 21 04 55](https://user-images.githubusercontent.com/9920355/111691549-b7e45600-882e-11eb-8406-1c228e52f43a.png)

While doing this, I found the `arg_len` parameter in `CallContext::new()` to be redundant (and thus even dangerous, should it end up different to the len of the vec), so I've also taken the liberty of trimming that part (adapting the derive accordingly).

Finally, two nits I've spotted when working with this crate: the `ref_count` parameter of `Ref`'s constructor was not used for the actual construction, and also there is an issue with the `maybe_ref` usage in `object.rs` I haven't fixed that one since I wasn't dealing with that part of the API yet, but I thought it best to at least add a comment warning about it).