### PR TITLE
Check compile target at runtime in build

### DIFF
--- a/build/Cargo.toml
+++ b/build/Cargo.toml
@@ -10,7 +10,4 @@ repository = "https://github.com/napi-rs/napi-rs"
 version = "1.0.1"
 
 [dependencies]
-cfg-if = "1"
-
-[target.'cfg(windows)'.dependencies]
 ureq = "2"

--- a/build/Cargo.toml
+++ b/build/Cargo.toml
@@ -10,4 +10,7 @@ repository = "https://github.com/napi-rs/napi-rs"
 version = "1.0.1"
 
 [dependencies]
+cfg-if = "1"
+
+[target.'cfg(not(target_env = "musl"))'.dependencies]
 ureq = "2"

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -1,10 +1,23 @@
 mod macos;
-mod windows;
+
+cfg_if::cfg_if! {
+  if #[cfg(not(target_env = "musl"))] {
+    mod windows;
+  }
+}
 
 pub fn setup() {
   match std::env::var("CARGO_CFG_TARGET_OS").as_deref() {
     Ok("macos") => macos::setup(),
-    Ok("windows") => windows::setup(),
+    Ok("windows") => {
+      cfg_if::cfg_if! {
+        if #[cfg(not(target_env = "musl"))] {
+          windows::setup()
+        } else {
+          eprintln!("Cross compiling to windows-msvc is not supported from *-musl hosts")
+        }
+      }
+    }
     _ => {}
   }
 }

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -1,11 +1,10 @@
-cfg_if::cfg_if! {
-  if #[cfg(windows)] {
-    mod windows;
-    pub use windows::setup;
-  } else if #[cfg(target_os = "macos")] {
-    mod macos;
-    pub use macos::setup;
-  } else {
-    pub fn setup() { }
+mod macos;
+mod windows;
+
+pub fn setup() {
+  match std::env::var("CARGO_CFG_TARGET_OS").as_deref() {
+    Ok("macos") => macos::setup(),
+    Ok("windows") => windows::setup(),
+    _ => {}
   }
 }


### PR DESCRIPTION
I ran into some issues cross compiling from macos to x86_64-unknown-linux-gnu. 

The current compile time checks don't work well for this as the build script is always compiled for the host, so the Mac linker args were getting set for a linux build.

This PR moves the check to the build script's runtime, ie the library compile time