### PR TITLE
Fix CARGO env var in `napi build`

### DIFF
--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -285,7 +285,7 @@ export class BuildCommand extends Command {
         })())
     const isCrossForMacOS =
       triple.platform === 'darwin' && process.platform !== 'darwin'
-    const cargo = process.env.CARGO ?? isCrossForWin ? 'cargo-xwin' : 'cargo'
+    const cargo = process.env.CARGO ?? (isCrossForWin ? 'cargo-xwin' : 'cargo')
     if (isCrossForWin && triple.arch === 'ia32') {
       additionalEnv['XWIN_ARCH'] = 'x86'
     }


### PR DESCRIPTION
I assume that in CLI's build command, env var `CARGO` is meant to tell it what `cargo` to use.

e.g. `CARGO=my-cargo napi build --release` should result in CLI executing `my-cargo build --release`.

At present, this doesn't work. It instead executes `cargo-xwin build --release` (and I'm on a Mac).

Assuming that's the purpose of the var, this PR fixes it.