### PR TITLE
fix(cli): temporary dts path may not be writable

### DIFF
--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'child_process'
 import { existsSync, mkdirSync } from 'fs'
+import { tmpdir } from 'os'
 import { join, parse, sep } from 'path'
 
 import { Instance } from 'chalk'
@@ -200,7 +201,7 @@ export class BuildCommand extends Command {
       .filter((flag) => Boolean(flag))
       .join(' ')
     const cargoCommand = `cargo build ${externalFlags}`
-    const intermediateTypeFile = join(__dirname, `type_def.${Date.now()}.tmp`)
+    const intermediateTypeFile = join(tmpdir(), `type_def.${Date.now()}.tmp`)
     debug(`Run ${chalk.green(cargoCommand)}`)
     const additionalEnv = {}
     if (


### PR DESCRIPTION
The build command uses its `__dirname` inside `node_modules` as a temporary directory for writing type definitions, but this path may not be writable.

In my case, I have the cli as a dependency in a Yarn v3 project that also uses PnP, so the package lives in a ZIP file. My workaround for now is `yarn unplug @napi-rs/cli`, but this PR should be a more permanent fix.