### PR TITLE
chore(napi): make napi_register_module_v1 pub

### DIFF
--- a/crates/napi/src/bindgen_runtime/module_register.rs
+++ b/crates/napi/src/bindgen_runtime/module_register.rs
@@ -350,6 +350,13 @@ unsafe extern "C" fn napi_register_wasm_v1(
 
 #[cfg(not(feature = "noop"))]
 #[no_mangle]
+/// Register the n-api module exports.
+/// 
+/// # Safety
+/// This method is meant to be called by Node.js while importing the n-api module.
+/// Only call this method if the current module is **not** imported by a node-like runtime.
+/// 
+/// Arguments `env` and `exports` must **not** be null.
 pub unsafe extern "C" fn napi_register_module_v1(
   env: sys::napi_env,
   exports: sys::napi_value,

--- a/crates/napi/src/bindgen_runtime/module_register.rs
+++ b/crates/napi/src/bindgen_runtime/module_register.rs
@@ -350,7 +350,7 @@ unsafe extern "C" fn napi_register_wasm_v1(
 
 #[cfg(not(feature = "noop"))]
 #[no_mangle]
-unsafe extern "C" fn napi_register_module_v1(
+pub unsafe extern "C" fn napi_register_module_v1(
   env: sys::napi_env,
   exports: sys::napi_value,
 ) -> sys::napi_value {

--- a/crates/napi/src/bindgen_runtime/module_register.rs
+++ b/crates/napi/src/bindgen_runtime/module_register.rs
@@ -351,11 +351,11 @@ unsafe extern "C" fn napi_register_wasm_v1(
 #[cfg(not(feature = "noop"))]
 #[no_mangle]
 /// Register the n-api module exports.
-/// 
+///
 /// # Safety
 /// This method is meant to be called by Node.js while importing the n-api module.
 /// Only call this method if the current module is **not** imported by a node-like runtime.
-/// 
+///
 /// Arguments `env` and `exports` must **not** be null.
 pub unsafe extern "C" fn napi_register_module_v1(
   env: sys::napi_env,


### PR DESCRIPTION
I'd like to use classes created by `napi-rs` inside a Node.js instance which is created using [`rust-nodejs`](https://github.com/branchseer/rust-nodejs). For this to work, the classes need to be exported to the node runtime using `napi::bindgen_prelude::napi_register_module_v1`, which is currently not accessible from outside its module.

This PR makes this method accessible from outside its module.

<details><summary>Code I'm using to initialize <code>napi-rs</code> modules inside a node vm created by <code>rust-nodejs</code></summary>
<p>

If someone is interested in how I'm using the `napi_register_module_v1` method:

```rust
use napi::bindgen_prelude::napi_register_module_v1;
use napi::sys::{napi_env, napi_value};
use napi::Env;
use nodejs::run_raw;
use std::ffi::c_void;
use std::ptr::null_mut;

static ONCE: Once = Once::new();

unsafe fn run_napi<F: for<'a> FnOnce(Env)>(f: F) -> i32 {
    static mut MODULE_INIT_FN: *mut c_void = null_mut();

    let mut module_init_fn = Some(f);
    MODULE_INIT_FN = (&mut module_init_fn) as *mut Option<F> as _;

    unsafe extern "C" fn napi_reg_func<F: for<'a> FnOnce(Env)>(
        env: napi_env,
        exports: napi_value,
    ) -> napi_value {
        ONCE.call_once(|| {
            napi_register_module_v1(env, exports);
        });

        let module_init_fn = (MODULE_INIT_FN as *mut Option<F>).as_mut().unwrap();
        let module_init_fn = module_init_fn.take().unwrap();
        MODULE_INIT_FN = null_mut();
        module_init_fn(Env::from_raw(env));

        exports
    }

    run_raw(napi_reg_func::<F> as _)
}
```

</p>
</details> 