### PR TITLE
chore(cli): simplify publish step in ci-template

### DIFF
--- a/cli/src/api/templates/ci-template.ts
+++ b/cli/src/api/templates/ci-template.ts
@@ -543,6 +543,7 @@ jobs:
         with:
           node-version: 18
           cache: 'yarn'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: 'Install dependencies'
         run: yarn install
@@ -561,19 +562,16 @@ jobs:
 
       - name: Publish
         run: |
-          npm config set provenance true
           if git log -1 --pretty=%B | grep "^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+$";
           then
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            npm publish --access public
+            npm publish --access public --provenance
           elif git log -1 --pretty=%B | grep "^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+";
           then
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            npm publish --tag next --access public
+            npm publish --tag next --access public --provenance
           else
             echo "Not a release, skipping publish"
           fi
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
 `

--- a/cli/src/api/templates/ci-template.ts
+++ b/cli/src/api/templates/ci-template.ts
@@ -573,5 +573,5 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}
 `


### PR DESCRIPTION
This uses the standard way to handle npm auth in GitHub Actions.

Another improvement is to look for a tag push instead of a commit that has some line that matches a the version regex thing:
* Changing the check to `if echo "${{ github.ref_name }}" | grep "^v[0-9]\+\.[0-9]\+\.[0-9]\+$";` or even `if [[ ${{ github.ref_name }} =~ ^v[0-9]\+\.[0-9]\+\.[0-9]\+$ ]];`
* Turning `tags-ignore: **` to `tags: v[0-9]*`.
* And we can then also `if` then entire publish job with `if: github.ref_type == 'tag'` to save some GitHub Actions runtime.

`then` can also be in the same line as the `if`, but that's a matter of taste.
