### PR TITLE
fix(napi): cleanup registered hook upon unloading module with tokio_rt

### DIFF
--- a/crates/napi/src/bindgen_runtime/module_register.rs
+++ b/crates/napi/src/bindgen_runtime/module_register.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::ffi::c_void;
 use std::ffi::CStr;
 use std::ptr;
 use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
@@ -417,7 +418,7 @@ unsafe extern "C" fn napi_register_module_v1(
     crate::tokio_runtime::TOKIO_RT_REF_COUNT.fetch_add(1, Ordering::Relaxed);
     assert_eq!(
       unsafe {
-        sys::napi_add_env_cleanup_hook(env, Some(crate::shutdown_tokio_rt), ptr::null_mut())
+        sys::napi_add_env_cleanup_hook(env, Some(crate::shutdown_tokio_rt), env as *mut c_void)
       },
       sys::Status::napi_ok
     );

--- a/crates/napi/src/tokio_runtime.rs
+++ b/crates/napi/src/tokio_runtime.rs
@@ -35,7 +35,7 @@ pub(crate) static TOKIO_RT_REF_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 #[doc(hidden)]
 #[inline(never)]
-pub extern "C" fn shutdown_tokio_rt(_arg: *mut c_void) {
+pub extern "C" fn shutdown_tokio_rt(arg: *mut c_void) {
   if TOKIO_RT_REF_COUNT.fetch_sub(1, Ordering::Relaxed) == 0 {
     let sender = &RT.1;
     if let Err(e) = sender.clone().try_send(()) {
@@ -46,6 +46,11 @@ pub extern "C" fn shutdown_tokio_rt(_arg: *mut c_void) {
         }
       }
     }
+  }
+
+  unsafe {
+    let env: sys::napi_env = arg as *mut sys::napi_env__;
+    sys::napi_remove_env_cleanup_hook(env, Some(shutdown_tokio_rt), arg);
   }
 }
 

--- a/crates/napi/src/tokio_runtime.rs
+++ b/crates/napi/src/tokio_runtime.rs
@@ -35,7 +35,7 @@ pub(crate) static TOKIO_RT_REF_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 #[doc(hidden)]
 #[inline(never)]
-pub extern "C" fn shutdown_tokio_rt(arg: *mut c_void) {
+pub unsafe extern "C" fn shutdown_tokio_rt(arg: *mut c_void) {
   if TOKIO_RT_REF_COUNT.fetch_sub(1, Ordering::Relaxed) == 0 {
     let sender = &RT.1;
     if let Err(e) = sender.clone().try_send(()) {


### PR DESCRIPTION
The `arg` argument was unused and the `env` is now passed to the cleanup hook, such that it unregisters itself if the module is unloaded.

Due to https://github.com/nodejs/node/issues/5016 (and `dlclose` not being exposed) this doesn't fix anything critical, but it avoids a Node.js crash if the following is run:

```
require('./module.node');
delete require.cache[require.resolve('./module.node')];
require('./module.node');
```