### PR TITLE
feat(cli): allow specifying an alternative cargo binary via `CARGO` env var

### DIFF
--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -258,7 +258,8 @@ export class BuildCommand extends Command {
     ]
       .filter((flag) => Boolean(flag))
       .join(' ')
-    const cargoCommand = `cargo build ${externalFlags}`
+    const cargo = process.env.CARGO ?? 'cargo'
+    const cargoCommand = `${cargo} build ${externalFlags}`
     const intermediateTypeFile = join(tmpdir(), `type_def.${Date.now()}.tmp`)
     debug(`Run ${chalk.green(cargoCommand)}`)
     const additionalEnv = {}


### PR DESCRIPTION
This opens doors for using [cargo-xwin](https://github.com/messense/cargo-xwin) to cross compiling for Windows MSVC targets, for example

```bash
CARGO=cargo-xwin yarn build --target x86_64-pc-windows-msvc
   Compiling winapi v0.3.9
   Compiling pin-project-lite v0.2.7
   Compiling futures-sink v0.3.19
   Compiling slab v0.4.5
   Compiling pin-utils v0.1.0
   Compiling futures-io v0.3.19
   Compiling ryu v1.0.9
   Compiling once_cell v1.9.0
   Compiling num_cpus v1.13.1
   Compiling cfg-if v1.0.0
   Compiling itoa v1.0.1
   Compiling lazy_static v1.4.0
   Compiling futures-core v0.3.19
   Compiling futures-task v0.3.19
   Compiling libc v0.2.112
   Compiling memchr v2.4.1
   Compiling futures-channel v0.3.19
   Compiling serde v1.0.132
   Compiling futures-util v0.3.19
   Compiling encoding_rs v0.8.30
   Compiling serde_json v1.0.73
   Compiling thread_local v1.1.4
   Compiling tokio v1.15.0
   Compiling num-traits v0.2.14
   Compiling num-integer v0.1.44
   Compiling napi-examples v0.1.0 (/Users/messense/Projects/napi-rs/examples/napi)
   Compiling libloading v0.7.3
   Compiling time v0.1.44
   Compiling futures-executor v0.3.19
   Compiling napi-sys v2.2.2 (/Users/messense/Projects/napi-rs/crates/sys)
   Compiling futures v0.3.19
   Compiling chrono v0.4.19
   Compiling napi v2.4.3 (/Users/messense/Projects/napi-rs/crates/napi)
    Finished dev [unoptimized + debuginfo] target(s) in 11.33s
file index.node
index.node: PE32+ executable (DLL) (GUI) x86-64, for MS Windows
```

And [cargo-zigbuild](https://github.com/messense/cargo-zigbuild) can also be used the same way.

cc #1180 