### PR TITLE
fix(napi): JsObject.add_finalizer callback being allowed to reference non-static things

### DIFF
--- a/crates/napi/src/js_values/object.rs
+++ b/crates/napi/src/js_values/object.rs
@@ -37,7 +37,7 @@ impl JsObject {
   where
     T: 'static,
     Hint: 'static,
-    F: FnOnce(FinalizeContext<T, Hint>),
+    F: FnOnce(FinalizeContext<T, Hint>) + 'static,
   {
     let mut maybe_ref = ptr::null_mut();
     let wrap_context = Box::leak(Box::new((native, finalize_cb, ptr::null_mut())));


### PR DESCRIPTION
The `finalize_cb` passed to `add_finalizer` doesn't have a lifetime requirement, so it's allowed to reference things in scope. For example, this compiles fine, but it will segfault at runtime when the finalizer is called:

```rs
use napi::{JsObject, Result};

fn my_function(object: &mut JsObject) -> Result<()> {
    let my_string = String::from("Hello, world!");

    object.add_finalizer((), (), |_ctx| {
        println!("{}", my_string);
    });

    drop(my_string);
}
```

This commit just requires the callback has a static lifetime which prevents the example above compiling. However the other two arguments already require static lifetimes so I'm not sure why the callback didn't.