### PR TITLE
perf(cli): improve musl verification

### DIFF
--- a/cli/src/api/templates/js-binding.ts
+++ b/cli/src/api/templates/js-binding.ts
@@ -16,18 +16,52 @@ let nativeBinding = null
 let localFileExisted = false
 let loadError = null
 
-function isMusl() {
-  // For Node 10
-  if (!process.report || typeof process.report.getReport !== 'function') {
-    try {
-      const lddPath = require('child_process').execSync('which ldd').toString().trim()
-      return readFileSync(lddPath, 'utf8').includes('musl')
-    } catch (e) {
-      return true
+const isMusl = () => {
+  let musl = false;
+  if (process.platform === 'linux') {
+    musl = isMuslFromFilesystem();
+    if (musl === null) {
+      musl = isMuslFromReport();
     }
-  } else {
-    const { glibcVersionRuntime } = process.report.getReport().header
-    return !glibcVersionRuntime
+    if (musl === null) {
+      musl = isMuslFromChildProcess();
+    }
+  }
+  return musl;
+};
+
+const isFileMusl = (f) => f.includes('libc.musl-') || f.includes('ld-musl-');
+
+const isMuslFromFilesystem = () => {
+  try {
+    return readFileSync('/usr/bin/ldd', 'utf-8').includes('musl');
+  } catch {
+    return null;
+  }
+}
+
+const isMuslFromReport = () => {
+  const report = typeof process.report.getReport === 'function' ? process.report.getReport() : null;
+  if (!report) {
+    return null;
+  }
+  if (report.header && report.header.glibcVersionRuntime) {
+    return false;
+  }
+  if (Array.isArray(report.sharedObjects)) {
+    if (report.sharedObjects.some(isFileMusl)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const isMuslFromChildProcess = () => {
+  try {
+    return require('child_process').execSync('ldd --version', { encoding: 'utf8' }).includes('musl');
+  } catch (e) {
+    // If we reach this case, we don't know if the system is musl or not, so is better to just fallback to false
+    return false;
   }
 }
 


### PR DESCRIPTION
Recently I merged a PR this https://github.com/lovell/detect-libc/pull/19 to improve the performance to detect `glibc` and `musl` systems.

Now, I'm porting that solution to other libraries to help them improve their performance as well.

This change improves the performance from `25ms` in most cases to `0.15ms`, so the startup of every package will be faster.

Also, after Node 20.3.0, because of https://github.com/nodejs/node/issues/48831, it could take up to `600ms` (depending on the amount of CPU), so every package that uses `napi-rs` will be slowdown by this amount of time, this especially is bad for CLIs, like swc.