### PR TITLE
fix(cli): 🤖 align wasi template to nodejs demo

### DIFF
--- a/cli/src/api/load-wasi-template.ts
+++ b/cli/src/api/load-wasi-template.ts
@@ -16,6 +16,7 @@ import { instantiateNapiModule as __emnapiInstantiateNapiModule } from '@emnapi/
 import { getDefaultContext as __emnapiGetDefaultContext } from '@emnapi/runtime'
 
 const __wasi = new __nodeWASI({
+  version: 'preview1',
   env: process.env,
   preopens: {
     '/': __nodePath.join(__nodeURL.fileURLToPath(import.meta.url), '..'),


### PR DESCRIPTION
1. Aligning wasi template to nodejs demo, you can refer to https://nodejs.org/api/wasi.html
2. If you are using NodeJS greater than 21, NodeJS will emit an error if you don't specify `options. version` explicitly.
![image](https://github.com/napi-rs/napi-rs/assets/17974631/355911ba-a6fe-487a-8df8-b7a28ef464eb)
