### PR TITLE
feat(error): print anyhow error in debug mode to show trace

### DIFF
--- a/crates/napi/src/error.rs
+++ b/crates/napi/src/error.rs
@@ -124,7 +124,7 @@ impl From<JsUnknown> for Error {
 #[cfg(feature = "anyhow")]
 impl From<anyhow::Error> for Error {
   fn from(value: anyhow::Error) -> Self {
-    Error::new(Status::GenericFailure, format!("{}", value))
+    Error::new(Status::GenericFailure, format!("{:?}", value))
   }
 }
 


### PR DESCRIPTION
When printed in display mode it just shows last error on the error stack but if printed in debug mode it shows the error like so:

```
failed something:
     caused by failed other thing
    caused by failed another thing...
```