### PR TITLE
Fix panic in JsArrayBufferValue as_ref/as_mut with Rust 1.78

### DIFF
--- a/crates/napi/src/js_values/arraybuffer.rs
+++ b/crates/napi/src/js_values/arraybuffer.rs
@@ -219,12 +219,18 @@ impl JsArrayBufferValue {
 
 impl AsRef<[u8]> for JsArrayBufferValue {
   fn as_ref(&self) -> &[u8] {
+    if self.data.is_null() {
+      return &[];
+    }
     unsafe { slice::from_raw_parts(self.data as *const u8, self.len) }
   }
 }
 
 impl AsMut<[u8]> for JsArrayBufferValue {
   fn as_mut(&mut self) -> &mut [u8] {
+    if self.data.is_null() {
+      return &mut [];
+    }
     unsafe { slice::from_raw_parts_mut(self.data as *mut u8, self.len) }
   }
 }


### PR DESCRIPTION
In Rust 1.78, when debug assertions are enabled, slice::from_raw_parts panics if the provided data is a null pointer. This is possible through JsArrayBufferValue::new() as well as through JsArrayBuffer::into_value, when napi_get_arraybuffer_info returns a null pointer due to a zero length buffer.