### PR TITLE
Musl zig cross

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -49,6 +49,14 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository }}/nodejs-rust:lts-debian-zig
 
+      - name: Build and push alpine with zig
+        uses: docker/build-push-action@v2
+        with:
+          file: alpine-zig.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ github.repository }}/nodejs-rust:lts-alpine-zig
+
   build_image_arm:
     name: Build Node.js arm images
     strategy:

--- a/alpine-zig.Dockerfile
+++ b/alpine-zig.Dockerfile
@@ -1,0 +1,11 @@
+FROM ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+
+ARG ZIG_VERSION=0.9.0
+
+RUN apk add xz && \
+  rustup target add x86_64-unknown-linux-gnu && \
+  wget https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz && \
+  tar -xvf zig-linux-x86_64-${ZIG_VERSION}.tar.xz && \
+  mv zig-linux-x86_64-${ZIG_VERSION} /usr/local/zig && \
+  ln -sf /usr/local/zig/zig /usr/local/bin/zig && \
+  rm zig-linux-x86_64-${ZIG_VERSION}.tar.xz

--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -250,7 +250,7 @@ export class BuildCommand extends Command {
       const forwardArgs = process.platform === 'win32' ? '%*' : '$@'
       await writeFileAsync(
         linkerWrapperShell,
-        `node ${linkerWrapper} ${forwardArgs}`,
+        `#!/bin/sh\nnode ${linkerWrapper} ${forwardArgs}`,
         {
           mode: '777',
         },


### PR DESCRIPTION
Add `lts-alpine-zig`  Docker image for building `GLIBC_2.17` compatible binary.

I've tried to build `GLIBC_2.17` compatible binary on `ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-zig` image. But it seems the binary is always linked with `GLIBC_2.18` symbols:

```
yarn build --target x86_64-unknown-linux-gnu --zig --zig-abi-suffix 2.17

objdump -T zig-cross.linux-x64-gnu.node
```

<details>
  <summary>Symbols</summary>
  zig-cross.linux-x64-gnu.node:     file format elf64-x86-64

DYNAMIC SYMBOL TABLE:
0000000000000000  w   D  *UND*	0000000000000000  Base        __gmon_start__
0000000000000000  w   D  *UND*	0000000000000000  Base        _ITM_deregisterTMCloneTable
0000000000000000  w   D  *UND*	0000000000000000  Base        _ITM_registerTMCloneTable
0000000000000000  w   DF *UND*	0000000000000000  GLIBC_2.2.5 __cxa_finalize
0000000000000000  w   D  *UND*	0000000000000000  Base        _Jv_RegisterClasses
0000000000000000      D  *UND*	0000000000000000  Base        napi_get_cb_info
0000000000000000      D  *UND*	0000000000000000  Base        napi_get_value_int32
0000000000000000      D  *UND*	0000000000000000  Base        napi_create_int32
0000000000000000      D  *UND*	0000000000000000  Base        napi_create_function
0000000000000000      DF *UND*	0000000000000000  GCC_3.0     _Unwind_Resume
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.14  memcpy
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 bcmp
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 memset
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 memmove
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.3   __tls_get_addr
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 syscall
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 __errno_location
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 read
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 close
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 memchr
0000000000000000      D  *UND*	0000000000000000  Base        napi_create_string_utf8
0000000000000000      D  *UND*	0000000000000000  Base        napi_create_error
0000000000000000      D  *UND*	0000000000000000  Base        napi_throw
0000000000000000      D  *UND*	0000000000000000  Base        napi_create_object
0000000000000000      D  *UND*	0000000000000000  Base        napi_set_named_property
0000000000000000      D  *UND*	0000000000000000  Base        napi_define_class
0000000000000000      D  *UND*	0000000000000000  Base        napi_create_reference
0000000000000000      D  *UND*	0000000000000000  Base        napi_throw_error
0000000000000000      DF *UND*	0000000000000000  GCC_3.0     _Unwind_GetLanguageSpecificData
0000000000000000      DF *UND*	0000000000000000  GCC_4.2.0   _Unwind_GetIPInfo
0000000000000000      DF *UND*	0000000000000000  GCC_3.0     _Unwind_GetRegionStart
0000000000000000      DF *UND*	0000000000000000  GCC_3.0     _Unwind_SetGR
0000000000000000      DF *UND*	0000000000000000  GCC_3.0     _Unwind_SetIP
0000000000000000      DF *UND*	0000000000000000  GCC_3.0     _Unwind_GetDataRelBase
0000000000000000      DF *UND*	0000000000000000  GCC_3.0     _Unwind_GetTextRelBase
0000000000000000      DF *UND*	0000000000000000  GCC_3.0     _Unwind_RaiseException
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 pthread_mutex_lock
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 pthread_mutex_unlock
0000000000000000  w   DF *UND*	0000000000000000  GLIBC_2.18  __cxa_thread_atexit_impl
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 pthread_getspecific
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 pthread_setspecific
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 pthread_rwlock_rdlock
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 pthread_rwlock_unlock
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 getenv
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 strlen
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 abort
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 getcwd
0000000000000000      DF *UND*	0000000000000000  GCC_3.3     _Unwind_Backtrace
0000000000000000      DF *UND*	0000000000000000  GCC_3.0     _Unwind_GetIP
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 dl_iterate_phdr
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 readlink
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 munmap
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 mmap
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.3   realpath
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 free
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 dlsym
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 open64
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 write
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 pthread_key_create
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 pthread_key_delete
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.3.4 __xpg_strerror_r
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 clock_gettime
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 getrusage
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 snprintf
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 access
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 vsnprintf
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 sysconf
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 open
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 madvise
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 strerror
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 mprotect
0000000000000000      DO *UND*	0000000000000000  GLIBC_2.2.5 stderr
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 fputs
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 strncat
0000000000000000      DO *UND*	0000000000000000  GLIBC_2.2.5 environ
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.3   __ctype_toupper_loc
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 strncpy
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 strstr
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 strtol
0000000000000000      DO *UND*	0000000000000000  GLIBC_2.2.5 stdout
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 __cxa_atexit
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 __fxstat64
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 __xstat64
000000000001cad0 g    DF .text	00000000000020f7  Base        napi_register_module_v1
000000000001f740 g    DF .text	00000000000002e5  Base        rust_eh_personality
</details>

There is always `0000000000000000 w DF UND	0000000000000000 GLIBC_2.18 __cxa_thread_atexit_impl` symbol, seems like because: https://github.com/rust-lang/rust/issues/36826

And I've tried pass `-Wl,"--undefined=__cxa_thread_atexit_impl"` to `zig cc`, it doesn't work either.

But, building `gnu.2.17` in a non-gnu environment seems like works. I've tested on `macOS` and `alpine` it was both worked.

/cc @messense @andrewrk