### PR TITLE
fix(napi) `undefined` is recognized as a valid `None` for `Option<T>`

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values.rs
+++ b/crates/napi/src/bindgen_runtime/js_values.rs
@@ -169,7 +169,7 @@ impl<T: ValidateNapiValue> ValidateNapiValue for Option<T> {
     )?;
 
     let received_type = ValueType::from(result);
-    if received_type == ValueType::Null {
+    if received_type == ValueType::Null || received_type == ValueType::Undefined {
       Ok(ptr::null_mut())
     } else if let Ok(validate_ret) = unsafe { T::validate(env, napi_val) } {
       Ok(validate_ret)


### PR DESCRIPTION
Sequel of https://github.com/napi-rs/napi-rs/pull/1223.
Fix this comment https://github.com/napi-rs/napi-rs/pull/1223.

Let's say we have a Rust function defined as:

```rust
#[napi(strict)]
pub fn foo(a: i32, b: Option<i32>) -> … { … }
```

Calling this function in JavaScript as so will work:

```javascript
foo(1, null)
```

but calling this function as so will not work:

```javascript
foo(1)
foo(1, undefined)
```

This patch fixes that, by recognizing `undefined` as `Option::None`.