### PR TITLE
fix(napi): double allocation in create_buffer

### DIFF
--- a/crates/napi/src/env.rs
+++ b/crates/napi/src/env.rs
@@ -236,8 +236,7 @@ impl Env {
   /// This API allocates a node::Buffer object. While this is still a fully-supported data structure, in most cases using a TypedArray will suffice.
   pub fn create_buffer(&self, length: usize) -> Result<JsBufferValue> {
     let mut raw_value = ptr::null_mut();
-    let mut data: Vec<u8> = Vec::with_capacity(length);
-    let mut data_ptr = data.as_mut_ptr() as *mut c_void;
+    let mut data_ptr = ptr::null_mut();
     check_status!(unsafe {
       sys::napi_create_buffer(self.0, length, &mut data_ptr, &mut raw_value)
     })?;
@@ -248,7 +247,7 @@ impl Env {
         value: raw_value,
         value_type: ValueType::Object,
       }),
-      mem::ManuallyDrop::new(data),
+      mem::ManuallyDrop::new(unsafe { Vec::from_raw_parts(data_ptr as *mut _, length, length) }),
     ))
   }
 
@@ -366,8 +365,7 @@ impl Env {
 
   pub fn create_arraybuffer(&self, length: usize) -> Result<JsArrayBufferValue> {
     let mut raw_value = ptr::null_mut();
-    let mut data: Vec<u8> = Vec::with_capacity(length as usize);
-    let mut data_ptr = data.as_mut_ptr() as *mut c_void;
+    let mut data_ptr = ptr::null_mut();
     check_status!(unsafe {
       sys::napi_create_arraybuffer(self.0, length, &mut data_ptr, &mut raw_value)
     })?;


### PR DESCRIPTION
`napi_create_buffer` allocates, but so does `Vec::with_capacity`, so `Env::create_buffer` allocated twice then leaked the `Vec` allocation.

On top of this, a `JsBufferValue` was returned with an empty slice, because it was based on the `Vec` (which was empty, though with capacity). There was no way to extend the slice or otherwise access the full capacity, except to do a round-trip `buf.to_raw().into_value()` (so it'd base the new slice on `napi_get_buffer_info`).

Issue with this change is that `napi_create_buffer` allocates without initialization. I think technically we'd need a slice like `[MaybeUninit<u8>]` in cases like this. Alternatively we could zero the buffer for the user, but technically a user can also pass us a `Buffer.allocUnsafe()`, so then should `JsBufferValue` always deref to `[MaybeUninit<u8>]`? I haven't tried this yet, so not sure what inconveniences that brings. Since it's already a `[u8]`, I thought best not to change it for now.

I also changed `Env::create_arraybuffer`, which also allocated twice, but at least didn't leak or return an empty slice.