### PR TITLE
fix(napi): JsString* leak in from_js_value

### DIFF
--- a/napi/src/js_values/string/mod.rs
+++ b/napi/src/js_values/string/mod.rs
@@ -58,13 +58,9 @@ impl JsString {
       )
     })?;
 
-    mem::forget(result);
-
     Ok(JsStringUtf8 {
       inner: self,
-      buf: mem::ManuallyDrop::new(unsafe {
-        Vec::from_raw_parts(buf_ptr, written_char_count, written_char_count)
-      }),
+      buf: result,
     })
   }
 
@@ -83,13 +79,10 @@ impl JsString {
         &mut written_char_count,
       )
     })?;
-    mem::forget(result);
 
     Ok(JsStringUtf16 {
       inner: self,
-      buf: mem::ManuallyDrop::new(unsafe {
-        Vec::from_raw_parts(buf_ptr, written_char_count, written_char_count)
-      }),
+      buf: result,
     })
   }
 

--- a/napi/src/js_values/string/utf16.rs
+++ b/napi/src/js_values/string/utf16.rs
@@ -1,12 +1,11 @@
-use std::mem;
+use std::convert::TryFrom;
 use std::ops::Deref;
-use std::{convert::TryFrom, mem::ManuallyDrop};
 
 use crate::{Error, JsString, Result, Status};
 
 pub struct JsStringUtf16 {
   pub(crate) inner: JsString,
-  pub(crate) buf: mem::ManuallyDrop<Vec<u16>>,
+  pub(crate) buf: Vec<u16>,
 }
 
 impl JsStringUtf16 {
@@ -33,7 +32,6 @@ impl JsStringUtf16 {
 
   #[inline]
   pub fn into_value(self) -> JsString {
-    ManuallyDrop::into_inner(self.buf);
     self.inner
   }
 }
@@ -62,6 +60,6 @@ impl AsRef<Vec<u16>> for JsStringUtf16 {
 
 impl From<JsStringUtf16> for Vec<u16> {
   fn from(value: JsStringUtf16) -> Self {
-    ManuallyDrop::into_inner(value.buf)
+    value.as_slice().to_vec()
   }
 }


### PR DESCRIPTION
Close https://github.com/napi-rs/napi-rs/issues/583

Don't know why I was using the `ManuallyDrop` in the previous approach, but it's definitely a wrong way to handle `JsString` value. Maybe I want to use `ManuallyDrop` to avoid data copied from `JsString` <=> `JsStringUtf8`, but there is no way to recycle the memory on *GC*.