### PR TITLE
Enable node_api syntax error experimental functions

### DIFF
--- a/crates/napi/src/env.rs
+++ b/crates/napi/src/env.rs
@@ -659,6 +659,20 @@ impl Env {
     })
   }
 
+  /// This API throws a JavaScript SyntaxError with the text provided.
+  #[cfg(feature = "experimental")]
+  pub fn throw_syntax_error(&self, msg: &str, code: Option<&str>) -> Result<()> {
+    let code = code.and_then(|s| CString::new(s).ok());
+    let msg = CString::new(msg)?;
+    check_status!(unsafe {
+      sys::node_api_throw_syntax_error(
+        self.0,
+        code.map(|s| s.as_ptr()).unwrap_or(ptr::null_mut()),
+        msg.as_ptr(),
+      )
+    })
+  }
+
   #[allow(clippy::expect_fun_call)]
   /// In the event of an unrecoverable error in a native module
   ///

--- a/crates/napi/src/error.rs
+++ b/crates/napi/src/error.rs
@@ -238,6 +238,8 @@ macro_rules! impl_object_methods {
 impl_object_methods!(JsError, sys::napi_create_error);
 impl_object_methods!(JsTypeError, sys::napi_create_type_error);
 impl_object_methods!(JsRangeError, sys::napi_create_range_error);
+#[cfg(feature = "experimental")]
+impl_object_methods!(JsSyntaxError, sys::node_api_create_syntax_error);
 
 #[doc(hidden)]
 #[macro_export]

--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -850,6 +850,17 @@ extern "C" {
 #[cfg(feature = "experimental")]
 extern "C" {
   pub fn node_api_get_module_file_name(env: napi_env, result: *mut *const c_char) -> napi_status;
+  pub fn node_api_create_syntax_error(
+    env: napi_env,
+    code: napi_value,
+    msg: napi_value,
+    result: *mut napi_value,
+  ) -> napi_status;
+  pub fn node_api_throw_syntax_error(
+    env: napi_env,
+    code: *const c_char,
+    msg: *const c_char,
+  ) -> napi_status;
 }
 
 #[repr(C)]


### PR DESCRIPTION
Since the new added APIs are still experimental, I've added them under the `experimental` feature flag.
