### PR TITLE
throw `is not a valid identifier` when generating getters and setters

### DIFF
--- a/crates/backend/src/codegen/struct.rs
+++ b/crates/backend/src/codegen/struct.rs
@@ -628,8 +628,14 @@ impl NapiStruct {
       };
       let ty = &field.ty;
 
-      let getter_name = Ident::new(&format!("get_{}", field_name), Span::call_site());
-      let setter_name = Ident::new(&format!("set_{}", field_name), Span::call_site());
+      let getter_name = Ident::new(
+        &format!("get_{}", rm_raw_prefix(&field_name)),
+        Span::call_site(),
+      );
+      let setter_name = Ident::new(
+        &format!("set_{}", rm_raw_prefix(&field_name)),
+        Span::call_site(),
+      );
 
       if field.getter {
         let default_to_napi_value_convert = quote! {
@@ -748,12 +754,18 @@ impl NapiStruct {
       };
 
       if field.getter {
-        let getter_name = Ident::new(&format!("get_{}", field_name), Span::call_site());
+        let getter_name = Ident::new(
+          &format!("get_{}", rm_raw_prefix(&field_name)),
+          Span::call_site(),
+        );
         (quote! { .with_getter(#getter_name) }).to_tokens(&mut prop);
       }
 
       if field.writable && field.setter {
-        let setter_name = Ident::new(&format!("set_{}", field_name), Span::call_site());
+        let setter_name = Ident::new(
+          &format!("set_{}", rm_raw_prefix(&field_name)),
+          Span::call_site(),
+        );
         (quote! { .with_setter(#setter_name) }).to_tokens(&mut prop);
       }
 
@@ -902,5 +914,13 @@ impl NapiImpl {
         }
       }
     })
+  }
+}
+
+fn rm_raw_prefix(s: &str) -> &str {
+  if s.starts_with("r#") {
+    &s[2..]
+  } else {
+    s
   }
 }

--- a/examples/napi/index.d.ts
+++ b/examples/napi/index.d.ts
@@ -184,6 +184,14 @@ export class Optional {
   static optionOnly(optional?: string | undefined | null): string
 }
 
+export class Selector {
+  orderBy: Array<string>
+  select: Array<string>
+  where?: string
+  struct: string
+  constructor(orderBy: Array<string>, select: Array<string>, where?: string, struct: string)
+}
+
 export class Width {
   value: number
   constructor(value: number)

--- a/examples/napi/src/constructor.rs
+++ b/examples/napi/src/constructor.rs
@@ -1,0 +1,7 @@
+#[napi(constructor)]
+pub struct Selector {
+  pub order_by: Vec<String>,
+  pub select: Vec<String>,
+  pub r#where: Option<String>,
+  pub r#struct: String,
+}

--- a/examples/napi/src/lib.rs
+++ b/examples/napi/src/lib.rs
@@ -27,6 +27,7 @@ mod bigint;
 mod callback;
 mod class;
 mod class_factory;
+mod constructor;
 mod date;
 mod either;
 mod r#enum;


### PR DESCRIPTION
fix(backend): attribute of a struct marked as #[napi(constructor)] contain Rust keywords, causing to throw `is not a valid identifier` when generating getters and setters