### PR TITLE
Parse host target triple from `rustc -vV`

### DIFF
--- a/cli/src/__test__/parse-triple.spec.ts
+++ b/cli/src/__test__/parse-triple.spec.ts
@@ -1,8 +1,6 @@
-import { platform } from 'os'
-
 import test from 'ava'
 
-import { parseTriple, getDefaultTargetTriple } from '../parse-triple'
+import { parseTriple } from '../parse-triple'
 
 const triples = [
   {
@@ -122,23 +120,3 @@ for (const triple of triples) {
     t.deepEqual(parseTriple(triple.name), triple.expected)
   })
 }
-
-const MaybeTest =
-  process.arch !== 'x64' && platform() === 'linux' ? test.skip : test
-
-MaybeTest('should parse default triple from rustup show active', (t) => {
-  t.deepEqual(
-    getDefaultTargetTriple(
-      `x86_64-unknown-linux-gnu (directory override for '/home/runner/work/fast-escape/fast-escape')`,
-    ),
-    parseTriple('x86_64-unknown-linux-gnu'),
-  )
-  t.deepEqual(
-    getDefaultTargetTriple(`stable-x86_64-apple-darwin (default)`),
-    parseTriple(`x86_64-apple-darwin`),
-  )
-  t.deepEqual(
-    getDefaultTargetTriple(`nightly-2020-08-29-x86_64-apple-darwin (default)`),
-    parseTriple('x86_64-apple-darwin'),
-  )
-})

--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -12,7 +12,7 @@ import toml from 'toml'
 import { getNapiConfig } from './consts'
 import { debugFactory } from './debug'
 import { createJsBinding } from './js-binding-template'
-import { getDefaultTargetTriple, parseTriple } from './parse-triple'
+import { getHostTargetTriple, parseTriple } from './parse-triple'
 import {
   copyFileAsync,
   mkdirAsync,
@@ -241,11 +241,7 @@ export class BuildCommand extends Command {
     const binFlag = this.bin ? `--bin ${this.bin}` : ''
     const triple = this.targetTripleDir
       ? parseTriple(this.targetTripleDir)
-      : getDefaultTargetTriple(
-          execSync('rustup show active-toolchain', {
-            env: process.env,
-          }).toString('utf8'),
-        )
+      : getHostTargetTriple()
     debug(`Current triple is: ${chalk.green(triple.raw)}`)
     const pFlag = this.project ? `-p ${this.project}` : ''
     const externalFlags = [

--- a/cli/src/parse-triple.ts
+++ b/cli/src/parse-triple.ts
@@ -98,30 +98,16 @@ export function parseTriple(rawTriple: string): PlatformDetail {
   }
 }
 
-// x86_64-unknown-linux-gnu (directory override for '/home/runner/work/fast-escape/fast-escape')
-// stable-x86_64-apple-darwin (default)
-// nightly-2020-08-29-x86_64-apple-darwin (default)
-export function getDefaultTargetTriple(rustcfg: string): PlatformDetail {
-  const currentTriple = rustcfg
-    .trim()
-    .replace(/\(.*?\)/, '')
-    .trim()
-  const allTriples = execSync(`rustup target list`, {
+export function getHostTargetTriple(): PlatformDetail {
+  const host = execSync(`rustc -vV`, {
     env: process.env,
   })
     .toString('utf8')
     .split('\n')
-    .map((line) =>
-      line
-        .trim()
-        // remove (installed) from x86_64-apple-darwin (installed)
-        .replace(/\(.*?\)/, '')
-        .trim(),
-    )
-    .filter((line) => line.length)
-  const triple = allTriples.find((triple) => currentTriple.indexOf(triple) > -1)
+    .find((line) => line.startsWith('host: '))
+  const triple = host?.slice('host: '.length)
   if (!triple) {
-    throw new TypeError(`Can not parse target triple from ${currentTriple}`)
+    throw new TypeError(`Can not parse target triple from host`)
   }
   return parseTriple(triple)
 }


### PR DESCRIPTION
This matches [how `cargo` does it](https://github.com/rust-lang/cargo/blob/f624095e1c98228a74a165ddb702078c0dd8b81e/src/cargo/util/rustc.rs#L57-L75) and it removed `rustup` requirement. On some platforms like OpenBSD, rustup is not supported.