### PR TITLE
feat(cli): Add support for s390x linux arch in js bindings template

### DIFF
--- a/cli/src/api/templates/js-binding.ts
+++ b/cli/src/api/templates/js-binding.ts
@@ -303,6 +303,20 @@ switch (platform) {
           }
         }
         break
+      case 's390x':
+        localFileExisted = existsSync(
+          join(__dirname, '${localName}.linux-s390x-gnu.node')
+        )
+        try {
+          if (localFileExisted) {
+            nativeBinding = require('./${localName}.linux-s390x-gnu.node')
+          } else {
+            nativeBinding = require('${pkgName}-linux-s390x-gnu')
+          }
+        } catch (e) {
+          loadError = e
+        }
+        break
       default:
         throw new Error(\`Unsupported architecture on Linux: \${arch}\`)
     }


### PR DESCRIPTION
With this patch I was able to successfully use a Rust <-> NodeJS bindings built in the s390x architecture.

Might be a naive patch but I need this to get https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs to support this system without a custom build process.

Please let me know if there are other potential changes in the codebase that I should address.