### PR TITLE
pin minimum usable version of dependency syn

### DIFF
--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -21,7 +21,7 @@ type-def = ["regex", "once_cell"]
 convert_case = "0.5"
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1", features = ["fold", "full", "extra-traits"] }
+syn = { version = "1.0.61", features = ["fold", "full", "extra-traits"] }
 
 [dependencies.regex]
 optional = true

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -26,7 +26,7 @@ convert_case = "0.5"
 napi-derive-backend = { version = "1.0.37", path = "../backend" }
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["fold", "full", "extra-traits"] }
+syn = { version = "1.0.61", features = ["fold", "full", "extra-traits"] }
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Fixes https://github.com/napi-rs/napi-rs/issues/1292

This format still allows the same range of versions greater than 1.0.61 according to the docs:  https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html

1 is equal to >=1, <2
1.0 is equal to >=1, <2
1.0.61 is equal to >=1.0.61, <2