### PR TITLE
Set explicit target flag for x86_64 CI template

### DIFF
--- a/cli/src/api/templates/ci-template.ts
+++ b/cli/src/api/templates/ci-template.ts
@@ -42,7 +42,7 @@ jobs:
         settings:
           - host: macos-latest
             target: 'x86_64-apple-darwin'
-            build: ${packageManager} build --platform
+            build: ${packageManager} build --platform --target x86_64-apple-darwin
           - host: windows-latest
             build: ${packageManager} build --platform
             target: 'x86_64-pc-windows-msvc'


### PR DESCRIPTION
Fix for issue https://github.com/napi-rs/napi-rs/issues/2076

Update `ci-template.ts` to fix CI error for `x86_64-apple-darwin` platform.

Although in this issue I was using the `latest` v2.18.2. Not 3.0.0-alpha.4. I believe the fix is the same for them.