### PR TITLE
change MSRV to `1.58.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ _Main branch is now under napi@next developing. Checkout [v1 docs](https://napi.
 
 ## MSRV
 
-**Rust** `1.57.0`
+**Rust** `1.58.0`
 
 |                       | node12 | node14 | node16 | node17 |
 | --------------------- | ------ | ------ | ------ | ------ |


### PR DESCRIPTION
closes https://github.com/napi-rs/napi-rs/issues/1126

[`CString::from_vec_with_nul_unchecked`](https://doc.rust-lang.org/std/ffi/struct.CString.html#method.from_vec_with_nul_unchecked) was only stabilized in `1.58.0`