### PR TITLE
return join handle when spawning a tokio task

### DIFF
--- a/crates/napi/src/tokio_runtime.rs
+++ b/crates/napi/src/tokio_runtime.rs
@@ -52,11 +52,15 @@ pub unsafe extern "C" fn shutdown_tokio_rt(arg: *mut c_void) {
   }
 }
 
-pub fn spawn<F>(fut: F)
+/// Spawns a future onto the Tokio runtime.
+///
+/// Depending on where you use it, you should await or abort the future in your drop function.
+/// To avoid undefined behavior and memory corruptions.
+pub fn spawn<F>(fut: F) -> tokio::task::JoinHandle<F::Output>
 where
   F: 'static + Send + Future<Output = ()>,
 {
-  RT.0.spawn(fut);
+  RT.0.spawn(fut)
 }
 
 // This function's signature must be kept in sync with the one in lib.rs, otherwise napi


### PR DESCRIPTION
This pr makes the spawn function return the join handle so it can be safely aborted when droping the object it is 
spawned for.


Without this I need to run the future in a different tokio runtime instance to avoid a segfault:
https://github.com/deltachat/napi-jsonrpc/commit/de561631680789cb1db59f3c5d4145da028a052d

More info on the issue: https://github.com/deltachat/napi-jsonrpc/issues/2

Basically I have an event receiving loop that is spawned when creating an account manager, but without this pr I'm not able to shutdown/abort the event loop safely resulting in a segfault when Nodejs garbage collects the object.