### PR TITLE
Allow dropping of string&buffer values when converting

### DIFF
--- a/napi/src/js_values/string/utf16.rs
+++ b/napi/src/js_values/string/utf16.rs
@@ -1,6 +1,6 @@
-use std::convert::TryFrom;
 use std::mem;
 use std::ops::Deref;
+use std::{convert::TryFrom, mem::ManuallyDrop};
 
 use crate::{Error, JsString, Result, Status};
 
@@ -33,6 +33,7 @@ impl JsStringUtf16 {
 
   #[inline]
   pub fn into_value(self) -> JsString {
+    ManuallyDrop::into_inner(self.buf);
     self.inner
   }
 }
@@ -61,6 +62,6 @@ impl AsRef<Vec<u16>> for JsStringUtf16 {
 
 impl From<JsStringUtf16> for Vec<u16> {
   fn from(value: JsStringUtf16) -> Self {
-    value.as_slice().to_vec()
+    ManuallyDrop::into_inner(value.buf)
   }
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
 tab_spaces = 2
+edition = "2018"


### PR DESCRIPTION
The utf8 and utf16 values leak memory a lot, if we don't handle the `ManuallyDrop` values. This fix is first try of changing it. I'd remove the `ManuallyDrop` values completely, but I don't know are they actually needed elsewhere in the code.

Closes: https://github.com/napi-rs/napi-rs/issues/581