### PR TITLE
chore(napi): make Ser and De public

### DIFF
--- a/crates/napi/src/js_values/de.rs
+++ b/crates/napi/src/js_values/de.rs
@@ -9,7 +9,12 @@ use crate::JsBigInt;
 use crate::{type_of, NapiValue, Value, ValueType};
 use crate::{Error, JsBoolean, JsNumber, JsObject, JsString, JsUnknown, Result, Status};
 
-pub(crate) struct De<'env>(pub(crate) &'env Value);
+pub struct De<'env>(pub(crate) &'env Value);
+impl<'env> De<'env> {
+  pub fn new(value: &'env JsObject) -> Self {
+    Self(&value.0)
+  }
+}
 
 #[doc(hidden)]
 impl<'x, 'de, 'env> serde::de::Deserializer<'x> for &'de mut De<'env> {

--- a/crates/napi/src/js_values/mod.rs
+++ b/crates/napi/src/js_values/mod.rs
@@ -46,7 +46,7 @@ pub use buffer::*;
 #[cfg(feature = "napi5")]
 pub use date::*;
 #[cfg(feature = "serde-json")]
-pub(crate) use de::De;
+pub use de::De;
 #[cfg(feature = "napi4")]
 pub use deferred::*;
 pub use either::Either;
@@ -57,7 +57,7 @@ pub use number::JsNumber;
 pub use object::*;
 pub use object_property::*;
 #[cfg(feature = "serde-json")]
-pub(crate) use ser::Ser;
+pub use ser::Ser;
 pub use string::*;
 pub(crate) use tagged_object::TaggedObject;
 pub use undefined::JsUndefined;

--- a/crates/napi/src/js_values/object.rs
+++ b/crates/napi/src/js_values/object.rs
@@ -18,6 +18,11 @@ use crate::Error;
 use crate::Result;
 
 pub struct JsObject(pub(crate) Value);
+impl From<Value> for JsObject {
+  fn from(value: Value) -> Self {
+    Self(value)
+  }
+}
 
 #[cfg(feature = "napi5")]
 pub struct FinalizeContext<T: 'static, Hint: 'static> {

--- a/crates/napi/src/js_values/ser.rs
+++ b/crates/napi/src/js_values/ser.rs
@@ -5,10 +5,10 @@ use serde::{ser, Serialize, Serializer};
 use super::*;
 use crate::{Env, Error, Result};
 
-pub(crate) struct Ser<'env>(pub(crate) &'env Env);
+pub struct Ser<'env>(pub(crate) &'env Env);
 
 impl<'env> Ser<'env> {
-  fn new(env: &'env Env) -> Self {
+  pub fn new(env: &'env Env) -> Self {
     Self(env)
   }
 }


### PR DESCRIPTION
also adds helper functions needed to work with Ser and De

This allows more efficient serialization and deserialization of data

here is an example using both Ser and De for zerocopy messagepack encoding and decoding:
```rust
#[napi]
pub mod messagepack {
  use napi::{bindgen_prelude::Buffer, Env, JsObject};

  #[napi]
  pub fn decode(env: Env, bytes: &[u8]) -> napi::Result<JsObject> {
    let mut de = rmp_serde::Deserializer::new(bytes);
    let ser = napi::Ser::new(&env);
    let value = serde_transcode::transcode(&mut de, ser)?;
    Ok(value.into())
  }

  #[napi]
  pub fn encode(value: JsObject) -> napi::Result<Buffer> {
    let mut de = napi::De::new(&value);
    let mut ser = rmp_serde::Serializer::new(Vec::new());
    serde_transcode::transcode(&mut de, &mut ser)
      .map_err(|e| napi::Error::from_reason(e.to_string()))?;
    let buf = ser.into_inner();
    Ok(buf.into())
  }
}
```