### PR TITLE
DRAFT: "async_local" feature for local-thread Rust futures

### DIFF
--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -17,6 +17,7 @@ all-features = true
 independent = true
 
 [features]
+async_local = ["dep:futures", "dep:libuv"]
 async = ["tokio_rt"]
 compat-mode = []
 default = ["napi3", "compat-mode"]                                               # for most Node.js users
@@ -87,3 +88,14 @@ version = "1"
 [dependencies.serde_json]
 optional = true
 version = "1"
+
+[dependencies.futures]
+version = "0.3"
+optional = true
+
+# TEMP internalize libuv bindings
+[dependencies.libuv]
+package = "alsh_libuv"
+version = "2"
+features = ["sys"]
+optional = true

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -17,7 +17,7 @@ all-features = true
 independent = true
 
 [features]
-async_local = ["dep:futures", "dep:libuv"]
+async_local = ["dep:futures"]
 async = ["tokio_rt"]
 compat-mode = []
 default = ["napi3", "compat-mode"]                                               # for most Node.js users
@@ -91,11 +91,4 @@ version = "1"
 
 [dependencies.futures]
 version = "0.3"
-optional = true
-
-# TEMP internalize libuv bindings
-[dependencies.libuv]
-package = "alsh_libuv"
-version = "2"
-features = ["sys"]
 optional = true

--- a/crates/napi/src/async_local/executor/enter.rs
+++ b/crates/napi/src/async_local/executor/enter.rs
@@ -1,0 +1,53 @@
+use std::cell::Cell;
+use std::fmt;
+
+std::thread_local!(static ENTERED: Cell<bool> = Cell::new(false));
+
+pub struct Enter {
+  _priv: (),
+}
+
+pub struct EnterError {
+  _priv: (),
+}
+
+impl fmt::Debug for EnterError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct("EnterError").finish()
+  }
+}
+
+impl fmt::Display for EnterError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "an execution scope has already been entered")
+  }
+}
+
+impl std::error::Error for EnterError {}
+
+pub fn enter() -> Result<Enter, EnterError> {
+  ENTERED.with(|c| {
+    if c.get() {
+      Err(EnterError { _priv: () })
+    } else {
+      c.set(true);
+
+      Ok(Enter { _priv: () })
+    }
+  })
+}
+
+impl fmt::Debug for Enter {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct("Enter").finish()
+  }
+}
+
+impl Drop for Enter {
+  fn drop(&mut self) {
+    ENTERED.with(|c| {
+      assert!(c.get());
+      c.set(false);
+    });
+  }
+}

--- a/crates/napi/src/async_local/executor/local_pool.rs
+++ b/crates/napi/src/async_local/executor/local_pool.rs
@@ -1,0 +1,228 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::rc::Weak;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::thread;
+use std::thread::Thread;
+use std::vec::Vec;
+
+use futures::stream::FuturesUnordered;
+use futures::stream::StreamExt;
+use futures::task::waker_ref;
+use futures::task::ArcWake;
+use futures::task::Context;
+use futures::task::FutureObj;
+use futures::task::LocalFutureObj;
+use futures::task::LocalSpawn;
+use futures::task::Poll;
+use futures::task::Spawn;
+use futures::task::SpawnError;
+
+use super::enter::enter;
+
+#[derive(Debug)]
+pub struct LocalPool {
+  pool: FuturesUnordered<LocalFutureObj<'static, ()>>,
+  incoming: Rc<Incoming>,
+}
+
+#[derive(Clone, Debug)]
+pub struct LocalSpawner {
+  incoming: Weak<Incoming>,
+}
+
+type Incoming = RefCell<Vec<LocalFutureObj<'static, ()>>>;
+
+#[derive(Debug)]
+pub(crate) struct ThreadNotify {
+  pub(crate) thread: Thread,
+  pub(crate) unparked: AtomicBool,
+}
+
+impl ThreadNotify {
+  pub fn new() -> Arc<Self> {
+    Arc::new(ThreadNotify {
+      thread: thread::current(),
+      unparked: AtomicBool::new(false),
+    })
+  }
+}
+
+impl ArcWake for ThreadNotify {
+  fn wake_by_ref(arc_self: &Arc<Self>) {
+    let unparked = arc_self.unparked.swap(true, Ordering::Release);
+    if !unparked {
+      arc_self.thread.unpark();
+    }
+  }
+}
+
+pub fn wait_for_wake(thread_notify: &ThreadNotify) {
+  while !thread_notify.unparked.swap(false, Ordering::Acquire) {
+    std::thread::park();
+  }
+}
+
+fn woken(thread_notify: &ThreadNotify) -> bool {
+  thread_notify.unparked.load(Ordering::Acquire)
+}
+
+fn run_executor<T, F: FnMut(&mut Context<'_>) -> Poll<T>>(
+  thread_notify: Arc<ThreadNotify>,
+  mut f: F,
+) -> T {
+  let _enter = enter().expect(
+    "cannot execute `LocalPool` executor from within \
+         another executor",
+  );
+
+  let waker = waker_ref(&thread_notify);
+  let mut cx = Context::from_waker(&waker);
+
+  loop {
+    if let Poll::Ready(t) = f(&mut cx) {
+      return t;
+    }
+
+    // Wait for a wakeup.
+    while !thread_notify.unparked.swap(false, Ordering::Acquire) {
+      // No wakeup occurred. It may occur now, right before parking,
+      // but in that case the token made available by `unpark()`
+      // is guaranteed to still be available and `park()` is a no-op.
+      thread::park();
+    }
+  }
+}
+
+impl LocalPool {
+  pub fn new() -> Self {
+    Self {
+      pool: FuturesUnordered::new(),
+      incoming: Default::default(),
+    }
+  }
+
+  pub fn spawner(&self) -> LocalSpawner {
+    LocalSpawner {
+      incoming: Rc::downgrade(&self.incoming),
+    }
+  }
+
+  // Note: Can be used to interleave futures with the JS event loop
+  /// Runs all tasks and returns after completing one future or until no more progress
+  /// can be made. Returns `true` if one future was completed, `false` otherwise.
+  #[allow(unused)]
+  pub fn try_run_one(&mut self, thread_notify: Arc<ThreadNotify>) -> bool {
+    run_executor(thread_notify.clone(), |cx| {
+      loop {
+        self.drain_incoming();
+
+        match self.pool.poll_next_unpin(cx) {
+          // Success!
+          Poll::Ready(Some(())) => return Poll::Ready(true),
+          // The pool was empty.
+          Poll::Ready(None) => return Poll::Ready(false),
+          Poll::Pending => (),
+        }
+
+        if !self.incoming.borrow().is_empty() {
+          // New tasks were spawned; try again.
+          continue;
+        } else if woken(&thread_notify) {
+          // The pool yielded to us, but there's more progress to be made.
+          return Poll::Pending;
+        } else {
+          return Poll::Ready(false);
+        }
+      }
+    })
+  }
+
+  /// Runs all tasks in the pool and returns if no more progress can be made on any task.
+  #[allow(unused)]
+  pub fn run_until_stalled(&mut self, thread_notify: Arc<ThreadNotify>) {
+    run_executor(thread_notify.clone(), |cx| match self.poll_pool(cx) {
+      // The pool is empty.
+      Poll::Ready(()) => Poll::Ready(()),
+      Poll::Pending => {
+        if woken(&thread_notify) {
+          Poll::Pending
+        } else {
+          // We're stalled for now.
+          Poll::Ready(())
+        }
+      }
+    });
+  }
+
+  fn poll_pool(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+    loop {
+      self.drain_incoming();
+      let pool_ret = self.pool.poll_next_unpin(cx);
+
+      // We queued up some new tasks; add them and poll again.
+      if !self.incoming.borrow().is_empty() {
+        continue;
+      }
+
+      match pool_ret {
+        Poll::Ready(Some(())) => continue,
+        Poll::Ready(None) => return Poll::Ready(()),
+        Poll::Pending => return Poll::Pending,
+      }
+    }
+  }
+
+  fn drain_incoming(&mut self) {
+    let mut incoming = self.incoming.borrow_mut();
+    for task in incoming.drain(..) {
+      self.pool.push(task)
+    }
+  }
+}
+
+impl Default for LocalPool {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl Spawn for LocalSpawner {
+  fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
+    if let Some(incoming) = self.incoming.upgrade() {
+      incoming.borrow_mut().push(future.into());
+      Ok(())
+    } else {
+      Err(SpawnError::shutdown())
+    }
+  }
+
+  fn status(&self) -> Result<(), SpawnError> {
+    if self.incoming.upgrade().is_some() {
+      Ok(())
+    } else {
+      Err(SpawnError::shutdown())
+    }
+  }
+}
+
+impl LocalSpawn for LocalSpawner {
+  fn spawn_local_obj(&self, future: LocalFutureObj<'static, ()>) -> Result<(), SpawnError> {
+    if let Some(incoming) = self.incoming.upgrade() {
+      incoming.borrow_mut().push(future);
+      Ok(())
+    } else {
+      Err(SpawnError::shutdown())
+    }
+  }
+
+  fn status_local(&self) -> Result<(), SpawnError> {
+    if self.incoming.upgrade().is_some() {
+      Ok(())
+    } else {
+      Err(SpawnError::shutdown())
+    }
+  }
+}

--- a/crates/napi/src/async_local/executor/mod.rs
+++ b/crates/napi/src/async_local/executor/mod.rs
@@ -1,0 +1,4 @@
+mod enter;
+mod local_pool;
+
+pub use self::local_pool::*;

--- a/crates/napi/src/async_local/mod.rs
+++ b/crates/napi/src/async_local/mod.rs
@@ -1,4 +1,3 @@
-//! This module extends Libuv to work as an executor for Rust futures
 mod executor;
 mod runtime;
 

--- a/crates/napi/src/async_local/mod.rs
+++ b/crates/napi/src/async_local/mod.rs
@@ -1,0 +1,5 @@
+//! This module extends Libuv to work as an executor for Rust futures
+mod executor;
+mod runtime;
+
+pub use runtime::*;

--- a/crates/napi/src/async_local/runtime.rs
+++ b/crates/napi/src/async_local/runtime.rs
@@ -10,23 +10,25 @@ use super::executor::LocalPool;
 use super::executor::LocalSpawner;
 use super::executor::ThreadNotify;
 use futures::task::LocalSpawnExt;
-use libuv::sys::uv_loop_t;
-use libuv::AsyncHandle;
-use libuv::HandleTrait;
-use libuv::Loop;
 use once_cell::unsync::Lazy;
 
+use crate::threadsafe_function::ThreadSafeCallContext;
+use crate::threadsafe_function::ThreadsafeFunction;
+use crate::threadsafe_function::ThreadsafeFunctionCallMode;
 use crate::Env;
+use crate::JsUnknown;
+
+type ExecuterOptions = Arc<ThreadNotify>;
 
 enum WakerEvent {
-  GetThreadNotify(Sender<Arc<ThreadNotify>>),
-  Handle(AsyncHandle),
+  Context(ThreadsafeFunction<ExecuterOptions>),
   Next,
+  Done,
 }
 
 thread_local! {
   static LOCAL_POOL: Lazy<RefCell<LocalPool>> = Lazy::new(|| RefCell::new(LocalPool::new()));
-  static SPAWNER: Lazy<LocalSpawner> = Lazy::new(|| LOCAL_POOL.with(|ex| ex.borrow().spawner()) );
+  static SPAWNER: Lazy<LocalSpawner> = Lazy::new(|| LOCAL_POOL.with(|ex| ex.borrow().spawner()));
   static TASK_COUNT: Lazy<RefCell<usize>> = Lazy::new(|| Default::default() );
   static WAKER_THREAD: Lazy<Sender<WakerEvent>> = Lazy::new(|| {
     let (tx, rx) = channel();
@@ -34,20 +36,20 @@ thread_local! {
     // Dedicated waker thread to use for waiting on pending futures
     thread::spawn(move || {
       let thread_notify = ThreadNotify::new();
-      let mut handle = None::<AsyncHandle>;
+      let mut handle = None::<ThreadsafeFunction<ExecuterOptions>>;
 
       while let Ok(event) = rx.recv() {
         match event {
-          WakerEvent::GetThreadNotify(tx) => {
-            tx.send(thread_notify.clone()).unwrap();
-          }
-          WakerEvent::Handle(mut incoming) => {
-            incoming.send().unwrap();
+          WakerEvent::Context(incoming) => {
             handle.replace(incoming);
+            handle.as_ref().unwrap().call(Ok(thread_notify.clone()), ThreadsafeFunctionCallMode::Blocking);
           },
+          WakerEvent::Done => {
+            drop(handle.take());
+          }
           WakerEvent::Next => {
             wait_for_wake(&thread_notify);
-            handle.unwrap().send().unwrap();
+            handle.as_ref().unwrap().call(Ok(thread_notify.clone()), ThreadsafeFunctionCallMode::Blocking);
           },
         };
       }
@@ -57,61 +59,39 @@ thread_local! {
   });
 }
 
-pub fn spawn_async_local(env: &Env, future: impl Future + 'static) {
+pub fn spawn_async_local(env: &Env, future: impl Future + 'static) -> crate::Result<()> {
   SPAWNER.with(move |ls| {
     ls.spawn_local(async move {
       future.await;
       task_count_dec();
     })
-    .unwrap()
+    .unwrap();
   });
 
-  run_executor_if_not_running(env);
-}
-
-fn run_executor_if_not_running(env: &Env) {
   // Start the digest which will do a non-blocking poll of
   // all the futures in the pool
   if task_count_inc() != 0 {
-    return;
+    return Ok(());
   }
 
-  // Get access to the thread waker
-  let tx_waker_thread = WAKER_THREAD.with(|tx| (*tx).clone());
-  let thread_notify = {
-    let (tx, rx) = channel();
-    tx_waker_thread
-      .send(WakerEvent::GetThreadNotify(tx))
-      .unwrap();
-    rx.recv().unwrap()
-  };
+  let jsfn = env.create_function_from_closure("", |_ctx| Ok(Vec::<JsUnknown>::new()))?;
 
-  // Start an async handle that will be invoked by the waker thread
-  let handle = get_lib_uv(&env)
-    .r#async({
-      let tx_waker_thread = tx_waker_thread.clone();
-
-      move |mut handle: AsyncHandle| {
-        let thread_notify = thread_notify.clone();
-        LOCAL_POOL.with(move |lp| lp.borrow_mut().run_until_stalled(thread_notify));
-
-        if task_count() == 0 {
-          handle.close(|_| {});
-          return;
-        } else {
-          tx_waker_thread.send(WakerEvent::Next).unwrap();
-        }
+  let tsfn: ThreadsafeFunction<ExecuterOptions> = env.create_threadsafe_function(&jsfn, 0, {
+    move |ctx: ThreadSafeCallContext<ExecuterOptions>| {
+      let thread_notify = ctx.value;
+      LOCAL_POOL.with(move |lp| lp.borrow_mut().run_until_stalled(thread_notify));
+      if task_count() == 0 {
+        next_tx().send(WakerEvent::Done).unwrap();
+      } else {
+        next_tx().send(WakerEvent::Next).unwrap();
       }
-    })
-    .unwrap();
+      Ok(Vec::<JsUnknown>::new())
+    }
+  })?;
 
   // Give the waker thread the async handle
-  tx_waker_thread.send(WakerEvent::Handle(handle)).unwrap();
-}
-
-fn get_lib_uv(env: &Env) -> Loop {
-  let uv = env.get_uv_event_loop().unwrap();
-  unsafe { libuv::r#loop::Loop::from_external(uv as *mut uv_loop_t) }
+  next_tx().send(WakerEvent::Context(tsfn)).unwrap();
+  Ok(())
 }
 
 fn task_count() -> usize {
@@ -128,4 +108,8 @@ fn task_count_dec() -> usize {
   let current = task_count();
   TASK_COUNT.with(|c| *c.borrow_mut() -= 1);
   current
+}
+
+fn next_tx() -> Sender<WakerEvent> {
+  WAKER_THREAD.with(|tx| (*tx).clone())
 }

--- a/crates/napi/src/async_local/runtime.rs
+++ b/crates/napi/src/async_local/runtime.rs
@@ -1,0 +1,131 @@
+use std::cell::RefCell;
+use std::future::Future;
+use std::sync::mpsc::channel;
+use std::sync::mpsc::Sender;
+use std::sync::Arc;
+use std::thread;
+
+use super::executor::wait_for_wake;
+use super::executor::LocalPool;
+use super::executor::LocalSpawner;
+use super::executor::ThreadNotify;
+use futures::task::LocalSpawnExt;
+use libuv::sys::uv_loop_t;
+use libuv::AsyncHandle;
+use libuv::HandleTrait;
+use libuv::Loop;
+use once_cell::unsync::Lazy;
+
+use crate::Env;
+
+enum WakerEvent {
+  GetThreadNotify(Sender<Arc<ThreadNotify>>),
+  Handle(AsyncHandle),
+  Next,
+}
+
+thread_local! {
+  static LOCAL_POOL: Lazy<RefCell<LocalPool>> = Lazy::new(|| RefCell::new(LocalPool::new()));
+  static SPAWNER: Lazy<LocalSpawner> = Lazy::new(|| LOCAL_POOL.with(|ex| ex.borrow().spawner()) );
+  static TASK_COUNT: Lazy<RefCell<usize>> = Lazy::new(|| Default::default() );
+  static WAKER_THREAD: Lazy<Sender<WakerEvent>> = Lazy::new(|| {
+    let (tx, rx) = channel();
+
+    // Dedicated waker thread to use for waiting on pending futures
+    thread::spawn(move || {
+      let thread_notify = ThreadNotify::new();
+      let mut handle = None::<AsyncHandle>;
+
+      while let Ok(event) = rx.recv() {
+        match event {
+          WakerEvent::GetThreadNotify(tx) => {
+            tx.send(thread_notify.clone()).unwrap();
+          }
+          WakerEvent::Handle(mut incoming) => {
+            incoming.send().unwrap();
+            handle.replace(incoming);
+          },
+          WakerEvent::Next => {
+            wait_for_wake(&thread_notify);
+            handle.unwrap().send().unwrap();
+          },
+        };
+      }
+    });
+
+    tx
+  });
+}
+
+pub fn spawn_async_local(env: &Env, future: impl Future + 'static) {
+  SPAWNER.with(move |ls| {
+    ls.spawn_local(async move {
+      future.await;
+      task_count_dec();
+    })
+    .unwrap()
+  });
+
+  run_executor_if_not_running(env);
+}
+
+fn run_executor_if_not_running(env: &Env) {
+  // Start the digest which will do a non-blocking poll of
+  // all the futures in the pool
+  if task_count_inc() != 0 {
+    return;
+  }
+
+  // Get access to the thread waker
+  let tx_waker_thread = WAKER_THREAD.with(|tx| (*tx).clone());
+  let thread_notify = {
+    let (tx, rx) = channel();
+    tx_waker_thread
+      .send(WakerEvent::GetThreadNotify(tx))
+      .unwrap();
+    rx.recv().unwrap()
+  };
+
+  // Start an async handle that will be invoked by the waker thread
+  let handle = get_lib_uv(&env)
+    .r#async({
+      let tx_waker_thread = tx_waker_thread.clone();
+
+      move |mut handle: AsyncHandle| {
+        let thread_notify = thread_notify.clone();
+        LOCAL_POOL.with(move |lp| lp.borrow_mut().run_until_stalled(thread_notify));
+
+        if task_count() == 0 {
+          handle.close(|_| {});
+          return;
+        } else {
+          tx_waker_thread.send(WakerEvent::Next).unwrap();
+        }
+      }
+    })
+    .unwrap();
+
+  // Give the waker thread the async handle
+  tx_waker_thread.send(WakerEvent::Handle(handle)).unwrap();
+}
+
+fn get_lib_uv(env: &Env) -> Loop {
+  let uv = env.get_uv_event_loop().unwrap();
+  unsafe { libuv::r#loop::Loop::from_external(uv as *mut uv_loop_t) }
+}
+
+fn task_count() -> usize {
+  TASK_COUNT.with(|c| *c.borrow_mut())
+}
+
+fn task_count_inc() -> usize {
+  let current = task_count();
+  TASK_COUNT.with(|c| *c.borrow_mut() += 1);
+  current
+}
+
+fn task_count_dec() -> usize {
+  let current = task_count();
+  TASK_COUNT.with(|c| *c.borrow_mut() -= 1);
+  current
+}

--- a/crates/napi/src/env.rs
+++ b/crates/napi/src/env.rs
@@ -1072,7 +1072,7 @@ impl Env {
   }
 
   #[cfg(all(feature = "async_local", feature = "napi2"))]
-  pub fn spawn_local<F, Fut>(&self, fut: F) -> ()
+  pub fn spawn_local<F, Fut>(&self, fut: F) -> Result<()>
   where
     Fut: std::future::Future + 'static,
     F: FnOnce(Env) -> Fut + 'static,
@@ -1083,13 +1083,13 @@ impl Env {
       let env_raw = env_raw;
       let env = unsafe { Env::from_raw(env_raw) };
 
-      let mut handle_scope = ptr::null_mut();
-      check_status!(unsafe { sys::napi_open_handle_scope(env_raw, &mut handle_scope) }).unwrap();
+      // let mut handle_scope = ptr::null_mut();
+      // check_status!(unsafe { sys::napi_open_handle_scope(env_raw, &mut handle_scope) }).unwrap();
 
       fut(env).await;
 
-      check_status!(unsafe { sys::napi_close_handle_scope(env_raw, handle_scope) }).unwrap();
-    });
+      // check_status!(unsafe { sys::napi_close_handle_scope(env_raw, handle_scope) }).unwrap();
+    })
   }
 
   #[cfg(all(feature = "tokio_rt", feature = "napi4"))]

--- a/crates/napi/src/js_rc.rs
+++ b/crates/napi/src/js_rc.rs
@@ -1,0 +1,141 @@
+use once_cell::unsync::{Lazy, OnceCell};
+use std::cell::RefCell;
+use std::ops::Deref;
+use std::rc::Rc;
+
+use super::Value;
+use crate::{sys, Env, JsNumber, JsObject, NapiValue, Result};
+
+thread_local! {
+  /// Basic unique key generation
+  static COUNT: Lazy<RefCell<u32>> = Lazy::new(|| Default::default());
+  static CACHE_KEY: OnceCell<u32> = OnceCell::default();
+}
+
+/// Reference counted JavaScript value with a static lifetime for use in async closures
+pub struct JsRc<T> {
+  pub(crate) raw_env: sys::napi_env,
+  pub(crate) count: Rc<RefCell<u32>>,
+  pub(crate) inner_key: Rc<u32>,
+  pub(crate) inner: T,
+}
+
+#[allow(clippy::non_send_fields_in_send_ty)]
+unsafe impl<T> Send for JsRc<T> {}
+unsafe impl<T> Sync for JsRc<T> {}
+
+impl<T: NapiValue> JsRc<T> {
+  pub(crate) fn new(js_value: Value) -> Result<JsRc<T>> {
+    let env = unsafe { Env::from_raw(js_value.env) };
+    let value = unsafe { T::from_raw(js_value.env, js_value.value) }?;
+    let value_container = unsafe { T::from_raw(js_value.env, js_value.value) }?;
+    let inner_key = set_ref(&env, value_container)?;
+
+    Ok(Self {
+      raw_env: js_value.env,
+      count: Rc::new(RefCell::new(1)),
+      inner_key: Rc::new(inner_key),
+      inner: value,
+    })
+  }
+
+  pub fn clone(&self, env: &Env) -> Result<JsRc<T>> {
+    let mut count = self.count.borrow_mut();
+    *count += 1;
+
+    Ok(Self {
+      raw_env: env.0,
+      count: self.count.clone(),
+      inner_key: self.inner_key.clone(),
+      inner: get_ref(&env, &self.inner_key)?,
+    })
+  }
+}
+
+impl<T> Drop for JsRc<T> {
+  fn drop(&mut self) {
+    let mut count = self.count.borrow_mut();
+    *count -= 1;
+    if *count == 0 {
+      let env = unsafe { Env::from_raw(self.raw_env) };
+      remove_ref(&env, *self.inner_key).unwrap();
+    }
+  }
+}
+
+impl<T: NapiValue> Deref for JsRc<T> {
+  type Target = T;
+
+  fn deref(&self) -> &T {
+    &self.inner
+  }
+}
+
+/*
+  globalThis = {
+    __napi_cache: {
+      __instance_count: number,
+      [key: number]: Record<number, any>
+    }
+  }
+
+  Note: Is there a way to store this privately in the module scope?
+*/
+fn get_cache(env: &Env) -> crate::Result<JsObject> {
+  let mut g = env.get_global()?;
+
+  // Init global cache if it doesn't exist
+  if !g.has_named_property("__napi_cache")? {
+    let mut cache = env.create_object()?;
+    cache.set_named_property("__instance_count", env.create_uint32(0)?)?;
+    g.set_named_property("__napi_cache", cache)?;
+  }
+
+  let mut global_cache = g.get_named_property::<JsObject>("__napi_cache")?;
+
+  // Init module instance cache if it doesn't exist
+  let key = CACHE_KEY.with(|key| {
+    key
+      .get_or_try_init(|| -> crate::Result<u32> {
+        let instance_count = (&global_cache).get_named_property::<JsNumber>("__instance_count")?;
+        let instance_count = instance_count.get_uint32()? + 1;
+
+        (&mut global_cache).set_named_property("__instance_count", instance_count)?;
+        (&mut global_cache)
+          .set_property(env.create_uint32(instance_count)?, env.create_object()?)?;
+
+        Ok(instance_count)
+      })
+      .copied()
+  })?;
+
+  global_cache.get_property(env.create_uint32(key)?)
+}
+
+fn set_ref(env: &Env, value: impl NapiValue) -> crate::Result<u32> {
+  let mut cache = get_cache(env)?;
+
+  let key_raw = COUNT.with(|c| {
+    let mut c = c.borrow_mut();
+    let current = c.clone();
+    *c += 1;
+    current
+  });
+
+  let key = env.create_uint32(key_raw)?;
+  cache.set_property(&key, value)?;
+  Ok(key_raw)
+}
+
+fn get_ref<T: NapiValue>(env: &Env, key: &u32) -> crate::Result<T> {
+  let cache = get_cache(env)?;
+  let key = env.create_uint32(key.clone())?;
+  cache.get_property(key)
+}
+
+fn remove_ref(env: &Env, key: u32) -> crate::Result<()> {
+  let mut cache = get_cache(env)?;
+  let key = env.create_uint32(key)?;
+  cache.delete_property(&key)?;
+  Ok(())
+}

--- a/crates/napi/src/js_values/mod.rs
+++ b/crates/napi/src/js_values/mod.rs
@@ -6,7 +6,7 @@ use std::ptr;
 
 use crate::{
   bindgen_runtime::{FromNapiValue, ToNapiValue, TypeName, ValidateNapiValue},
-  check_status, sys, type_of, Callback, Error, Result, Status, ValueType,
+  check_status, sys, type_of, Callback, Error, JsRc, Result, Status, ValueType,
 };
 
 #[cfg(feature = "serde-json")]
@@ -613,6 +613,16 @@ macro_rules! impl_object_methods {
   };
 }
 
+macro_rules! impl_js_ref_methods {
+  ($js_value:ident) => {
+    impl $js_value {
+      pub fn into_ref(self) -> Result<JsRc<$js_value>> {
+        JsRc::<$js_value>::new(self.0)
+      }
+    }
+  };
+}
+
 pub trait NapiRaw {
   #[allow(clippy::missing_safety_doc)]
   unsafe fn raw(&self) -> sys::napi_value;
@@ -653,6 +663,18 @@ impl_object_methods!(JsTypedArray);
 impl_object_methods!(JsDataView);
 impl_object_methods!(JsGlobal);
 impl_object_methods!(JSON);
+
+impl_js_ref_methods!(JsUnknown);
+impl_js_ref_methods!(JsUndefined);
+impl_js_ref_methods!(JsNull);
+impl_js_ref_methods!(JsBoolean);
+impl_js_ref_methods!(JsTypedArray);
+impl_js_ref_methods!(JsNumber);
+impl_js_ref_methods!(JsString);
+impl_js_ref_methods!(JsObject);
+impl_js_ref_methods!(JsDate);
+impl_js_ref_methods!(JsFunction);
+impl_js_ref_methods!(JsSymbol);
 
 use ValueType::*;
 

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -76,6 +76,8 @@
 
 #[cfg(feature = "napi8")]
 mod async_cleanup_hook;
+#[cfg(all(feature = "async_local", feature = "napi2"))]
+mod async_local;
 #[cfg(feature = "napi8")]
 pub use async_cleanup_hook::AsyncCleanupHook;
 mod async_work;
@@ -95,6 +97,9 @@ mod value_type;
 pub use cleanup_env::CleanupEnvHook;
 #[cfg(feature = "napi4")]
 pub mod threadsafe_function;
+
+pub mod js_rc;
+pub use js_rc::*;
 
 mod version;
 


### PR DESCRIPTION
This PR adds the ability to use the local thread to manage concurrency allowing for faster and more ergonomic syntax

**Changelog**
- `async_local` feature
- adds `env.spawn_local`
- adds `JsRc`

Usage:

```rust
#[napi]
pub fn run_callback(env: Env, callback: JsFunction,
) -> napi::Result<JsUndefined> {
  let callback = callback.into_ref()?;

  env.spawn_local(move |env| async move {
    let callback = callback.clone(&env).unwrap();
    callback.call_without_args(None).unwrap();
  });

  env.get_undefined()
}

```

[For more details see Github RFC here](https://github.com/napi-rs/napi-rs/issues/2152)