### PR TITLE
chore(napi): use recommended `vmactions/freebsd-vm@v0`

### DIFF
--- a/cli/src/new/ci-template.ts
+++ b/cli/src/new/ci-template.ts
@@ -201,7 +201,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build
         id: build
-        uses: vmactions/freebsd-vm@v0.2.3
+        uses: vmactions/freebsd-vm@v0
         env:
           DEBUG: 'napi:*'
           RUSTUP_HOME: /usr/local/rustup


### PR DESCRIPTION
Since a few days ago freebsd-vm [recommends using the latest major version v0](https://github.com/vmactions/freebsd-vm#:~:text=is%20the%20most-,recommended%20to%20use), which might be common for actions.