### PR TITLE
Ensure tokio runtime exists when registering the module

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -204,6 +204,8 @@ overrides:
     parserOptions:
       project:
         - ./examples/tsconfig.json
+    rules:
+      'import/no-extraneous-dependencies': 0
 
   - files:
       - ./bench/**/*.{ts,js}

--- a/crates/napi/src/bindgen_runtime/module_register.rs
+++ b/crates/napi/src/bindgen_runtime/module_register.rs
@@ -488,6 +488,8 @@ unsafe extern "C" fn napi_register_module_v1(
 
   #[cfg(all(windows, feature = "napi4", feature = "tokio_rt"))]
   {
+    crate::tokio_runtime::ensure_runtime();
+
     crate::tokio_runtime::RT_REFERENCE_COUNT.fetch_add(1, Ordering::SeqCst);
     unsafe {
       sys::napi_add_env_cleanup_hook(

--- a/examples/napi/electron-renderer/index.html
+++ b/examples/napi/electron-renderer/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Electron test</title>
+</head>
+<body>
+  <div>Electron test</div>
+  <script src="./index.js"></script>
+</body>
+</html>

--- a/examples/napi/electron-renderer/index.js
+++ b/examples/napi/electron-renderer/index.js
@@ -1,0 +1,7 @@
+const { ipcRenderer } = require('electron')
+
+const { callThreadsafeFunction } = require('../index')
+
+callThreadsafeFunction(() => {})
+
+ipcRenderer.on('ping', () => ipcRenderer.send('pong'))

--- a/examples/napi/tsconfig.json
+++ b/examples/napi/tsconfig.json
@@ -7,5 +7,5 @@
     "target": "ES2018",
     "skipLibCheck": false
   },
-  "exclude": ["dist", "electron.js"]
+  "exclude": ["dist", "electron.js", "electron-renderer"]
 }


### PR DESCRIPTION
In windows, electron renderer process will crash if:
1. Import some NAPI module that enable `tokio-rt` flag in renderer process.
2. Reload the page.
3. Call a function imported from that NAPI module.

Because the tokio runtime will be dropped when reloading the page, and won't create again, but currently we assume that the runtime must exist in tokio-based `within_runtime_if_available`.
This will cause some panic like this:

```
thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', napi-rs\crates\napi\src\tokio_runtime.rs:72:42
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Error: Renderer process crashed: crashed, exitCode: -529697949
    at EventEmitter.<anonymous> (napi-rs\examples\napi\electron.js:33:9)
    at EventEmitter.emit (node:events:525:35)
```