### PR TITLE
Remove unused ci condition

### DIFF
--- a/cli/src/new/ci-template.ts
+++ b/cli/src/new/ci-template.ts
@@ -22,7 +22,6 @@ on:
 
 jobs:
   build:
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
This has been [officially supported](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs).