### PR TITLE
chore(napi): adds support for `Rc<T>` / `Arc<T>` / `Mutex<T>`

### DIFF
--- a/crates/backend/src/typegen.rs
+++ b/crates/backend/src/typegen.rs
@@ -205,7 +205,10 @@ static KNOWN_TYPES: Lazy<HashMap<&'static str, (&'static str, bool, bool)>> = La
     ("unknown", ("unknown", false, false)),
     ("Unknown", ("unknown", false, false)),
     ("JsUnknown", ("unknown", false, false)),
-    ("This", ("this", false, false))
+    ("This", ("this", false, false)),
+    ("Rc", ("{}", false, false)),
+    ("Arc", ("{}", false, false)),
+    ("Mutex", ("{}", false, false)),
   ]);
 
   map

--- a/crates/napi/src/bindgen_runtime/js_values.rs
+++ b/crates/napi/src/bindgen_runtime/js_values.rs
@@ -428,7 +428,7 @@ where
         Ok(inner) => T::to_napi_value(env, inner.clone()),
         Err(_) => Err(Error::new(
           Status::GenericFailure,
-          format!("Failed to acquire a lock"),
+          "Failed to acquire a lock",
         )),
       }
     }

--- a/crates/napi/src/bindgen_runtime/js_values.rs
+++ b/crates/napi/src/bindgen_runtime/js_values.rs
@@ -1,4 +1,8 @@
-use std::{ptr, sync::{Arc, Mutex}, rc::Rc};
+use std::{
+  ptr,
+  rc::Rc,
+  sync::{Arc, Mutex},
+};
 
 use crate::{check_status, sys, Error, JsUnknown, NapiRaw, NapiValue, Result, Status, ValueType};
 


### PR DESCRIPTION
Since those types can be safely cloned across the JS/Rust boundaries, we can support them by default.