### PR TITLE
fix: keep `.d.ts` and `.js` untouched if native doesn't change

### DIFF
--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -354,6 +354,11 @@ async function processIntermediateTypeFile(
     .split('\n')
     .map((line) => line.trim())
     .filter(Boolean)
+
+  if (!lines.length) {
+    return idents
+  }
+
   const dtsHeader = `/* eslint-disable */
 
 export class ExternalObject<T> {
@@ -466,7 +471,7 @@ async function writeJsBinding(
   distFileName: string | null,
   idents: string[],
 ) {
-  if (distFileName) {
+  if (distFileName && idents.length) {
     const template = createJsBinding(localName, packageName)
     const declareCodes = `const { ${idents.join(', ')} } = nativeBinding\n`
     const exportsCode = idents.reduce(

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -2,7 +2,6 @@ mod macos;
 mod windows;
 
 pub fn setup() {
-  println!("cargo:rerun-if-env-changed=TYPE_DEF_TMP_PATH");
   println!("cargo:rerun-if-env-changed=DEBUG_GENERATED_CODE");
   match std::env::var("CARGO_CFG_TARGET_OS").as_deref() {
     Ok("macos") => macos::setup(),


### PR DESCRIPTION
fix #920 