### PR TITLE
Make sure CI fails if `yarn test` fails

### DIFF
--- a/cli/src/new/ci-template.ts
+++ b/cli/src/new/ci-template.ts
@@ -528,4 +528,4 @@ jobs:
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
-`;
+`


### PR DESCRIPTION
These jobs will happily succeed even if there's no `test` script in `package.json`.