### PR TITLE
chore(napi): remove napi_val on Ref because it is unused

### DIFF
--- a/crates/napi/src/env.rs
+++ b/crates/napi/src/env.rs
@@ -833,7 +833,6 @@ impl Env {
       raw_ref,
       count: 1,
       inner: (),
-      raw_value,
     })
   }
 
@@ -851,7 +850,6 @@ impl Env {
       raw_ref,
       count: ref_count,
       inner: (),
-      raw_value,
     })
   }
 

--- a/crates/napi/src/js_values/value_ref.rs
+++ b/crates/napi/src/js_values/value_ref.rs
@@ -8,7 +8,6 @@ pub struct Ref<T> {
   pub(crate) raw_ref: sys::napi_ref,
   pub(crate) count: u32,
   pub(crate) inner: T,
-  pub(crate) raw_value: sys::napi_value,
 }
 
 #[allow(clippy::non_send_fields_in_send_ty)]
@@ -26,7 +25,6 @@ impl<T> Ref<T> {
       raw_ref,
       count: ref_count,
       inner,
-      raw_value: js_value.value,
     })
   }
 


### PR DESCRIPTION
This private field is never used in NAPI-RS.