### PR TITLE
fix: `create_bigint_from_*128` returned incorrect word_count

### DIFF
--- a/crates/napi/src/env.rs
+++ b/crates/napi/src/env.rs
@@ -123,7 +123,7 @@ impl Env {
     check_status!(unsafe {
       sys::napi_create_bigint_words(self.0, sign_bit, 2, words, &mut raw_value)
     })?;
-    Ok(JsBigInt::from_raw_unchecked(self.0, raw_value, 1))
+    Ok(JsBigInt::from_raw_unchecked(self.0, raw_value, 2))
   }
 
   #[cfg(feature = "napi6")]
@@ -131,7 +131,7 @@ impl Env {
     let mut raw_value = ptr::null_mut();
     let words = &value as *const u128 as *const u64;
     check_status!(unsafe { sys::napi_create_bigint_words(self.0, 0, 2, words, &mut raw_value) })?;
-    Ok(JsBigInt::from_raw_unchecked(self.0, raw_value, 1))
+    Ok(JsBigInt::from_raw_unchecked(self.0, raw_value, 2))
   }
 
   /// [n_api_napi_create_bigint_words](https://nodejs.org/api/n-api.html#n_api_napi_create_bigint_words)


### PR DESCRIPTION
The value of `word_count` was inconsistent between the node side and rust side when calling `create_bigint_from_i128`/`create_bigint_from_u128`.
