### PR TITLE
fix(napi): ensure CalleeHandled works as expected

### DIFF
--- a/crates/napi/src/threadsafe_function.rs
+++ b/crates/napi/src/threadsafe_function.rs
@@ -658,7 +658,7 @@ unsafe extern "C" fn call_js_cb<
           )
         },
         Err(e) => {
-          if CalleeHandled {
+          if !CalleeHandled {
             unsafe { sys::napi_fatal_exception(raw_env, JsError::from(e).into_value(raw_env)) }
           } else {
             unsafe {


### PR DESCRIPTION
This was refactored in 4719caa64377f7d926c92a4c1051474ae79036c4. This codepath was swapped, as the fatal exception must be the normal codepath when the callee handled field is false. This fixes it by swapping this if statement, all the other calls have been checked and seem fine.