### PR TITLE
fix(napi): `cannot find trait ToNapiValue` error

### DIFF
--- a/crates/napi/src/env.rs
+++ b/crates/napi/src/env.rs
@@ -7,7 +7,7 @@ use std::mem;
 use std::os::raw::{c_char, c_void};
 use std::ptr;
 
-#[cfg(all(feature = "tokio_rt", feature = "napi4"))]
+#[cfg(all(feature = "napi4"))]
 use crate::bindgen_runtime::ToNapiValue;
 use crate::{
   async_work::{self, AsyncWorkPromise},


### PR DESCRIPTION
fixes #1135 

This error occurs when
```toml
napi = { version="2", default-features = false, features = ["napi4"] }
```