### PR TITLE
Add docs and target env variable to napi/cli

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -66,6 +66,8 @@ If not set, cli will read the `package.name` field in `Cargo.toml` under `proces
 
 > default `undefined`
 
+You can also define this value using the `RUST_TARGET` environment variable.
+
 This value will be passed to `Cargo build` command directly. eg: `napi build --target x86_64-unknown-linux-musl`
 
 #### `--cargo-flags`
@@ -73,6 +75,12 @@ This value will be passed to `Cargo build` command directly. eg: `napi build --t
 > default `undefined`
 
 Other flags you want pass to `Cargo build`.
+
+#### `--cargo-cwd`
+
+> default `undefined`
+
+This flag can be used to build binaries that are not in the current directory. The path that is passed to this flag should be relative to the current directory.
 
 ### `napi artifacts`
 

--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -30,7 +30,7 @@ export class BuildCommand extends Command {
   cargoName?: string
 
   @Command.String('--target')
-  targetTripleDir = ''
+  targetTripleDir = process.env.RUST_TARGET ?? ''
 
   @Command.String('--features')
   features?: string


### PR DESCRIPTION
For CI it's sometimes very useful to have an environment variable for the target.

Also noticed the cwd flag existed and added it to the readme