### PR TITLE
docs(README): update platform support status

### DIFF
--- a/crates/napi/README.md
+++ b/crates/napi/README.md
@@ -22,6 +22,7 @@ A framework for building compiled `Node.js` add-ons in `Rust` via Node-API. Webs
 ![macOS/Windows/Linux x64](https://github.com/napi-rs/napi-rs/workflows/macOS/Windows/Linux%20x64/badge.svg)
 ![Linux-aarch64](https://github.com/napi-rs/napi-rs/workflows/Linux-aarch64/badge.svg)
 ![Linux-armv7](https://github.com/napi-rs/napi-rs/workflows/Linux-armv7/badge.svg)
+![Linux-riscv64](https://github.com/napi-rs/napi-rs/actions/workflows/linux-riscv64.yaml/badge.svg)
 ![macOS-Android](https://github.com/napi-rs/napi-rs/workflows/macOS-Android/badge.svg)
 [![Android-armv7](https://github.com/napi-rs/napi-rs/actions/workflows/android-armv7.yml/badge.svg)](https://github.com/napi-rs/napi-rs/actions/workflows/android-armv7.yml)
 ![Windows i686](https://github.com/napi-rs/napi-rs/workflows/Windows%20i686/badge.svg)
@@ -32,21 +33,22 @@ A framework for building compiled `Node.js` add-ons in `Rust` via Node-API. Webs
 
 **Rust** `1.57.0`
 
-|                       | node12 | node14 | node16 | node18 |
-| --------------------- | ------ | ------ | ------ | ------ |
-| Windows x64           | ✓      | ✓      | ✓      | ✓      |
-| Windows x86           | ✓      | ✓      | ✓      | ✓      |
-| Windows arm64         | ✓      | ✓      | ✓      | ✓      |
-| macOS x64             | ✓      | ✓      | ✓      | ✓      |
-| macOS aarch64         | ✓      | ✓      | ✓      | ✓      |
-| Linux x64 gnu         | ✓      | ✓      | ✓      | ✓      |
-| Linux x64 musl        | ✓      | ✓      | ✓      | ✓      |
-| Linux aarch64 gnu     | ✓      | ✓      | ✓      | ✓      |
-| Linux aarch64 musl    | ✓      | ✓      | ✓      | ✓      |
-| Linux arm gnueabihf   | ✓      | ✓      | ✓      | ✓      |
-| Linux aarch64 android | ✓      | ✓      | ✓      | ✓      |
-| Linux armv7 android   | ✓      | ✓      | ✓      | ✓      |
-| FreeBSD x64           | ✓      | ✓      | ✓      | ✓      |
+|                       | node12 | node14 | node16 | node18 | node20 |
+| --------------------- | ------ | ------ | ------ | ------ | ------ |
+| Windows x64           | ✓      | ✓      | ✓      | ✓      | ✓      |
+| Windows x86           | ✓      | ✓      | ✓      | ✓      | ✓      |
+| Windows arm64         | ✓      | ✓      | ✓      | ✓      | ✓      |
+| macOS x64             | ✓      | ✓      | ✓      | ✓      | ✓      |
+| macOS aarch64         | ✓      | ✓      | ✓      | ✓      | ✓      |
+| Linux x64 gnu         | ✓      | ✓      | ✓      | ✓      | ✓      |
+| Linux x64 musl        | ✓      | ✓      | ✓      | ✓      | ✓      |
+| Linux aarch64 gnu     | ✓      | ✓      | ✓      | ✓      | ✓      |
+| Linux aarch64 musl    | ✓      | ✓      | ✓      | ✓      | ✓      |
+| Linux arm gnueabihf   | ✓      | ✓      | ✓      | ✓      | ✓      |
+| Linux riscv64 gnu     | N/A    | N/A    | ✓      | ✓      | ✓      |
+| Linux aarch64 android | ✓      | ✓      | ✓      | ✓      | ✓      |
+| Linux armv7 android   | ✓      | ✓      | ✓      | ✓      | ✓      |
+| FreeBSD x64           | ✓      | ✓      | ✓      | ✓      | ✓      |
 
 This library depends on Node-API and requires `Node@10.0.0` or later.
 


### PR DESCRIPTION
Document riscv64 linux support status.
BTW add the missing node20 column.

The minimum working version of nodejs on riscv64 is 16. Some people tried to port node 14 to riscv64 but it is buggy.