### PR TITLE
Improve error propagation

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values.rs
+++ b/crates/napi/src/bindgen_runtime/js_values.rs
@@ -233,7 +233,7 @@ where
       Ok(v) => unsafe { T::to_napi_value(env, v) },
       Err(e) => {
         let error_code = unsafe { String::to_napi_value(env, format!("{:?}", e.status))? };
-        let reason = unsafe { String::to_napi_value(env, e.reason)? };
+        let reason = unsafe { String::to_napi_value(env, e.reason.clone())? };
         let mut error = ptr::null_mut();
         check_status!(
           unsafe { sys::napi_create_error(env, error_code, reason, &mut error) },

--- a/crates/napi/src/env.rs
+++ b/crates/napi/src/env.rs
@@ -994,7 +994,7 @@ impl Env {
   }
 
   pub fn create_error(&self, e: Error) -> Result<JsObject> {
-    let reason = e.reason;
+    let reason = &e.reason;
     let reason_string = self.create_string(reason.as_str())?;
     let mut result = ptr::null_mut();
     check_status!(unsafe {

--- a/crates/napi/src/js_values/function.rs
+++ b/crates/napi/src/js_values/function.rs
@@ -7,7 +7,7 @@ use crate::{
   bindgen_runtime::ToNapiValue,
   threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunction},
 };
-use crate::{check_status, ValueType};
+use crate::{check_pending_exception, ValueType};
 use crate::{sys, Env, Error, JsObject, JsUnknown, NapiRaw, NapiValue, Result, Status};
 
 pub struct JsFunction(pub(crate) Value);
@@ -56,7 +56,7 @@ impl JsFunction {
       .map(|arg| unsafe { arg.raw() })
       .collect::<Vec<sys::napi_value>>();
     let mut return_value = ptr::null_mut();
-    check_status!(unsafe {
+    check_pending_exception!(self.0.env, unsafe {
       sys::napi_call_function(
         self.0.env,
         raw_this,
@@ -83,7 +83,7 @@ impl JsFunction {
       })
       .ok_or_else(|| Error::new(Status::GenericFailure, "Get raw this failed".to_owned()))?;
     let mut return_value = ptr::null_mut();
-    check_status!(unsafe {
+    check_pending_exception!(self.0.env, unsafe {
       sys::napi_call_function(
         self.0.env,
         raw_this,
@@ -110,7 +110,7 @@ impl JsFunction {
       .iter()
       .map(|arg| unsafe { arg.raw() })
       .collect::<Vec<sys::napi_value>>();
-    check_status!(unsafe {
+    check_pending_exception!(self.0.env, unsafe {
       sys::napi_new_instance(
         self.0.env,
         self.0.value,

--- a/crates/napi/src/promise.rs
+++ b/crates/napi/src/promise.rs
@@ -109,28 +109,8 @@ unsafe extern "C" fn call_js_cb<
       debug_assert!(status == sys::Status::napi_ok, "Resolve promise failed");
     }
     Err(e) => {
-      let status = unsafe {
-        sys::napi_reject_deferred(
-          env,
-          deferred,
-          if e.maybe_raw.is_null() {
-            JsError::from(e).into_value(env)
-          } else {
-            let mut err = ptr::null_mut();
-            let get_err_status = sys::napi_get_reference_value(env, e.maybe_raw, &mut err);
-            debug_assert!(
-              get_err_status == sys::Status::napi_ok,
-              "Get Error from Reference failed"
-            );
-            let delete_reference_status = sys::napi_delete_reference(env, e.maybe_raw);
-            debug_assert!(
-              delete_reference_status == sys::Status::napi_ok,
-              "Delete Error Reference failed"
-            );
-            err
-          },
-        )
-      };
+      let status =
+        unsafe { sys::napi_reject_deferred(env, deferred, JsError::from(e).into_value(env)) };
       debug_assert!(status == sys::Status::napi_ok, "Reject promise failed");
     }
   };

--- a/examples/napi-compat-mode/__test__/function.spec.ts
+++ b/examples/napi-compat-mode/__test__/function.spec.ts
@@ -20,3 +20,14 @@ test('should set "this" properly', (t) => {
     t.is(this, obj)
   })
 })
+
+test('should handle errors', (t) => {
+  bindings.testCallFunctionError(
+    () => {
+      throw new Error('Testing')
+    },
+    (err: Error) => {
+      t.is(err.message, 'Testing')
+    },
+  )
+})


### PR DESCRIPTION
This enables `napi::Error` to wrap an arbitrary JavaScript value, which may have been returned or thrown from a function. This is useful for functions that must return an `napi::Result`, but may have an error propagated from calling a JavaScript function. The support was partially already there for the Promise implementation, but I've extended it.

This also checks if an exception is pending after calling a JS function, and retrieves it with `napi_get_and_clear_last_exception`. This way, the pending exception isn't necessarily immediately thrown when returning from the native function, but can be passed elsewhere if needed (e.g. to an error callback). This is also important when calling JS functions outside the native call context (e.g. from a background thread).