### PR TITLE
Add derived traits to `ThreadsafeFunctionCallMode`

### DIFF
--- a/crates/napi/src/threadsafe_function.rs
+++ b/crates/napi/src/threadsafe_function.rs
@@ -19,6 +19,7 @@ pub struct ThreadSafeCallContext<T: 'static> {
 }
 
 #[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ThreadsafeFunctionCallMode {
   NonBlocking,
   Blocking,


### PR DESCRIPTION
This makes it possible to reuse the same value, e.g. when writing utility/helper functions.