### PR TITLE
feat(cli): add --use-cross command for building with `cross`

### DIFF
--- a/cli/codegen/commands.ts
+++ b/cli/codegen/commands.ts
@@ -228,6 +228,12 @@ const BUILD_OPTIONS: CommandSchema = {
       short: 'x',
     },
     {
+      name: 'useCross',
+      type: 'boolean',
+      description:
+        '[experimental] use [cross](https://github.com/cross-rs/cross) instead of `cargo`',
+    },
+    {
       name: 'watch',
       type: 'boolean',
       description:

--- a/cli/docs/build.md
+++ b/cli/docs/build.md
@@ -44,6 +44,7 @@ new NapiCli().build({
 | bin               | --bin                 | string   | false    |         | Build only the specified binary                                                                                           |
 | package           | --package,-p          | string   | false    |         | Build the specified library or the one at cwd                                                                             |
 | crossCompile      | --cross-compile,-x    | boolean  | false    |         | [experimental] cross-compile for the specified target with `cargo-xwin` on windows and `cargo-zigbuild` on other platform |
+| useCross          | --use-cross           | boolean  | false    |         | [experimental] use [cross](https://github.com/cross-rs/cross) instead of `cargo`                                          |
 | watch             | --watch,-w            | boolean  | false    |         | watch the crate changes and build continiously with `cargo-watch` crates                                                  |
 | features          | --features,-F         | string[] | false    |         | Space-separated list of features to activate                                                                              |
 | allFeatures       | --all-features        | boolean  | false    |         | Activate all available features                                                                                           |

--- a/cli/src/api/build.ts
+++ b/cli/src/api/build.ts
@@ -150,7 +150,8 @@ class Builder {
     const controller = new AbortController()
 
     const buildTask = new Promise<void>((resolve, reject) => {
-      const buildProcess = spawn('cargo', this.args, {
+      const command = this.options.useCross ? 'cross' : 'cargo'
+      const buildProcess = spawn(command, this.args, {
         env: {
           ...process.env,
           ...this.envs,

--- a/cli/src/def/build.ts
+++ b/cli/src/def/build.ts
@@ -97,6 +97,11 @@ export abstract class BaseBuildCommand extends Command {
       '[experimental] cross-compile for the specified target with `cargo-xwin` on windows and `cargo-zigbuild` on other platform',
   })
 
+  useCross?: boolean = Option.Boolean('--use-cross', {
+    description:
+      '[experimental] use [cross](https://github.com/cross-rs/cross) instead of `cargo`',
+  })
+
   watch?: boolean = Option.Boolean('--watch,-w', {
     description:
       'watch the crate changes and build continiously with `cargo-watch` crates',
@@ -135,6 +140,7 @@ export abstract class BaseBuildCommand extends Command {
       bin: this.bin,
       package: this.package,
       crossCompile: this.crossCompile,
+      useCross: this.useCross,
       watch: this.watch,
       features: this.features,
       allFeatures: this.allFeatures,
@@ -223,6 +229,10 @@ export interface BuildOptions {
    * [experimental] cross-compile for the specified target with `cargo-xwin` on windows and `cargo-zigbuild` on other platform
    */
   crossCompile?: boolean
+  /**
+   * [experimental] use [cross](https://github.com/cross-rs/cross) instead of `cargo`
+   */
+  useCross?: boolean
   /**
    * watch the crate changes and build continiously with `cargo-watch` crates
    */


### PR DESCRIPTION
closes #1582

Replacing the `cargo` command with `cross` has been tested in https://github.com/web-infra-dev/rspack/actions/runs/4912599372/jobs/8771798276 by using sed to replace the command inside the script.

Example run:

<img width="1092" alt="image" src="https://user-images.githubusercontent.com/1430279/236770552-4d6f1034-c0d6-4687-bc1f-f85df8fd917d.png">
