### PR TITLE
feat(cli): detect Cargo `--profile` argument

### DIFF
--- a/cli/src/api/build.ts
+++ b/cli/src/api/build.ts
@@ -460,12 +460,13 @@ class Builder {
       return
     }
 
-    const src = join(
-      this.targetDir,
-      this.target.triple,
-      this.options.release ? 'release' : 'debug',
-      srcName,
-    )
+    let outputFolder = this.options.release ? 'release' : 'debug'
+    if (this.options.cargoOptions?.includes('--profile')) {
+      const args = this.options.cargoOptions
+      const profileIndex = args.indexOf('--profile')
+      outputFolder = args[profileIndex + 1]
+    }
+    const src = join(this.targetDir, this.target.triple, outputFolder, srcName)
     const dest = join(this.outputDir, destName)
 
     try {


### PR DESCRIPTION
I actually need this feature on the v2 CLI, do you think you could backport and publish it? I used patch-package [on the Tauri PR](https://github.com/tauri-apps/tauri/pull/6861) but it's.. ugly :smile: 

I wanted to push to v2 instead but I couldn't find how you are handling it, I guess you're doing it manually?