### PR TITLE
remove duplicate typedefs in `index.d.ts` from macro re-evaluation

### DIFF
--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -750,7 +750,9 @@ async function processIntermediateTypeFile(
     return idents
   }
 
-  const allDefs = lines.map((line) => JSON.parse(line) as TypeDef)
+  // Deduplicate lines, to account for macros being possibly evaluated more than once:
+  const uniqueLines = [...new Set(lines)]
+  const allDefs = uniqueLines.map((line) => JSON.parse(line) as TypeDef)
 
   function convertDefs(defs: TypeDef[], nested = false): string {
     const classes = new Map<


### PR DESCRIPTION
Type definitions are generated during `cargo build`, and written to a temporary typedefs file. Usually, they are only evaluated once, but they can also be evaluated more times, when modules are loaded through [conditional compilation](https://github.com/napi-rs/napi-rs/issues/1541), by using `#[path]` attributes, or various other code patterns required to get around [existing cargo limitations](https://github.com/rust-lang/cargo/issues/8628).

This causes the temp file to have duplicate entries, which results in an invalid `index.d.ts` generated, with twice the number of types, causing `tsc` to fail with many `TS2300` errors. The issue happens with the latest released `@napi-rs/cli` version `2.18.2`.

This localized fix here deduplicates any entries found in the file, and has no effect when there are none.