### PR TITLE
fix(napi): load Node-API symbols manually on Windows

### DIFF
--- a/crates/napi/src/bindgen_runtime/module_register.rs
+++ b/crates/napi/src/bindgen_runtime/module_register.rs
@@ -262,6 +262,10 @@ unsafe extern "C" fn napi_register_module_v1(
   env: sys::napi_env,
   exports: sys::napi_value,
 ) -> sys::napi_value {
+  #[cfg(windows)]
+  unsafe {
+    sys::setup();
+  }
   let lock = MODULE_REGISTER_LOCK
     .lock()
     .expect("Failed to acquire module register lock");

--- a/crates/sys/Cargo.toml
+++ b/crates/sys/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["LongYinan <lynweklm@gmail.com>"]
 description = "NodeJS N-API raw binding"
 edition = "2021"
-include = ["src/**/*", "Cargo.toml", "build.rs", ".node-headers/**/*"]
+include = ["src/**/*", "Cargo.toml"]
 keywords = ["NodeJS", "FFI", "NAPI", "n-api"]
 license = "MIT"
 name = "napi-sys"
@@ -26,6 +26,3 @@ independent = true
 
 [target.'cfg(windows)'.dependencies.libloading]
 version = "0.7"
-
-[target.'cfg(windows)'.dependencies.ctor]
-version = "0.1"

--- a/crates/sys/src/functions.rs
+++ b/crates/sys/src/functions.rs
@@ -739,10 +739,13 @@ pub use napi8::*;
 
 #[cfg(windows)]
 pub(super) unsafe fn load() -> Result<(), libloading::Error> {
-  #[cfg(not(windows))]
-  let host = libloading::os::unix::Library::this().into();
-  #[cfg(windows)]
-  let host = libloading::os::windows::Library::this()?.into();
+  let host = match libloading::os::windows::Library::this() {
+    Ok(lib) => lib.into(),
+    Err(err) => {
+      eprintln!("Initialize libloading failed {}", err);
+      return Err(err);
+    }
+  };
 
   napi1::load(&host)?;
   #[cfg(feature = "napi2")]

--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -81,7 +81,10 @@ static SETUP: Once = Once::new();
 /// they will panic.
 /// Safety: `env` must be a valid `napi_env` for the current thread
 #[cfg(windows)]
-#[ctor::ctor]
-unsafe fn setup() {
-  SETUP.call_once(|| load().expect("Failed to load N-API symbols"));
+pub unsafe fn setup() {
+  SETUP.call_once(|| {
+    if let Err(err) = load() {
+      panic!("{}", err);
+    }
+  });
 }


### PR DESCRIPTION
Ref: https://github.com/yisibl/resvg-js/pull/107

`#[ctor::ctor]` doesn't run on windows-i686, don't know why ...