### PR TITLE
fix: cargo metadata with large project

### DIFF
--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -213,6 +213,7 @@ export class BuildCommand extends Command {
     const cargoMetadata = JSON.parse(
       execSync('cargo metadata --format-version 1', {
         stdio: 'pipe',
+        maxBuffer: 1024 * 1024 * 10,
       }).toString('utf8'),
     )
     const packages = cargoMetadata.packages


### PR DESCRIPTION
Set `maxBuffer` to 10mb, cargo metadata may output
data more than 1mb(the nodejs default value).

Refs:
- https://github.com/napi-rs/napi-rs/issues/1116