### PR TITLE
fix(napi): dropping Error should not call sys if feature is set to noop

### DIFF
--- a/crates/napi/src/error.rs
+++ b/crates/napi/src/error.rs
@@ -162,13 +162,16 @@ impl From<std::io::Error> for Error {
 
 impl Drop for Error {
   fn drop(&mut self) {
-    if !self.maybe_env.is_null() && !self.maybe_raw.is_null() {
-      let delete_reference_status =
-        unsafe { sys::napi_delete_reference(self.maybe_env, self.maybe_raw) };
-      debug_assert!(
-        delete_reference_status == sys::Status::napi_ok,
-        "Delete Error Reference failed"
-      );
+    #[cfg(not(feature = "noop"))]
+    {
+      if !self.maybe_env.is_null() && !self.maybe_raw.is_null() {
+        let delete_reference_status =
+          unsafe { sys::napi_delete_reference(self.maybe_env, self.maybe_raw) };
+        debug_assert!(
+          delete_reference_status == sys::Status::napi_ok,
+          "Delete Error Reference failed"
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
For those who use both `feature = "noop"` and `Error` would cause a linking issue as the symbol used in `drop` may not be existed. With this PR, you can use `Error` more freely.