### PR TITLE
Add support for building binaries

### DIFF
--- a/.github/workflows/cli-binary.yml
+++ b/.github/workflows/cli-binary.yml
@@ -1,0 +1,57 @@
+name: Cli Build Binary
+
+env:
+  DEBUG: 'napi:*'
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build_binary_crate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          check-latest: true
+          cache: 'yarn'
+
+      - name: Install
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: stable-cargo-cache-build-binary
+
+      - name: 'Install dependencies'
+        run: yarn install --mode=skip-build --immutable --network-timeout 300000
+
+      - name: 'Build TypeScript'
+        run: yarn build
+
+      - name: Build and run binary
+        run: |
+          yarn workspace binary build
+          ./examples/binary/napi-examples-binary
+        env:
+          RUST_BACKTRACE: 1
+
+      - name: Clear the cargo caches
+        run: |
+          cargo install cargo-cache --no-default-features --features ci-autoclean
+          cargo-cache

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "./crates/sys",
   "./examples/napi",
   "./examples/napi-compat-mode",
+  "./examples/binary",
   "./bench",
   "./memory-testing",
 ]

--- a/examples/binary/.gitignore
+++ b/examples/binary/.gitignore
@@ -1,0 +1,2 @@
+*.node
+napi-examples-binary

--- a/examples/binary/Cargo.toml
+++ b/examples/binary/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+edition = "2021"
+name = "napi-examples-binary"
+publish = false
+version = "0.1.0"
+
+[dependencies]

--- a/examples/binary/package.json
+++ b/examples/binary/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "binary",
+  "private": true,
+  "version": "0.0.0",
+  "bin": "napi-examples-binary",
+  "scripts": {
+    "build": "node ../../cli/scripts/index.js build --js false",
+    "build-aarch64": "node ../../cli/scripts/index.js build --js false --target aarch64-unknown-linux-gnu",
+    "build-armv7": "node ../../cli/scripts/index.js build --js false --target armv7-unknown-linux-gnueabihf",
+    "build-i686": "node ../../cli/scripts/index.js build --js false --target i686-pc-windows-msvc",
+    "build-i686-release": "node ../../cli/scripts/index.js build --js false --release --target i686-pc-windows-msvc",
+    "build-release": "node ../../cli/scripts/index.js build --js false --release"
+  }
+}

--- a/examples/binary/src/main.rs
+++ b/examples/binary/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+  println!("Hello World!");
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "triples",
     "memory-testing",
     "examples/napi",
-    "examples/napi-compat-mode"
+    "examples/napi-compat-mode",
+    "examples/binary"
   ],
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2217,6 +2217,14 @@ __metadata:
   languageName: node
   linkType: hard
 
+"binary@workspace:examples/binary":
+  version: 0.0.0-use.local
+  resolution: "binary@workspace:examples/binary"
+  bin:
+    binary: napi-examples-binary
+  languageName: unknown
+  linkType: soft
+
 "bl@npm:^4.0.3, bl@npm:^4.1.0":
   version: 4.1.0
   resolution: "bl@npm:4.1.0"


### PR DESCRIPTION
For https://github.com/napi-rs/napi-rs/discussions/1077

> It would be nice if n-api CLI supported binaries, since the rest of the tooling (artifacts, CI actions, etc) are still beneficial.

I think #1074 would also need this to distribute binaries on npm.