### PR TITLE
fix(napi): potential double free issue

### DIFF
--- a/crates/napi/src/bindgen_runtime/module_register.rs
+++ b/crates/napi/src/bindgen_runtime/module_register.rs
@@ -47,7 +47,8 @@ impl<T> PersistedPerInstanceVec<T> {
       f(&mut []);
     } else {
       let inner = self.inner.load(Ordering::Relaxed);
-      let mut temp = std::mem::ManuallyDrop::new(unsafe { Vec::from_raw_parts(inner, length, length) });
+      let mut temp =
+        std::mem::ManuallyDrop::new(unsafe { Vec::from_raw_parts(inner, length, length) });
       f(temp.as_mut_slice());
       // Inner Vec has been reallocated, so we need to update the pointer
       if temp.as_mut_ptr() != inner {
@@ -60,7 +61,8 @@ impl<T> PersistedPerInstanceVec<T> {
   fn push(&self, item: T) {
     let length = self.length.load(Ordering::Relaxed);
     let inner = self.inner.load(Ordering::Relaxed);
-    let mut temp = std::mem::ManuallyDrop::new(unsafe { Vec::from_raw_parts(inner, length, length) });
+    let mut temp =
+      std::mem::ManuallyDrop::new(unsafe { Vec::from_raw_parts(inner, length, length) });
     temp.push(item);
     // Inner Vec has been reallocated, so we need to update the pointer
     if temp.as_mut_ptr() != inner {

--- a/crates/napi/src/bindgen_runtime/module_register.rs
+++ b/crates/napi/src/bindgen_runtime/module_register.rs
@@ -47,28 +47,25 @@ impl<T> PersistedPerInstanceVec<T> {
       f(&mut []);
     } else {
       let inner = self.inner.load(Ordering::Relaxed);
-      let mut temp = unsafe { Vec::from_raw_parts(inner, length, length) };
+      let mut temp = std::mem::ManuallyDrop::new(unsafe { Vec::from_raw_parts(inner, length, length) });
       f(temp.as_mut_slice());
       // Inner Vec has been reallocated, so we need to update the pointer
       if temp.as_mut_ptr() != inner {
         self.inner.store(temp.as_mut_ptr(), Ordering::Relaxed);
       }
       self.length.store(temp.len(), Ordering::Relaxed);
-      std::mem::forget(temp);
     }
   }
 
   fn push(&self, item: T) {
     let length = self.length.load(Ordering::Relaxed);
     let inner = self.inner.load(Ordering::Relaxed);
-    let mut temp = unsafe { Vec::from_raw_parts(inner, length, length) };
+    let mut temp = std::mem::ManuallyDrop::new(unsafe { Vec::from_raw_parts(inner, length, length) });
     temp.push(item);
     // Inner Vec has been reallocated, so we need to update the pointer
     if temp.as_mut_ptr() != inner {
       self.inner.store(temp.as_mut_ptr(), Ordering::Relaxed);
     }
-    std::mem::forget(temp);
-
     self.length.fetch_add(1, Ordering::Relaxed);
   }
 }


### PR DESCRIPTION
Hi,
I found a memory-safety/soundness issue in this crate while scanning Rust code for potential vulnerabilities. This PR contains a fix for the issue.

# Issue Description
https://github.com/napi-rs/napi-rs/blob/30534d428803c3c8a027a6b7737c1508f68cb9bb/crates/napi/src/bindgen_runtime/module_register.rs#L64-L70

https://github.com/napi-rs/napi-rs/blob/30534d428803c3c8a027a6b7737c1508f68cb9bb/crates/napi/src/bindgen_runtime/module_register.rs#L50-L57

If a panic!() occurs between the `Vec::from_raw_parts` function, including the `Vec::from_raw_parts` function itself, and `std::mem::forget`, a double free vulnerability emerges.



# Fix
In Rust, `std::mem::forget` does not actually free the memory, instead it simply allows the memory to leak. This can lead to double free when the data object goes out of scope and its destructor is called automatically. The modification here uses `std::mem::ManuallyDrop` to wrap data. This ensures that data will not be automatically dropped when it goes out of scope, thus avoiding a double free scenario. With `ManuallyDrop`, we explicitly state that the data variable should not be dropped, thus avoiding any potential double free issues.

