### PR TITLE
feat(napi) implement `From<Infallible>` for `napi::Error`

### DIFF
--- a/crates/napi/src/error.rs
+++ b/crates/napi/src/error.rs
@@ -34,6 +34,12 @@ unsafe impl Sync for Error {}
 
 impl error::Error for Error {}
 
+impl From<std::convert::Infallible> for Error {
+  fn from(_: std::convert::Infallible) -> Self {
+    unreachable!()
+  }
+}
+
 #[cfg(feature = "serde-json")]
 impl ser::Error for Error {
   fn custom<T: Display>(msg: T) -> Self {


### PR DESCRIPTION
Thanks for creating awesome library!

I implemented `From<std::convert::Infallible>` for `napi::Error`, which makes the code below work.


```rust
#[napi]
fn test() -> napi::Result<u32> {
    let a = 100i32;
    let b: i32 = a.try_into()?;
    Ok(b)
}
```

This example doesn't seem to make sense, but I have some code that is auto-generated so it goods for me.
