### PR TITLE
feat(napi) Extend #1195 to `Vec<T>`.

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/array.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/array.rs
@@ -212,6 +212,10 @@ macro_rules! impl_for_primitive_type {
   };
 }
 
+impl_for_primitive_type!(u8);
+impl_for_primitive_type!(i8);
+impl_for_primitive_type!(u16);
+impl_for_primitive_type!(i16);
 impl_for_primitive_type!(u32);
 impl_for_primitive_type!(i32);
 impl_for_primitive_type!(i64);


### PR DESCRIPTION
This patch is the sequel of https://github.com/napi-rs/napi-rs/pull/1195 where `ToNapiValue` and `FromNapiValue` are implemented for all `Vec<T>` where `T` is a 8 or 16 bits number.