### PR TITLE
Reduce monomorphization load of various functions

### DIFF
--- a/crates/napi/src/threadsafe_function.rs
+++ b/crates/napi/src/threadsafe_function.rs
@@ -706,6 +706,10 @@ unsafe extern "C" fn call_js_cb<
       )
     },
   };
+  handle_call_js_cb_status(status, raw_env)
+}
+
+fn handle_call_js_cb_status(status: sys::napi_status, raw_env: sys::napi_env) {
   if status == sys::Status::napi_ok {
     return;
   }


### PR DESCRIPTION
Outside of the stdlib and `tokio`, these functions were the highest-up in [`cargo-llvm-lines`](https://crates.io/crates/cargo-llvm-lines) in our project that uses `napi-rs` extensively. These changes aim to reduce the amount of generated code (and hopefully also improve compile times because of it).

Before:
```plain
    LLVM Lines             Instantiations     Function name
    70967 (2.4%, 11.5%)    286 (0.3%,  8.5%)  napi::bindgen_runtime::js_values::object::<impl napi::js_values::object::JsObject>::set
    51856 (1.7%, 19.3%)    164 (0.2%, 10.9%)  napi::bindgen_runtime::js_values::object::<impl napi::js_values::object::JsObject>::get
    26928 (0.9%, 33.4%)    132 (0.1%, 18.8%)  napi::js_values::deferred::JsDeferred<Data,Resolver>::new
    25549 (0.9%, 34.3%)     32 (0.0%, 18.8%)  napi::threadsafe_function::call_js_cb
```

After:
```plain
    LLVM Lines             Instantiations     Function name
    17771 (0.6%, 41.5%)    286 (0.3%, 33.5%)  napi::bindgen_runtime::js_values::object::<impl napi::js_values::object::JsObject>::set
    18020 (0.6%, 40.9%)    164 (0.2%, 33.2%)  napi::bindgen_runtime::js_values::object::<impl napi::js_values::object::JsObject>::get
     8580 (0.3%, 49.9%)    132 (0.1%, 41.3%)  napi::js_values::deferred::JsDeferred<Data,Resolver>::new
    11277 (0.4%, 47.9%)     32 (0.0%, 39.5%)  napi::threadsafe_function::call_js_cb
```

After these changes, outside of `napi::tokio_runtime::execute_tokio_future::{{closure}}` there is no napi anymore in the top ~40 functions with the most lines generated.

Binary size savings in our project (release, fully-optimized build):

- `JsObject::{get, set}`: 200 KiB
- `JsDeferred::new`: 60 KiB
- `call_js_cb`: 140 KiB (though with the new `Return` generic I wasn't able to outline as much in the 3.x version, so this might be lower now)

In total, it saved ~120K LLVM lines.

Note that these changes were first done on napi 2.6, but I've ported them over to main. All size measurements were done on the 2.6 version, but other than a slightly less effective change on `call_js_cb` this should be just as good on 3.x.