### PR TITLE
fix: remove outdated rustdoc about tokio channels

### DIFF
--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -34,14 +34,6 @@
 //! }
 //! ```
 //!
-//! ***Tokio channel in `napi-rs` buffer size is default `100`.***
-//!
-//! ***You can adjust it via `NAPI_RS_TOKIO_CHANNEL_BUFFER_SIZE` environment variable***
-//!
-//! ```
-//! NAPI_RS_TOKIO_CHANNEL_BUFFER_SIZE=1000 node ./app.js
-//! ```
-//!
 //! ### latin1
 //!
 //! Decode latin1 string from JavaScript using [encoding_rs](https://docs.rs/encoding_rs).


### PR DESCRIPTION
This seems to be a relic of when napi-rs used channels to send data to the tokio runtime. This removes the outdated doc, as this could be misleading if one wants to understand what those channels are about.