### PR TITLE
fix(napi): do not call release tsfn in Drop when ref count is 0

### DIFF
--- a/test_module/__test__/napi4/threadsafe_function.spec.ts
+++ b/test_module/__test__/napi4/threadsafe_function.spec.ts
@@ -86,3 +86,13 @@ test('should be able to throw error in tsfn', (t) => {
     execSync(`node ${join(__dirname, 'tsfn-throw.js')}`)
   })
 })
+
+test('tsfn dua instance', (t) => {
+  if (napiVersion < 4) {
+    t.is(bindings.A, undefined)
+    return
+  }
+  t.notThrows(() => {
+    execSync(`node ${join(__dirname, 'tsfn-dua-instance.js')}`)
+  })
+})

--- a/test_module/__test__/napi4/tsfn-dua-instance.js
+++ b/test_module/__test__/napi4/tsfn-dua-instance.js
@@ -1,0 +1,11 @@
+const bindings = require('../../index.node')
+
+async function main() {
+  await Promise.resolve()
+  new bindings.A((s) => console.info(s))
+  new bindings.A((s) => console.info(s))
+}
+
+main().catch((e) => {
+  console.error(e)
+})

--- a/test_module/__test__/napi4/tsfn_error.spec.ts
+++ b/test_module/__test__/napi4/tsfn_error.spec.ts
@@ -9,7 +9,7 @@ test('should call callback with the first arguments as an Error', async (t) => {
     t.is(bindings.testTsfnError, undefined)
     return
   }
-  await new Promise((resolve, reject) => {
+  await new Promise<void>((resolve, reject) => {
     bindings.testTsfnError((err: Error) => {
       try {
         t.is(err instanceof Error, true)

--- a/test_module/src/lib.rs
+++ b/test_module/src/lib.rs
@@ -3,7 +3,7 @@ extern crate napi_derive;
 #[macro_use]
 extern crate serde_derive;
 
-use napi::{JsObject, Result};
+use napi::{Env, JsObject, Result};
 
 mod cleanup_env;
 #[cfg(feature = "latest")]
@@ -35,7 +35,7 @@ mod task;
 use napi_version::get_napi_version;
 
 #[module_exports]
-fn init(mut exports: JsObject) -> Result<()> {
+fn init(mut exports: JsObject, env: Env) -> Result<()> {
   exports.create_named_method("getNapiVersion", get_napi_version)?;
   array::register_js(&mut exports)?;
   error::register_js(&mut exports)?;
@@ -54,7 +54,7 @@ fn init(mut exports: JsObject) -> Result<()> {
   global::register_js(&mut exports)?;
   cleanup_env::register_js(&mut exports)?;
   #[cfg(feature = "latest")]
-  napi4::register_js(&mut exports)?;
+  napi4::register_js(&mut exports, &env)?;
   #[cfg(feature = "latest")]
   tokio_rt::register_js(&mut exports)?;
   #[cfg(feature = "latest")]

--- a/test_module/src/napi4/mod.rs
+++ b/test_module/src/napi4/mod.rs
@@ -1,10 +1,12 @@
-use napi::{JsObject, Result};
+use napi::{Env, JsObject, Result};
 
 mod tsfn;
+mod tsfn_dua_instance;
 
 use tsfn::*;
+use tsfn_dua_instance::constructor;
 
-pub fn register_js(exports: &mut JsObject) -> Result<()> {
+pub fn register_js(exports: &mut JsObject, env: &Env) -> Result<()> {
   exports.create_named_method("testThreadsafeFunction", test_threadsafe_function)?;
   exports.create_named_method("testTsfnError", test_tsfn_error)?;
   exports.create_named_method("testTokioReadfile", test_tokio_readfile)?;
@@ -21,5 +23,9 @@ pub fn register_js(exports: &mut JsObject) -> Result<()> {
     test_call_aborted_threadsafe_function,
   )?;
   exports.create_named_method("testTsfnWithRef", test_tsfn_with_ref)?;
+
+  let obj = env.define_class("A", constructor, &[])?;
+
+  exports.set_named_property("A", obj)?;
   Ok(())
 }

--- a/test_module/src/napi4/tsfn_dua_instance.rs
+++ b/test_module/src/napi4/tsfn_dua_instance.rs
@@ -1,0 +1,33 @@
+use napi::{
+  threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunction},
+  CallContext, JsFunction, JsObject, JsUndefined,
+};
+use napi_derive::js_function;
+
+#[derive(Clone)]
+struct A {
+  cb: ThreadsafeFunction<String>,
+}
+
+#[js_function(1)]
+pub fn constructor(ctx: CallContext) -> napi::Result<JsUndefined> {
+  let callback = ctx.get::<JsFunction>(0)?;
+
+  let mut cb =
+    ctx
+      .env
+      .create_threadsafe_function(&callback, 0, |ctx: ThreadSafeCallContext<String>| {
+        ctx
+          .env
+          .create_string_from_std(ctx.value)
+          .map(|js_string| vec![js_string])
+      })?;
+
+  cb.unref(&ctx.env)?;
+
+  let mut this: JsObject = ctx.this_unchecked();
+  let obj = A { cb };
+
+  ctx.env.wrap(&mut this, obj)?;
+  ctx.env.get_undefined()
+}


### PR DESCRIPTION
Before fix:
```
napi4 › threadsafe_function.ts › tsfn dua instance

  test_module/__test__/napi4/threadsafe_function.spec.ts:95

   94:   }                                                            
   95:   t.notThrows(() => {                                          
   96:     execSync(`node ${join(__dirname, 'tsfn-dua-instance.js')}`)

  Function threw:

  Error {
    output: [
      null,
      Buffer @Uint8Array [],
      Buffer @Uint8Array [],
    ],
    pid: 26327,
    signal: 'SIGABRT',
    status: null,
    stderr: Buffer @Uint8Array [],
    stdout: Buffer @Uint8Array [],
    message: 'Command failed: node /Users/longyinan/workspace/github/napi-rs/test_module/__test__/napi4/tsfn-dua-instance.js',
  }

  › test_module/__test__/napi4/threadsafe_function.spec.ts:96:5
  › test_module/__test__/napi4/threadsafe_function.spec.ts:95:5

  ─

  1 test failed
```

Close https://github.com/napi-rs/napi-rs/issues/518