### PR TITLE
Add support for nwjs adding fallback for node library search

### DIFF
--- a/crates/sys/src/functions.rs
+++ b/crates/sys/src/functions.rs
@@ -780,10 +780,32 @@ pub use napi8::*;
 #[cfg(feature = "napi9")]
 pub use napi9::*;
 
+#[cfg(windows)]
+fn test_library( lib_result : Result<libloading::os::windows::Library, libloading::Error> ) -> Result<libloading::Library, libloading::Error> {
+  unsafe {
+    match lib_result {
+      Ok(lib) => {
+        let symbol: Result<libloading::os::windows::Symbol<unsafe extern "C" fn ()>, libloading::Error> = lib.get(b"napi_create_int32\0");
+        match symbol {
+          Ok(_) => Ok(lib.into()),
+          Err(err) => Err(err)
+        }
+      },
+      Err(err) => Err(err)
+    }
+  }
+}
+
+#[cfg(windows)]
+fn find_node_library() -> Result<libloading::Library, libloading::Error> {
+  return test_library(libloading::os::windows::Library::this())
+    .or(test_library(libloading::os::windows::Library::open_already_loaded("node")));
+}
+
 #[cfg(any(windows, feature = "dyn-symbols"))]
 pub(super) unsafe fn load_all() -> Result<libloading::Library, libloading::Error> {
   #[cfg(windows)]
-  let host = libloading::os::windows::Library::this()?.into();
+  let host = find_node_library()?;
 
   #[cfg(unix)]
   let host = libloading::os::unix::Library::this().into();


### PR DESCRIPTION
This is to allow for node files to also work with Windows nw.js. not just electron and node.

Using the patch from this issue: https://github.com/napi-rs/napi-rs/issues/1480.

The patch checks if a node library function is available in the executable, if not, it loads the external library version of node via node.dll (which is already loaded.)