### PR TITLE
Add support for cross compilation with Zig

### DIFF
--- a/.github/workflows/linux-aarch64-zig.yaml
+++ b/.github/workflows/linux-aarch64-zig.yaml
@@ -1,0 +1,69 @@
+name: Linux-aarch64-zig
+
+env:
+  DEBUG: 'napi:*'
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    name: stable - aarch64-unknown-linux-gnu - node@16
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
+
+      - uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          check-latest: true
+          cache: 'yarn'
+
+      - name: Install
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          target: aarch64-unknown-linux-musl
+
+      - name: Install aarch64 toolchain
+        run: rustup target add aarch64-unknown-linux-gnu
+
+      - name: Install ziglang
+        uses: goto-bus-stop/setup-zig@v1
+        with:
+          version: 0.9.0
+
+      - name: Cache NPM dependencies
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: npm-cache-linux-aarch64-gnu-node@16-${{ hashFiles('yarn.lock') }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --ignore-platform --registry https://registry.npmjs.org --network-timeout 300000
+
+      - name: 'Build TypeScript'
+        run: yarn build
+
+      - name: Cross build native tests
+        run: |
+          yarn --cwd ./examples/napi-compat-mode build --target aarch64-unknown-linux-musl --zig
+          yarn --cwd ./examples/napi build --target aarch64-unknown-linux-musl --zig
+
+      - name: Setup and run tests
+        uses: docker://multiarch/alpine:aarch64-latest-stable
+        with:
+          args: >
+            sh -c "
+              apk add nodejs yarn && \
+              yarn test
+            "

--- a/cli/package.json
+++ b/cli/package.json
@@ -47,6 +47,7 @@
     "chalk": "4",
     "clipanion": "^3.1.0",
     "debug": "^4.3.3",
+    "env-paths": "^3.0.0",
     "fdir": "^5.1.0",
     "inquirer": "^8.2.0",
     "js-yaml": "^4.1.0",

--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -166,6 +166,14 @@ export class BuildCommand extends Command {
       })
     }
 
+    if (triple.raw.includes('musl')) {
+      let rustflags = process.env.RUSTFLAGS ?? ''
+      if (!rustflags.includes('target-feature=-crt-static')) {
+        rustflags += '-C target-feature=-crt-static'
+        additionalEnv['RUSTFLAGS'] = rustflags
+      }
+    }
+
     if (this.useZig && triple.platform === 'linux') {
       const paths = envPaths('napi-rs')
       const cpuArch = getCpuArch(triple.arch)

--- a/cli/src/parse-triple.ts
+++ b/cli/src/parse-triple.ts
@@ -21,6 +21,14 @@ const CpuToNodeArch: { [index: string]: NodeJSArch } = {
   armv7: 'arm',
 }
 
+const NodeArchToCpu: { [index: string]: string } = {
+  arm64: 'aarch64',
+  ppc: 'powerpc',
+  ppc64: 'powerpc64',
+  x32: 'i686',
+  x64: 'x86_64',
+}
+
 const SysToNodePlatform: { [index: string]: NodeJS.Platform } = {
   linux: 'linux',
   freebsd: 'freebsd',
@@ -124,4 +132,8 @@ export function getDefaultTargetTriple(rustcfg: string): PlatformDetail {
     throw new TypeError(`Can not parse target triple from ${currentTriple}`)
   }
   return parseTriple(triple)
+}
+
+export function getCpuArch(nodeArch: NodeJSArch): string {
+  return NodeArchToCpu[nodeArch] || nodeArch
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2636,6 +2636,11 @@ env-paths@^2.2.0:
   resolved "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
+env-paths@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz#2f1e89c2f6dbd3408e1b1711dd82d62e317f58da"
+  integrity sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==
+
 envinfo@^7.7.4:
   version "7.8.1"
   resolved "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz#06377e3e5f4d379fea7ac592d5ad8927e0c4d475"


### PR DESCRIPTION
https://actually.fyi/posts/zig-makes-rust-cross-compilation-just-work/

So that you don't need to compile in a docker container.

Example:

```bash
❯ uname -a
Darwin m1.lan 21.2.0 Darwin Kernel Version 21.2.0: Sun Nov 28 20:29:10 PST 2021; root:xnu-8019.61.5~1/RELEASE_ARM64_T8101 arm64

messense in m1 in napi-rs/examples/napi on  zig is 📦 v0.1.0 via  v17.3.0 via 🦀 v1.57.0
❯ yarn run build --zig --target x86_64-unknown-linux-gnu
yarn run v1.22.17
$ node ../../cli/scripts/index.js build --js false --zig --target x86_64-unknown-linux-gnu
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
✨  Done in 0.67s.

messense in m1 in napi-rs/examples/napi on  zig is 📦 v0.1.0 via  v17.3.0 via 🦀 v1.57.0
❯ file index.node
index.node: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, with debug_info, not stripped
```