### PR TITLE
let docs.rs generate all documentation

### DIFF
--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.workspaces]
 independent = true


### PR DESCRIPTION
this additional flag tells docs.rs to use a nightly rustc to generate the documentation. Without this, all-features = true has no effect and I have tested locally that this configuration at least generates docs for all disabled features

there is a way to annotate "this function is only available with crate feature `serde`" but I'd like to first see if this change adds the documentation in general

ref for feature attrs:
- https://github.com/rust-random/rand/issues/986
- https://users.rust-lang.org/t/how-to-document-optional-features-in-api-docs/64577