### PR TITLE
Unraw rust identifiers before sending it to js.

### DIFF
--- a/crates/macro/src/parser/mod.rs
+++ b/crates/macro/src/parser/mod.rs
@@ -15,6 +15,7 @@ use napi_derive_backend::{
 };
 use proc_macro2::{Ident, TokenStream, TokenTree};
 use quote::ToTokens;
+use syn::ext::IdentExt;
 use syn::parse::{Parse, ParseStream, Result as SynResult};
 use syn::{Attribute, Signature, Type, Visibility};
 
@@ -745,7 +746,7 @@ impl ConvertToAST for syn::ItemStruct {
       let (js_name, name) = match &field.ident {
         Some(ident) => (
           field_opts.js_name().map_or_else(
-            || ident.to_string().to_case(Case::Camel),
+            || ident.unraw().to_string().to_case(Case::Camel),
             |(js_name, _)| js_name.to_owned(),
           ),
           syn::Member::Named(ident.clone()),


### PR DESCRIPTION
To support structs like this one:
```rust
#[napi(object)]
pub struct Struct {
  pub r#type: u32,
}
```