### PR TITLE
Fix broken zig behaviors

### DIFF
--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -309,11 +309,12 @@ export class BuildCommand extends Command {
     if (rustflags.length > 0) {
       additionalEnv['RUSTFLAGS'] = rustflags.join(' ')
     }
-    let isZigExisted = false
-    if (isCrossForLinux || isCrossForMacOS) {
+
+    let useZig = false
+    if (this.useZig || isCrossForLinux || isCrossForMacOS) {
       try {
         execSync('zig version')
-        isZigExisted = true
+        useZig = true
       } catch (e) {
         if (this.useZig) {
           throw new TypeError(
@@ -329,15 +330,15 @@ export class BuildCommand extends Command {
       }
     }
 
-    if ((this.useZig || isCrossForLinux || isCrossForMacOS) && isZigExisted) {
+    if (useZig) {
       const zigABIVersion =
-        this.zigABIVersion ?? (isCrossForLinux && triple.abi === 'gnu')
-          ? DEFAULT_GLIBC_TARGET
-          : null
+        this.zigABIVersion ??
+        (isCrossForLinux && triple.abi === 'gnu' ? DEFAULT_GLIBC_TARGET : null)
       const mappedZigTarget = ZIG_PLATFORM_TARGET_MAP[triple.raw]
       const zigTarget = `${mappedZigTarget}${
         zigABIVersion ? `.${zigABIVersion}` : ''
       }`
+      debug(`Using Zig with target ${chalk.green(zigTarget)}`)
       if (!mappedZigTarget) {
         throw new Error(`${triple.raw} can not be cross compiled by zig`)
       }


### PR DESCRIPTION
This PR includes 2 fixes:
1. fix #1430
  Zig wasn’t being activated when `--zig` is passed unless the build was also cross-platform. Under this PR, the `--zig` flag opts in to zig compilation regardless of platform.
3. fix #1431 
  `--zig-abi-suffix` was completely broken (its value did not change the suffix passed to zig). Under this PR, it works.

This PR also adds a debug message to show when zig is activated, so that (in debug mode) the user can tell whether their program is being compiled with `zig` or with the default compiler tools, as well as what target `zig` will compile for.