### PR TITLE
feat(napi): expose `uv_run`

### DIFF
--- a/crates/sys/src/functions.rs
+++ b/crates/sys/src/functions.rs
@@ -487,10 +487,13 @@ mod napi1 {
 #[cfg(feature = "napi2")]
 mod napi2 {
   use super::super::types::*;
+  use std::os::raw::c_int;
 
   generate!(
     extern "C" {
       fn napi_get_uv_event_loop(env: napi_env, loop_: *mut *mut uv_loop_s) -> napi_status;
+
+      fn uv_run(loop_: *mut uv_loop_s, mode: uv_run_mode) -> c_int;
     }
   );
 }

--- a/crates/sys/src/types.rs
+++ b/crates/sys/src/types.rs
@@ -55,6 +55,13 @@ pub struct napi_deferred__ {
 pub struct uv_loop_s {
   _unused: [u8; 0],
 }
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub enum uv_run_mode {
+  UV_RUN_DEFAULT = 0,
+  UV_RUN_ONCE = 1,
+  UV_RUN_NOWAIT = 2,
+}
 pub type napi_deferred = *mut napi_deferred__;
 
 pub type napi_property_attributes = i32;


### PR DESCRIPTION
I'd like to use `uv_run` in order to execute js code while waiting in some special cases, just like [deasync](https://github.com/abbr/deasync) does.

Example:
```rust
#[napi]
fn run_event_loop(env: Env) -> napi::Result<()> {
  unsafe {
    sys::uv_run(env.get_uv_event_loop()?, sys::uv_run_mode::UV_RUN_ONCE);
  }

  Ok(())
}
```