### PR TITLE
Fix ArrayBuffer memory leak

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/arraybuffer.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/arraybuffer.rs
@@ -125,6 +125,7 @@ macro_rules! impl_typed_array {
       fn noop_finalize(_data: *mut $rust_type, _length: usize) {}
 
       pub fn new(mut data: Vec<$rust_type>) -> Self {
+        data.shrink_to_fit();
         let ret = $name {
           data: data.as_mut_ptr(),
           length: data.len(),

--- a/memory-testing/buffer.mjs
+++ b/memory-testing/buffer.mjs
@@ -17,6 +17,7 @@ while (true) {
   api.arrayBufferLen()
   api.bufferConvert(Buffer.from(FIXTURE))
   api.arrayBufferConvert(Uint8Array.from(FIXTURE))
+  api.arrayBufferCreateFromVecWithSpareCapacity()
   api.bufferPassThrough(Buffer.from(FIXTURE))
   api.arrayBufferPassThrough(Uint8Array.from(FIXTURE))
   if (i % 10 === 0) {

--- a/memory-testing/src/lib.rs
+++ b/memory-testing/src/lib.rs
@@ -158,6 +158,13 @@ pub fn array_buffer_convert(array_buffer: Uint8Array) -> Uint8Array {
 }
 
 #[napi]
+pub fn array_buffer_create_from_vec_with_spare_capacity() -> Uint8Array {
+  let mut v = vec![1; 1024 * 10240];
+  v.truncate(1);
+  Uint8Array::new(v)
+}
+
+#[napi]
 pub fn array_buffer_len() -> u32 {
   Uint8Array::new(vec![1; 1024 * 10240]).len() as u32
 }


### PR DESCRIPTION
Fix for #1419.

### Problem

Problem is that `Uint8Array::new` only records the length of the `Vec` it receives, and ignores the capacity.

When it recreates the `Vec` later in order to drop it, it is created with capacity equal to the length:

https://github.com/napi-rs/napi-rs/blob/83e157e101046f516b09de006b345d075bfb57bb/crates/napi/src/bindgen_runtime/js_values/arraybuffer.rs#L109-L110

So if original `Vec` had a larger capacity, `capacity - length` bytes are leaked. The allocator is also called with a different layout from what the original `Vec` was created with, which may cause unknown consequences.

### Solution

This PR just adds `data::shrink_to_fit()` before recording length of the Vec. This is the simplest solution, and since `Uint8Array::new` takes ownership of the `Vec`, I can't see much benefit of not freeing the excess capacity immediately.

### Potential complication

As far as I can see, `Vec::shrink_to_fit()` always reduces capacity to exactly length:

https://github.com/rust-lang/rust/blob/8ea62f6c30c94778d9146ddc26c8520ed2b50a58/library/alloc/src/raw_vec.rs#L425-L440

However, [Rust's docs](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.shrink_to_fit) say "It will drop down as close as possible to the length but the allocator may still inform the vector that there is space for a few more elements."

So can we rely on `shrink_to_fit()` always leaving `capacity == length`?

If not, would need to record capacity in the `Uint8Array`, and then use that value when dropping (as `Buffer` does).

If you think this is a concern, please let me know and I'll amend this PR.