### PR TITLE
Ensure cwd and outputDir are used for finding files

### DIFF
--- a/cli/src/api/universalize.ts
+++ b/cli/src/api/universalize.ts
@@ -43,7 +43,7 @@ export async function universalizeBinaries(userOptions: UniversalizeOptions) {
   }
 
   const srcFiles = UniArchsByPlatform[process.platform]?.map(
-    (arch) => `${config.binaryName}.${process.platform}-${arch}.node`,
+    (arch) => resolve(options.cwd, options.outputDir, `${config.binaryName}.${process.platform}-${arch}.node`),
   )
 
   if (!srcFiles || !universalizers[process.platform]) {
@@ -56,7 +56,7 @@ export async function universalizeBinaries(userOptions: UniversalizeOptions) {
   debug('  %O', srcFiles)
 
   const srcFileLookup = await Promise.all(
-    srcFiles.map((f) => fileExists(resolve(options.cwd, options.outputDir, f))),
+    srcFiles.map((f) => fileExists(f)),
   )
 
   const notFoundFiles = srcFiles.filter((_, i) => !srcFileLookup[i])


### PR DESCRIPTION
Using the latest alpha I had an issue using a non standard `--output-dir` with the universalize command where the JS would find the files but the XCode tool couldn't. 

I have a patch running locally with this change that resolved the issue. https://github.com/wypes-rs/wypes/blob/main/.yarn/patches/%40napi-rs-cli-npm-3.0.0-alpha.38-93961b489d.patch