### PR TITLE
auto encode string to Uint8Array

### DIFF
--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -21,7 +21,7 @@ type-def = ["regex", "once_cell"]
 convert_case = "0.5"
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1.0.61", features = ["fold", "full", "extra-traits"] }
+syn = { version = "1.0.99", features = ["fold", "full", "extra-traits"] }
 
 [dependencies.regex]
 optional = true

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -26,7 +26,7 @@ convert_case = "0.5"
 napi-derive-backend = { version = "1.0.38", path = "../backend" }
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0.61", features = ["fold", "full", "extra-traits"] }
+syn = { version = "1.0.99", features = ["fold", "full", "extra-traits"] }
 
 [lib]
 proc-macro = true

--- a/crates/napi/src/bindgen_runtime/js_values/arraybuffer.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/arraybuffer.rs
@@ -395,3 +395,9 @@ impl_typed_array!(Float64Array, f64, TypedArrayType::Float64);
 impl_typed_array!(BigInt64Array, i64, TypedArrayType::BigInt64);
 #[cfg(feature = "napi6")]
 impl_typed_array!(BigUint64Array, u64, TypedArrayType::BigUint64);
+
+impl<T: Into<Vec<u8>>> From<T> for Uint8Array {
+  fn from(data: T) -> Self {
+    Uint8Array::new(data.into())
+  }
+}

--- a/crates/napi/src/bindgen_runtime/js_values/external.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/external.rs
@@ -3,15 +3,16 @@ use std::{
   ops::{Deref, DerefMut},
 };
 
-use crate::{check_status, sys, Error, Status, TaggedObject};
-
 use super::{FromNapiValue, ToNapiValue, TypeName, ValidateNapiValue};
+use crate::{check_status, sys, Error, Status, TaggedObject};
 
 pub struct External<T: 'static> {
   obj: *mut TaggedObject<T>,
   size_hint: usize,
   pub adjusted_size: i64,
 }
+
+unsafe impl<T: 'static> Send for External<T> {}
 
 impl<T: 'static> TypeName for External<T> {
   fn type_name() -> &'static str {

--- a/examples/napi/Cargo.toml
+++ b/examples/napi/Cargo.toml
@@ -25,7 +25,7 @@ napi-derive = { path = "../../crates/macro", features = ["type-def"] }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-tokio = { version = "1.20.0", features = ["full"] }
+tokio = { version = "1.21.1", features = ["full"] }
 
 [build-dependencies]
 napi-build = { path = "../../crates/build" }


### PR DESCRIPTION
fix https://github.com/napi-rs/napi-rs/issues/1310

我的场景是这样的，我封装一个redis客户的给nodejs用，redis的key可以是字符串也可以是二进制，有这个自动转换会方便很多

测试了应该没问题，如下图
![image](https://user-images.githubusercontent.com/110233389/190685368-25c96a22-7bdf-4f27-92cf-8f3c08903677.png)

测试代码是
https://github.com/user-tax-dev/redis/blob/main/src/lib.rs

```rust
use fred::{
  interfaces::{ClientLike, KeysInterface},
  prelude::{ReconnectPolicy, RedisClient, RedisConfig},
};
use napi::bindgen_prelude::Uint8Array;
use napi_derive::napi;

#[napi]
pub struct Redis {
  c: RedisClient,
}

macro_rules! def {
  (
    $fn:ident ( $($field_name:ident $(: $($type:tt)+)? ),*) -> $result:ty $body:block
  )=>{
#[napi]
    pub async fn $fn($($field_name$(: $($type)+)?,)*) -> napi::Result<$result> {
      Ok({
        async move {
          Ok($body)
        }
        .await as anyhow::Result<_, anyhow::Error>
      }?)
    }
  }
}

macro_rules! napiImpl {
  (
    $cls:ty :
    $(
      $fn:ident (&$($field_name:ident $(: $($type:tt)+ )? ),*) -> $result:ty $body:block
    )*
  )=>{
#[napi]
    impl $cls {
      $(
        #[napi]
        pub async fn $fn(&$($field_name$(: $($type)+ )?,)*) -> napi::Result<$result> {
          Ok({
            async move {
              Ok($body)
            }
            .await as anyhow::Result<_, anyhow::Error>
          }?)
        }
      )*
    }
  }
}

def!(
  test(key:Vec<u8>)->usize{
    dbg!(&key);
    key.len()
  }
);

def!(redis_conn(db: u8) -> Redis {
  let mut config = RedisConfig::default();
  config.database = Some(db);
  // configure exponential backoff when reconnecting, starting at 100 ms, and doubling each time up to 30 sec.
  let policy = ReconnectPolicy::new_exponential(0, 100, 30_000, 2);

  let client = RedisClient::new(config);
  let _ = client.connect(Some(policy));
  let _ = client.wait_for_connect().await?;

  Redis { c: client }
});

napiImpl!(
  Redis :
  get(&self, key: Uint8Array) -> String {
    self.c.get::<String, _>(&key[..]).await.unwrap()
  }

  get_b(&self, key: Uint8Array) -> Uint8Array {
    Uint8Array::new(
      self.c.get::<Vec<u8>, _>(&key[..]).await?
    )
  }
);
```