### PR TITLE
fix(napi): js promise error messages

### DIFF
--- a/crates/napi/src/error.rs
+++ b/crates/napi/src/error.rs
@@ -90,6 +90,18 @@ impl From<JsUnknown> for Error {
         "Create Error reference failed".to_owned(),
       );
     }
+
+    let maybe_error_message = value
+      .coerce_to_string()
+      .and_then(|a| a.into_utf8().and_then(|a| a.into_owned()));
+    if let Ok(error_message) = maybe_error_message {
+      return Self {
+        status: Status::GenericFailure,
+        reason: error_message,
+        maybe_raw: result,
+      };
+    }
+
     Self {
       status: Status::GenericFailure,
       reason: "".to_string(),


### PR DESCRIPTION
Adds more detailed error messages when promises fail in threadsafe function by trying to coerce them to a string. This is useful in situation when an error is thrown within async function, and enables capturing of errors in such cases.

For example (in https://github.com/gorules/zen):
```ts
const { ZenEngine } = require('./index');

const engine = new ZenEngine({
    loader: async (key) => {
        throw Error("Custom thrown error");
    }
});

(async () => {
    try {
        await engine.evaluate("unknown key", {});
    } catch (e) {
        console.log(e);
    }
})();
```

Fails without "Custom thrown error" until changes above are introduced. When introduced stack is visible with e.g.:
```
[Error: Loader error: Internal error on key unknown key: GenericFailure, Error: Custom thrown error]
```