### PR TITLE
chore: remove extra #[cfg] attribute

### DIFF
--- a/crates/napi/src/bindgen_runtime/module_register.rs
+++ b/crates/napi/src/bindgen_runtime/module_register.rs
@@ -539,7 +539,6 @@ unsafe extern "C" fn napi_register_module_v1(
   });
 
   #[cfg(all(windows, feature = "napi4", feature = "tokio_rt"))]
-  #[cfg(all(feature = "napi4", feature = "tokio_rt"))]
   {
     crate::tokio_runtime::ensure_runtime();
 


### PR DESCRIPTION
This was accidentally added in 2d1e4144b315894164c8316a5fcfa2bc887a19d0. The second cfg attribute is essentially a no-op since the first one is still valid and has more conditions, but we don't need it.