### PR TITLE
fix(cli): alias the value as well as the type in .d.ts

### DIFF
--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -550,6 +550,7 @@ async function processIntermediateTypeFile(
 
       if (original_name && name !== original_name) {
         dts += indentLines(`export type ${original_name} = ${name}\n`, nest)
+        dts += indentLines(`export const ${original_name} = ${name}\n`, nest)
       }
 
       dts += indentLines(`${js_doc}export class ${name} {`, nest)


### PR DESCRIPTION
When Rust structs are annotated with an alias for the JS name, the generated `index.d.ts` file exports the *type* name, but not the value. This PR adds a line to export the value with `export const ...`.
