### PR TITLE
[Feat+Fix] Enhances Build Config with specific JS File

### DIFF
--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -466,7 +466,7 @@ export class BuildCommand extends Command {
       throw e
     }
     const { binaryName, packageName, jsFile } = getNapiConfig(
-      this.configFileName
+      this.configFileName,
     )
     let cargoArtifactName = this.cargoName
     if (!cargoArtifactName) {

--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -337,7 +337,7 @@ export class BuildCommand extends Command {
       const mappedZigTarget = ZIG_PLATFORM_TARGET_MAP[triple.raw]
       const zigTarget = `${mappedZigTarget}${
         zigABIVersion ? `.${zigABIVersion}` : ''
-      }`
+        }`
       if (!mappedZigTarget) {
         throw new Error(`${triple.raw} can not be cross compiled by zig`)
       }
@@ -465,7 +465,7 @@ export class BuildCommand extends Command {
       }
       throw e
     }
-    const { binaryName, packageName } = getNapiConfig(this.configFileName)
+    const { binaryName, packageName, jsFile } = getNapiConfig(this.configFileName)
     let cargoArtifactName = this.cargoName
     if (!cargoArtifactName) {
       if (this.bin) {
@@ -597,9 +597,9 @@ export class BuildCommand extends Command {
         }
       }
       const jsBindingFilePath =
-        this.jsBinding &&
-        this.jsBinding !== 'false' &&
-        this.appendPlatformToFilename
+        (this.jsBinding ?? jsFile) &&
+          this.jsBinding !== 'false' &&
+          this.appendPlatformToFilename
           ? join(process.cwd(), this.jsBinding)
           : null
       const idents = await processIntermediateTypeFile(
@@ -778,7 +778,7 @@ async function processIntermediateTypeFile(
 
   const externalDef =
     topLevelDef.indexOf('ExternalObject<') > -1 ||
-    namespaceDefs.indexOf('ExternalObject<') > -1
+      namespaceDefs.indexOf('ExternalObject<') > -1
       ? `export class ExternalObject<T> {
   readonly '': {
     readonly '': unique symbol

--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -337,7 +337,7 @@ export class BuildCommand extends Command {
       const mappedZigTarget = ZIG_PLATFORM_TARGET_MAP[triple.raw]
       const zigTarget = `${mappedZigTarget}${
         zigABIVersion ? `.${zigABIVersion}` : ''
-        }`
+      }`
       if (!mappedZigTarget) {
         throw new Error(`${triple.raw} can not be cross compiled by zig`)
       }
@@ -465,7 +465,9 @@ export class BuildCommand extends Command {
       }
       throw e
     }
-    const { binaryName, packageName, jsFile } = getNapiConfig(this.configFileName)
+    const { binaryName, packageName, jsFile } = getNapiConfig(
+      this.configFileName
+    )
     let cargoArtifactName = this.cargoName
     if (!cargoArtifactName) {
       if (this.bin) {
@@ -598,8 +600,8 @@ export class BuildCommand extends Command {
       }
       const jsBindingFilePath =
         (this.jsBinding ?? jsFile) &&
-          this.jsBinding !== 'false' &&
-          this.appendPlatformToFilename
+        this.jsBinding !== 'false' &&
+        this.appendPlatformToFilename
           ? join(process.cwd(), this.jsBinding)
           : null
       const idents = await processIntermediateTypeFile(
@@ -778,7 +780,7 @@ async function processIntermediateTypeFile(
 
   const externalDef =
     topLevelDef.indexOf('ExternalObject<') > -1 ||
-      namespaceDefs.indexOf('ExternalObject<') > -1
+    namespaceDefs.indexOf('ExternalObject<') > -1
       ? `export class ExternalObject<T> {
   readonly '': {
     readonly '': unique symbol

--- a/cli/src/consts.ts
+++ b/cli/src/consts.ts
@@ -34,5 +34,6 @@ export function getNapiConfig(
     packageJsonPath,
     content: pkgJson,
     npmClient,
+    jsFile,
   }
 }

--- a/cli/src/consts.ts
+++ b/cli/src/consts.ts
@@ -23,7 +23,7 @@ export function getNapiConfig(
   const version = releaseVersionWithoutPrefix ?? packageVersion
   const packageName = napi?.package?.name ?? name
   const npmClient: string = napi?.npmClient ?? 'npm'
-
+  const jsFile: string = napi?.jsFile ?? "index.js"
   const binaryName: string = napi?.name ?? 'index'
 
   return {

--- a/cli/src/consts.ts
+++ b/cli/src/consts.ts
@@ -23,7 +23,7 @@ export function getNapiConfig(
   const version = releaseVersionWithoutPrefix ?? packageVersion
   const packageName = napi?.package?.name ?? name
   const npmClient: string = napi?.npmClient ?? 'npm'
-  const jsFile: string = napi?.jsFile ?? "index.js"
+  const jsFile: string = napi?.jsFile ?? 'index.js'
   const binaryName: string = napi?.name ?? 'index'
 
   return {


### PR DESCRIPTION
Added `jsFile` to the build config for `package.json`. It allows users to specify where to store the generated javascript bindings file. Currently, the only workaround is to either specify it on the command line (which is fine if you use NPM scripts), but if you want to one-off run `napi build --some-flag` and forget to add `--js path/to/index.js` then you'll miss out on it. This feature fixes this problem.