### PR TITLE
feat(napi) Implement `ToNapiValue` for 8 and 16-bits numbers

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/number.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/number.rs
@@ -2,8 +2,8 @@ use super::{check_status, sys, Result};
 use crate::type_of;
 
 macro_rules! impl_number_conversions {
-	( $( ($name:literal, $t:ty, $get:ident, $create:ident) ,)* ) => {
-		$(
+  ( $( ($name:literal, $t:ty as $st:ty, $get:ident, $create:ident) ,)* ) => {
+    $(
       impl $crate::bindgen_prelude::TypeName for $t {
         #[inline(always)]
         fn type_name() -> &'static str {
@@ -26,11 +26,12 @@ macro_rules! impl_number_conversions {
         #[inline(always)]
         unsafe fn to_napi_value(env: $crate::sys::napi_env, val: $t) -> Result<$crate::sys::napi_value> {
           let mut ptr = std::ptr::null_mut();
+          let val: $st = val.into();
 
           check_status!(
             unsafe { sys::$create(env, val, &mut ptr) },
-						"Failed to convert rust type `{}` into napi value",
-						$name,
+            "Failed to convert rust type `{}` into napi value",
+            $name,
           )?;
 
           Ok(ptr)
@@ -39,8 +40,8 @@ macro_rules! impl_number_conversions {
 
       impl $crate::bindgen_prelude::FromNapiValue for $t {
         #[inline(always)]
-				unsafe fn from_napi_value(env: $crate::sys::napi_env, napi_val: $crate::sys::napi_value) -> Result<Self> {
-					let mut ret = 0 as $t;
+        unsafe fn from_napi_value(env: $crate::sys::napi_env, napi_val: $crate::sys::napi_value) -> Result<Self> {
+          let mut ret = 0 as $st;
 
           check_status!(
             unsafe { sys::$get(env, napi_val, &mut ret) },
@@ -49,16 +50,20 @@ macro_rules! impl_number_conversions {
             $name,
           )?;
 
-            Ok(ret)
-				}
+          Ok(ret.try_into().expect(concat!("Failed to convert ", stringify!($st), " to ", stringify!($t))))
+        }
       }
-		)*
-	};
+    )*
+  };
 }
 
 impl_number_conversions!(
-  ("u32", u32, napi_get_value_uint32, napi_create_uint32),
-  ("i32", i32, napi_get_value_int32, napi_create_int32),
-  ("i64", i64, napi_get_value_int64, napi_create_int64),
-  ("f64", f64, napi_get_value_double, napi_create_double),
+  ("u8", u8 as u32, napi_get_value_uint32, napi_create_uint32),
+  ("i8", i8 as i32, napi_get_value_int32, napi_create_int32),
+  ("u16", u16 as u32, napi_get_value_uint32, napi_create_uint32),
+  ("i16", i16 as i32, napi_get_value_int32, napi_create_int32),
+  ("u32", u32 as u32, napi_get_value_uint32, napi_create_uint32),
+  ("i32", i32 as i32, napi_get_value_int32, napi_create_int32),
+  ("i64", i64 as i64, napi_get_value_int64, napi_create_int64),
+  ("f64", f64 as f64, napi_get_value_double, napi_create_double),
 );


### PR DESCRIPTION
`napi` only supports numbers in 16 and 32-bits. To support Rust
numbers with 8 and 16-bits, we can cast them to 32-bits. To convert
from 8 and 16-bits to 32-bits, we use their `Into` implementation. To
convert from 32-bits to 8 and 16-bits, we use their `TryInto`, we
should theorically not fail, but in case of, an `except` message is
appended.

The code has also been re-indented as it was containing a mix of 2
spaces, 4 spaces and tabs identation.