### PR TITLE
Replace lazy_static with once_cell

### DIFF
--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -49,7 +49,7 @@ tokio_time = ["tokio/time"]
 
 [dependencies]
 ctor = "0.1"
-lazy_static = "1"
+once_cell = "1"
 thread_local = "1"
 
 [dependencies.napi-sys]

--- a/crates/napi/src/bindgen_runtime/callback_info.rs
+++ b/crates/napi/src/bindgen_runtime/callback_info.rs
@@ -4,16 +4,14 @@ use std::ptr;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use thread_local::ThreadLocal;
 
 use crate::{bindgen_prelude::*, check_status, sys, Result};
 
-lazy_static! {
-  #[doc(hidden)]
-  /// Determined is `constructor` called from Class `factory`
-  pub static ref ___CALL_FROM_FACTORY: ThreadLocal<AtomicBool> = ThreadLocal::new();
-}
+#[doc(hidden)]
+/// Determined is `constructor` called from Class `factory`
+pub static ___CALL_FROM_FACTORY: Lazy<ThreadLocal<AtomicBool>> = Lazy::new(ThreadLocal::new);
 
 pub struct CallbackInfo<const N: usize> {
   env: sys::napi_env,

--- a/crates/napi/src/bindgen_runtime/js_values/value_ref.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/value_ref.rs
@@ -3,7 +3,7 @@ use std::ffi::c_void;
 use std::ops::{Deref, DerefMut};
 use std::rc::{Rc, Weak};
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
 use crate::{
   bindgen_runtime::{PersistedSingleThreadHashMap, ToNapiValue},
@@ -16,10 +16,8 @@ type RefInformation = (
   *const Cell<*mut dyn FnOnce()>,
 );
 
-lazy_static! {
-  pub(crate) static ref REFERENCE_MAP: PersistedSingleThreadHashMap<*mut c_void, RefInformation> =
-    Default::default();
-}
+pub(crate) static REFERENCE_MAP: Lazy<PersistedSingleThreadHashMap<*mut c_void, RefInformation>> =
+  Lazy::new(Default::default);
 
 /// ### Experimental feature
 ///


### PR DESCRIPTION
This makes the code a little bit easier to read because it's not a macro. It also reduces the dependencies when tokio is used, as tokio already depends on once_cell but not lazy_static.