### PR TITLE
fix(napi): callback in execute_tokio_future does not need to be Send

### DIFF
--- a/crates/napi/src/env.rs
+++ b/crates/napi/src/env.rs
@@ -1087,7 +1087,7 @@ impl Env {
     T: 'static + Send,
     V: 'static + ToNapiValue,
     F: 'static + Send + Future<Output = Result<T>>,
-    R: 'static + Send + FnOnce(&mut Env, T) -> Result<V>,
+    R: 'static + FnOnce(&mut Env, T) -> Result<V>,
   >(
     &self,
     fut: F,


### PR DESCRIPTION
The resolver does not need to be `Send` or `Sync`, because it's assumed to be called from the same thread that the JavaScript thread is running on.