### PR TITLE
docs(cli): fix typo

### DIFF
--- a/cli/codegen/commands.ts
+++ b/cli/codegen/commands.ts
@@ -182,7 +182,7 @@ const BUILD_OPTIONS: CommandSchema = {
       name: 'jsBinding',
       type: 'string',
       description:
-        'Path and filename of generated JS binding file. Only works with `--platform` flag. Relative to `--output_dir`.',
+        'Path and filename of generated JS binding file. Only works with `--platform` flag. Relative to `--output-dir`.',
       long: 'js',
     },
     {
@@ -196,7 +196,7 @@ const BUILD_OPTIONS: CommandSchema = {
       name: 'dts',
       type: 'string',
       description:
-        'Path and filename of generated type def file. Relative to `--output_dir`',
+        'Path and filename of generated type def file. Relative to `--output-dir`',
     },
     {
       name: 'dtsHeader',

--- a/cli/docs/build.md
+++ b/cli/docs/build.md
@@ -35,9 +35,9 @@ new NapiCli().build({
 | platform          | --platform            | boolean  | false    |         | Add platform triple to the generated nodejs binding file, eg: `[name].linux-x64-gnu.node`                                 |
 | jsPackageName     | --js-package-name     | string   | false    |         | Package name in generated js binding file. Only works with `--platform` flag                                              |
 | constEnum         | --const-enum          | boolean  | false    |         | Whether generate const enum for typescript bindings                                                                       |
-| jsBinding         | --js                  | string   | false    |         | Path and filename of generated JS binding file. Only works with `--platform` flag. Relative to `--output_dir`.            |
+| jsBinding         | --js                  | string   | false    |         | Path and filename of generated JS binding file. Only works with `--platform` flag. Relative to `--output-dir`.            |
 | noJsBinding       | --no-js               | boolean  | false    |         | Whether to disable the generation JS binding file. Only works with `--platform` flag.                                     |
-| dts               | --dts                 | string   | false    |         | Path and filename of generated type def file. Relative to `--output_dir`                                                  |
+| dts               | --dts                 | string   | false    |         | Path and filename of generated type def file. Relative to `--output-dir`                                                  |
 | dtsHeader         | --dts-header          | string   | false    |         | Custom file header for generated type def file. Only works when `typedef` feature enabled.                                |
 | noDtsHeader       | --no-dts-header       | boolean  | false    |         | Whether to disable the default file header for generated type def file. Only works when `typedef` feature enabled.        |
 | strip             | --strip,-s            | boolean  | false    |         | Whether strip the library to achieve the minimum file size                                                                |

--- a/cli/src/def/build.ts
+++ b/cli/src/def/build.ts
@@ -57,7 +57,7 @@ export abstract class BaseBuildCommand extends Command {
 
   jsBinding?: string = Option.String('--js', {
     description:
-      'Path and filename of generated JS binding file. Only works with `--platform` flag. Relative to `--output_dir`.',
+      'Path and filename of generated JS binding file. Only works with `--platform` flag. Relative to `--output-dir`.',
   })
 
   noJsBinding?: boolean = Option.Boolean('--no-js', {
@@ -67,7 +67,7 @@ export abstract class BaseBuildCommand extends Command {
 
   dts?: string = Option.String('--dts', {
     description:
-      'Path and filename of generated type def file. Relative to `--output_dir`',
+      'Path and filename of generated type def file. Relative to `--output-dir`',
   })
 
   dtsHeader?: string = Option.String('--dts-header', {
@@ -215,7 +215,7 @@ export interface BuildOptions {
    */
   constEnum?: boolean
   /**
-   * Path and filename of generated JS binding file. Only works with `--platform` flag. Relative to `--output_dir`.
+   * Path and filename of generated JS binding file. Only works with `--platform` flag. Relative to `--output-dir`.
    */
   jsBinding?: string
   /**
@@ -223,7 +223,7 @@ export interface BuildOptions {
    */
   noJsBinding?: boolean
   /**
-   * Path and filename of generated type def file. Relative to `--output_dir`
+   * Path and filename of generated type def file. Relative to `--output-dir`
    */
   dts?: string
   /**


### PR DESCRIPTION
This pull request fixes a minor typo: `--output_dir` → `--output-dir`