### PR TITLE
fix(napi): use weak arc for passing `thread_finalize_data`

### DIFF
--- a/examples/napi/src/threadsafe_function.rs
+++ b/examples/napi/src/threadsafe_function.rs
@@ -137,7 +137,7 @@ pub async fn tsfn_return_promise(func: ThreadsafeFunction<u32>) -> Result<u32> {
 pub async fn tsfn_return_promise_timeout(func: ThreadsafeFunction<u32>) -> Result<u32> {
   use tokio::time::{self, Duration};
   let promise = func.call_async::<Promise<u32>>(Ok(1)).await?;
-  let sleep = time::sleep(Duration::from_millis(200));
+  let sleep = time::sleep(Duration::from_millis(100));
   tokio::select! {
     _ = sleep => {
       return Err(Error::new(Status::GenericFailure, "Timeout".to_owned()));


### PR DESCRIPTION
If `thread_finalize_data` uses Arc::clone(), the reference count will not decrease to 0 after `ThreadsafeFunction` dropped, which will also cause node process to not exit.

```rs
pub fn function(callback: JsFunction) -> Result<()>  {
  let function = callback
      .create_threadsafe_function(0, ...).unwrap();

  std::thread::spawn(move || {
    function.call(..., ThreadsafeFunctionCallMode::Blocking);
  });
  Ok(())
}
```

```js
// this progress won't exit automatically
function((() => {})
```

The problem was introduced in #1515

Additional:

`impl Send + Sync` seems to be unnecessary anymore.

BTW I also remove `Pin` because I don't well know it but it seems to work well after been removed. If I have some mistake please tell me.
