### PR TITLE
[Fix] Quote toml path

### DIFF
--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -211,7 +211,7 @@ export class BuildCommand extends Command {
       debug('Start parse toml')
       cargoMetadata = JSON.parse(
         execSync(
-          `cargo metadata --format-version 1 --manifest-path ${cargoTomlPath}`,
+          `cargo metadata --format-version 1 --manifest-path "${cargoTomlPath}"`,
           {
             stdio: 'pipe',
             maxBuffer: 1024 * 1024 * 10,


### PR DESCRIPTION
Fixes issue when tomlPath has a space in it

(N.b. Sorry if I didn't follow a PR template - this was done in the browser)