### PR TITLE
fix(cli): ts constEnum option not working when set in package.json

### DIFF
--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -123,7 +123,7 @@ export class BuildCommand extends Command {
     )} file, relative to cwd`,
   })
 
-  constEnum?: boolean = Option.Boolean('--const-enum', true, {
+  constEnum?: boolean = Option.Boolean('--const-enum', {
     description: `Generate ${chalk.green(
       'const enum',
     )} in .d.ts file or not, default is ${chalk.green('true')}`,
@@ -455,7 +455,7 @@ export class BuildCommand extends Command {
       packageName,
       tsConstEnum: tsConstEnumFromConfig,
     } = getNapiConfig(this.configFileName)
-    const tsConstEnum = this.constEnum ?? tsConstEnumFromConfig
+    const tsConstEnum = this.constEnum ?? tsConstEnumFromConfig ?? true
     if (triple.platform === 'wasi') {
       try {
         const emnapiDir = require.resolve('emnapi')

--- a/cli/src/consts.ts
+++ b/cli/src/consts.ts
@@ -15,7 +15,7 @@ export function getNapiConfig(
   ).map(parseTriple)
   const defaultPlatforms =
     napi?.triples?.defaults === false ? [] : [...DefaultPlatforms]
-  const tsConstEnum: boolean = napi?.ts?.constEnum ?? true
+  const tsConstEnum: boolean | undefined = napi?.ts?.constEnum
   const platforms = [...defaultPlatforms, ...additionPlatforms]
   const releaseVersion = process.env.RELEASE_VERSION
   const releaseVersionWithoutPrefix = releaseVersion?.startsWith('v')


### PR DESCRIPTION
Due to the implementation of v2, cli specific argument value will always be used if it has default value.

I also noticed that the `const enum` feature https://github.com/napi-rs/napi-rs/pull/1527 is not yet ported in v3.