### PR TITLE
Non-blocking Rust futures

### DIFF
--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -18,6 +18,7 @@ independent = true
 
 [features]
 async = ["tokio_rt"]
+async_local = ["dep:futures"]
 compat-mode = []
 default = ["napi3", "compat-mode"]                                               # for most Node.js users
 experimental = ["napi-sys/experimental"]
@@ -87,3 +88,7 @@ version = "1"
 [dependencies.serde_json]
 optional = true
 version = "1"
+
+[dependencies.futures]
+version = "0.3"
+optional = true

--- a/crates/napi/src/async_local/executor/enter.rs
+++ b/crates/napi/src/async_local/executor/enter.rs
@@ -1,0 +1,53 @@
+use std::cell::Cell;
+use std::fmt;
+
+std::thread_local!(static ENTERED: Cell<bool> = Cell::new(false));
+
+pub struct Enter {
+  _priv: (),
+}
+
+pub struct EnterError {
+  _priv: (),
+}
+
+impl fmt::Debug for EnterError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct("EnterError").finish()
+  }
+}
+
+impl fmt::Display for EnterError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "an execution scope has already been entered")
+  }
+}
+
+impl std::error::Error for EnterError {}
+
+pub fn enter() -> Result<Enter, EnterError> {
+  ENTERED.with(|c| {
+    if c.get() {
+      Err(EnterError { _priv: () })
+    } else {
+      c.set(true);
+
+      Ok(Enter { _priv: () })
+    }
+  })
+}
+
+impl fmt::Debug for Enter {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct("Enter").finish()
+  }
+}
+
+impl Drop for Enter {
+  fn drop(&mut self) {
+    ENTERED.with(|c| {
+      assert!(c.get());
+      c.set(false);
+    });
+  }
+}

--- a/crates/napi/src/async_local/executor/local_pool.rs
+++ b/crates/napi/src/async_local/executor/local_pool.rs
@@ -1,0 +1,230 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::rc::Weak;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::thread;
+use std::thread::Thread;
+use std::vec::Vec;
+
+use futures::stream::FuturesUnordered;
+use futures::stream::StreamExt;
+use futures::task::waker_ref;
+use futures::task::ArcWake;
+use futures::task::Context;
+use futures::task::FutureObj;
+use futures::task::LocalFutureObj;
+use futures::task::LocalSpawn;
+use futures::task::Poll;
+use futures::task::Spawn;
+use futures::task::SpawnError;
+
+use super::enter::enter;
+
+#[derive(Debug)]
+pub struct LocalPool {
+  pool: FuturesUnordered<LocalFutureObj<'static, ()>>,
+  incoming: Rc<Incoming>,
+}
+
+#[derive(Clone, Debug)]
+pub struct LocalSpawner {
+  incoming: Weak<Incoming>,
+}
+
+type Incoming = RefCell<Vec<LocalFutureObj<'static, ()>>>;
+
+#[derive(Debug)]
+pub(crate) struct ThreadNotify {
+  pub(crate) thread: Thread,
+  pub(crate) unparked: AtomicBool,
+}
+
+pub type ThreadNotifyRef = Arc<ThreadNotify>;
+
+impl ThreadNotify {
+  pub fn new() -> Arc<Self> {
+    Arc::new(ThreadNotify {
+      thread: thread::current(),
+      unparked: AtomicBool::new(false),
+    })
+  }
+}
+
+impl ArcWake for ThreadNotify {
+  fn wake_by_ref(arc_self: &Arc<Self>) {
+    let unparked = arc_self.unparked.swap(true, Ordering::Release);
+    if !unparked {
+      arc_self.thread.unpark();
+    }
+  }
+}
+
+pub fn wait_for_wake(thread_notify: &ThreadNotify) {
+  while !thread_notify.unparked.swap(false, Ordering::Acquire) {
+    std::thread::park();
+  }
+}
+
+fn woken(thread_notify: &ThreadNotify) -> bool {
+  thread_notify.unparked.load(Ordering::Acquire)
+}
+
+fn run_executor<T, F: FnMut(&mut Context<'_>) -> Poll<T>>(
+  thread_notify: Arc<ThreadNotify>,
+  mut f: F,
+) -> T {
+  let _enter = enter().expect(
+    "cannot execute `LocalPool` executor from within \
+         another executor",
+  );
+
+  let waker = waker_ref(&thread_notify);
+  let mut cx = Context::from_waker(&waker);
+
+  loop {
+    if let Poll::Ready(t) = f(&mut cx) {
+      return t;
+    }
+
+    // Wait for a wakeup.
+    while !thread_notify.unparked.swap(false, Ordering::Acquire) {
+      // No wakeup occurred. It may occur now, right before parking,
+      // but in that case the token made available by `unpark()`
+      // is guaranteed to still be available and `park()` is a no-op.
+      thread::park();
+    }
+  }
+}
+
+impl LocalPool {
+  pub fn new() -> Self {
+    Self {
+      pool: FuturesUnordered::new(),
+      incoming: Default::default(),
+    }
+  }
+
+  pub fn spawner(&self) -> LocalSpawner {
+    LocalSpawner {
+      incoming: Rc::downgrade(&self.incoming),
+    }
+  }
+
+  // Note: Can be used to interleave futures with the JS event loop
+  /// Runs all tasks and returns after completing one future or until no more progress
+  /// can be made. Returns `true` if one future was completed, `false` otherwise.
+  #[allow(unused)]
+  pub fn try_run_one(&mut self, thread_notify: Arc<ThreadNotify>) -> bool {
+    run_executor(thread_notify.clone(), |cx| {
+      loop {
+        self.drain_incoming();
+
+        match self.pool.poll_next_unpin(cx) {
+          // Success!
+          Poll::Ready(Some(())) => return Poll::Ready(true),
+          // The pool was empty.
+          Poll::Ready(None) => return Poll::Ready(false),
+          Poll::Pending => (),
+        }
+
+        if !self.incoming.borrow().is_empty() {
+          // New tasks were spawned; try again.
+          continue;
+        } else if woken(&thread_notify) {
+          // The pool yielded to us, but there's more progress to be made.
+          return Poll::Pending;
+        } else {
+          return Poll::Ready(false);
+        }
+      }
+    })
+  }
+
+  /// Runs all tasks in the pool and returns if no more progress can be made on any task.
+  #[allow(unused)]
+  pub fn run_until_stalled(&mut self, thread_notify: Arc<ThreadNotify>) {
+    run_executor(thread_notify.clone(), |cx| match self.poll_pool(cx) {
+      // The pool is empty.
+      Poll::Ready(()) => Poll::Ready(()),
+      Poll::Pending => {
+        if woken(&thread_notify) {
+          Poll::Pending
+        } else {
+          // We're stalled for now.
+          Poll::Ready(())
+        }
+      }
+    });
+  }
+
+  fn poll_pool(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+    loop {
+      self.drain_incoming();
+      let pool_ret = self.pool.poll_next_unpin(cx);
+
+      // We queued up some new tasks; add them and poll again.
+      if !self.incoming.borrow().is_empty() {
+        continue;
+      }
+
+      match pool_ret {
+        Poll::Ready(Some(())) => continue,
+        Poll::Ready(None) => return Poll::Ready(()),
+        Poll::Pending => return Poll::Pending,
+      }
+    }
+  }
+
+  fn drain_incoming(&mut self) {
+    let mut incoming = self.incoming.borrow_mut();
+    for task in incoming.drain(..) {
+      self.pool.push(task)
+    }
+  }
+}
+
+impl Default for LocalPool {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl Spawn for LocalSpawner {
+  fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
+    if let Some(incoming) = self.incoming.upgrade() {
+      incoming.borrow_mut().push(future.into());
+      Ok(())
+    } else {
+      Err(SpawnError::shutdown())
+    }
+  }
+
+  fn status(&self) -> Result<(), SpawnError> {
+    if self.incoming.upgrade().is_some() {
+      Ok(())
+    } else {
+      Err(SpawnError::shutdown())
+    }
+  }
+}
+
+impl LocalSpawn for LocalSpawner {
+  fn spawn_local_obj(&self, future: LocalFutureObj<'static, ()>) -> Result<(), SpawnError> {
+    if let Some(incoming) = self.incoming.upgrade() {
+      incoming.borrow_mut().push(future);
+      Ok(())
+    } else {
+      Err(SpawnError::shutdown())
+    }
+  }
+
+  fn status_local(&self) -> Result<(), SpawnError> {
+    if self.incoming.upgrade().is_some() {
+      Ok(())
+    } else {
+      Err(SpawnError::shutdown())
+    }
+  }
+}

--- a/crates/napi/src/async_local/executor/mod.rs
+++ b/crates/napi/src/async_local/executor/mod.rs
@@ -1,0 +1,4 @@
+mod enter;
+mod local_pool;
+
+pub use self::local_pool::*;

--- a/crates/napi/src/async_local/mod.rs
+++ b/crates/napi/src/async_local/mod.rs
@@ -1,0 +1,63 @@
+mod executor;
+mod runtime;
+mod waker;
+
+use std::future::Future;
+
+use executor::ThreadNotifyRef;
+use waker::LocalWaker;
+use waker::WakerEvent;
+
+use self::runtime::LocalRuntime;
+use crate::Env;
+use crate::JsUnknown;
+
+/// Schedule a future to run asynchronously on the local JavaScript thread.
+/// The future's execution will not block the local thread.
+pub fn spawn_async_local<'a>(
+  env: &Env,
+  future: impl Future<Output = ()> + 'static,
+) -> crate::Result<()> {
+  // Add a future to the future pool to be executed
+  // whenever the Nodejs event loop is free to do so
+  LocalRuntime::queue_future(future);
+
+  // If there are tasks in flight then the executor
+  // is already running and should be reused
+  if LocalRuntime::futures_count() > 1 {
+    return Ok(());
+  }
+
+  // The futures executor runs on the main thread thread but
+  // the waker runs on another thread.
+  //
+  // The main thread executor will run the contained futures
+  // and as soon as they stall (e.g. waiting for a channel, timer, etc),
+  // the executor will immediately yield back to the JavaScript event loop.
+  //
+  // This "parks" the executer, which normally means the thread
+  // is block - however we cannot do that here so instead, there
+  // is a sacrificial "waker" thread who's only job is to sleep/wake and
+  // signal to Nodejs that futures need to be run.
+  //
+  // The waker thread notifies the main thread of pending work by
+  // running the futures executor within a threadsafe function
+  let jsfn = env.create_function_from_closure::<Vec<JsUnknown>, _>("", |_| Ok(vec![]))?;
+
+  LocalWaker::send(WakerEvent::Init(
+    env.create_threadsafe_function::<ThreadNotifyRef, Vec<JsUnknown>, _>(&jsfn, 0, |ctx| {
+      let thread_notify = ctx.value;
+      let done = LocalRuntime::run_until_stalled(thread_notify);
+
+      if done {
+        LocalWaker::send(WakerEvent::Done);
+      } else {
+        LocalWaker::send(WakerEvent::Next);
+      }
+
+      Ok(vec![])
+    })?,
+  ));
+
+  Ok(())
+}

--- a/crates/napi/src/async_local/runtime.rs
+++ b/crates/napi/src/async_local/runtime.rs
@@ -1,0 +1,55 @@
+use std::cell::RefCell;
+use std::future::Future;
+
+use super::executor::LocalPool;
+use super::executor::LocalSpawner;
+use super::executor::ThreadNotifyRef;
+use futures::task::LocalSpawnExt;
+use once_cell::unsync::Lazy;
+
+thread_local! {
+    static LOCAL_POOL: Lazy<RefCell<LocalPool>> = Lazy::default();
+    static SPAWNER: Lazy<LocalSpawner> = Lazy::new(|| LOCAL_POOL.with(|ex| ex.borrow().spawner()));
+    static FUTURES_COUNT: Lazy<RefCell<usize>> = Lazy::default();
+}
+
+pub struct LocalRuntime;
+
+impl LocalRuntime {
+  pub fn futures_count() -> usize {
+    Self::count()
+  }
+
+  pub fn queue_future(future: impl Future<Output = ()> + 'static) {
+    Self::increment();
+    SPAWNER
+      .with(move |ls| {
+        ls.spawn_local(async move {
+          future.await;
+          Self::decrement();
+        })
+      })
+      .expect("Unable to spawn future on local pool");
+  }
+
+  pub fn run_until_stalled(thread_notify: ThreadNotifyRef) -> bool {
+    LOCAL_POOL.with(move |lp| lp.borrow_mut().run_until_stalled(thread_notify));
+    if Self::count() == 0 {
+      true
+    } else {
+      false
+    }
+  }
+
+  fn count() -> usize {
+    FUTURES_COUNT.with(|c| *c.borrow_mut())
+  }
+
+  fn increment() {
+    FUTURES_COUNT.with(|c| *c.borrow_mut() += 1);
+  }
+
+  fn decrement() {
+    FUTURES_COUNT.with(|c| *c.borrow_mut() -= 1);
+  }
+}

--- a/crates/napi/src/async_local/waker.rs
+++ b/crates/napi/src/async_local/waker.rs
@@ -1,0 +1,91 @@
+use std::sync::mpsc::channel;
+use std::sync::mpsc::Sender;
+use std::thread;
+
+use crate::threadsafe_function::ThreadsafeFunction;
+use crate::threadsafe_function::ThreadsafeFunctionCallMode;
+
+use super::executor::wait_for_wake;
+use super::executor::ThreadNotify;
+use super::executor::ThreadNotifyRef;
+use once_cell::unsync::Lazy;
+
+thread_local! {
+    static WAKER_THREAD: Lazy<Sender<WakerEvent>> = Lazy::new(LocalWaker::start_waker_thread);
+}
+
+pub type WakerInit = ThreadsafeFunction<ThreadNotifyRef>;
+
+pub enum WakerEvent {
+  Init(WakerInit),
+  Next,
+  Done,
+}
+
+/// The futures waker that coordinates with the futures executor to notify
+/// the main thread to resume execution of futures.
+///
+/// The waker is implemented as a dedicated system thread which is parked
+/// by the local futures executor. Futures (like channel, timers) will
+/// call the wake() method Futures Waker trait.
+///
+/// This gives it some level of portability - for instance any utilities
+/// from the "async_std" crate will work however most things from Tokio
+/// won't work.
+///
+/// Once woken up, the waker resumes execution of futures on the JavaScript
+/// thread by triggering a napi threadsafe function which executes a callback
+/// that runs on the main JavaScript thread. This callback is used to poll
+/// the futures in the local pool.
+pub struct LocalWaker;
+
+impl LocalWaker {
+  pub fn send(event: WakerEvent) {
+    WAKER_THREAD
+      .with(|tx| tx.send(event))
+      .expect("Unable to communicate with waker");
+  }
+
+  fn start_waker_thread() -> Sender<WakerEvent> {
+    let (tx, rx) = channel();
+
+    thread::spawn(move || {
+      let thread_notify = ThreadNotify::new();
+      let mut handle = None::<WakerInit>;
+
+      while let Ok(event) = rx.recv() {
+        match event {
+          WakerEvent::Init(incoming) => {
+            if handle.replace(incoming).is_some() {
+              panic!("Handle already init");
+            };
+            let Some(ref handle) = handle else {
+              panic!("No handle");
+            };
+            handle.call(
+              Ok(thread_notify.clone()),
+              ThreadsafeFunctionCallMode::Blocking,
+            );
+          }
+          WakerEvent::Next => {
+            wait_for_wake(&thread_notify);
+            let Some(ref handle) = handle else {
+              panic!("No handle");
+            };
+            handle.call(
+              Ok(thread_notify.clone()),
+              ThreadsafeFunctionCallMode::Blocking,
+            );
+          }
+          WakerEvent::Done => {
+            if let Some(handle) = handle.take() {
+              drop(handle);
+            }
+          }
+        };
+      }
+    });
+
+    tx
+  }
+}

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -76,6 +76,8 @@
 
 #[cfg(feature = "napi8")]
 mod async_cleanup_hook;
+#[cfg(feature = "async_local")]
+mod async_local;
 #[cfg(feature = "napi8")]
 pub use async_cleanup_hook::AsyncCleanupHook;
 mod async_work;


### PR DESCRIPTION
This PR introduces a custom Rust futures runtime that runs on the main/local JavaScript thread without blocking the JavaScript event loop. 

This is gated behind the `async_local` feature and enables the use of async channels, timers and other similar patterns that simplify the development experience.

This is done by combining a custom futures executor with a thread-safe napi function.

The runtime supports utilities from any package that uses `std:future` - a recommendation is [async_std](https://github.com/async-rs/async-std).

```rust
#[napi]
pub fn run_callback() -> napi::Result<JsUndefined> {
  // Runs asynchronously on the main thread
  // without blocking the event loop
  env.spawn_local(|env| async move {
    task::sleep(Duration::from_secs(3)).await;
    let message = env.create_string("Hello World!")?;
    console_log(&env, &[message]);
  });

  env.get_undefined()
}
```

[More info](https://github.com/napi-rs/napi-rs/issues/2152)

## Future plans
- Add `env.spawn_local_weak` for unref'ed futures that shouldn't hold the process open
- Need a reference counted handle for JavaScript values that has a static lifetime
- Support for `async fn` with `#[napi(async_local)]` macro



