### PR TITLE
chore(napi): switch from windows crate to windows-sys

### DIFF
--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -68,4 +68,4 @@ optional = true
 version = "1"
 
 [target.'cfg(windows)'.dependencies]
-windows = {version = "0.30", features = ["Win32_System_WindowsProgramming", "Win32_System_LibraryLoader", "Win32_Foundation"]}
+windows-sys = {version = "0.32", features = ["Win32_System_WindowsProgramming", "Win32_System_LibraryLoader", "Win32_Foundation"]}

--- a/crates/napi/src/win_delay_load_hook.rs
+++ b/crates/napi/src/win_delay_load_hook.rs
@@ -11,9 +11,11 @@
 
 use std::ffi::CStr;
 
-use windows::Win32::Foundation::{HINSTANCE, PSTR};
-use windows::Win32::System::LibraryLoader::GetModuleHandleA;
-use windows::Win32::System::WindowsProgramming::{DELAYLOAD_INFO, PDELAYLOAD_FAILURE_DLL_CALLBACK};
+use windows_sys::Win32::Foundation::{HINSTANCE, PSTR};
+use windows_sys::Win32::System::LibraryLoader::GetModuleHandleA;
+use windows_sys::Win32::System::WindowsProgramming::{
+  DELAYLOAD_INFO, PDELAYLOAD_FAILURE_DLL_CALLBACK,
+};
 
 // Structures hand-copied from
 // https://docs.microsoft.com/en-us/cpp/build/reference/structure-and-constant-definitions


### PR DESCRIPTION
> The windows-sys crate is a zero-overhead fallback for the most demanding situations and primarily where the absolute best compile time is essential. It only includes function declarations (externs), structs, and constants. No convenience helpers, traits, or wrappers are provided.

https://github.com/microsoft/windows-rs#windows-sys