### PR TITLE
feat(napi): asynchronous functions can return any errors

### DIFF
--- a/crates/backend/src/codegen/fn.rs
+++ b/crates/backend/src/codegen/fn.rs
@@ -103,7 +103,12 @@ impl TryToTokens for NapiFn {
       let call = if self.is_ret_result {
         quote! { #receiver(#(#arg_names),*).await }
       } else {
-        quote! { Ok(#receiver(#(#arg_names),*).await) }
+        let ret_type = if let Some(t) = &self.ret {
+          quote! { #t }
+        } else {
+          quote! { () }
+        };
+        quote! { Ok(#receiver(#(#arg_names),*).await) as napi::bindgen_prelude::Result<#ret_type> }
       };
       quote! {
         napi::bindgen_prelude::execute_tokio_future(env, async move { #call }, move |env, #receiver_ret_name| {

--- a/crates/napi/src/tokio_runtime.rs
+++ b/crates/napi/src/tokio_runtime.rs
@@ -150,9 +150,8 @@ impl<Data: 'static + Send, R: 'static + FnOnce(sys::napi_env, Data) -> Result<sy
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn execute_tokio_future<
   Data: 'static + Send,
-  Fut: 'static + Send + Future<Output = std::result::Result<Data, E>>,
+  Fut: 'static + Send + Future<Output = std::result::Result<Data, impl Into<Error>>>,
   Resolver: 'static + FnOnce(sys::napi_env, Data) -> Result<sys::napi_value>,
-  E: Into<Error>,
 >(
   env: sys::napi_env,
   fut: Fut,

--- a/crates/napi/src/tokio_runtime.rs
+++ b/crates/napi/src/tokio_runtime.rs
@@ -150,8 +150,9 @@ impl<Data: 'static + Send, R: 'static + FnOnce(sys::napi_env, Data) -> Result<sy
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn execute_tokio_future<
   Data: 'static + Send,
-  Fut: 'static + Send + Future<Output = Result<Data>>,
+  Fut: 'static + Send + Future<Output = std::result::Result<Data, E>>,
   Resolver: 'static + FnOnce(sys::napi_env, Data) -> Result<sys::napi_value>,
+  E: Into<Error>,
 >(
   env: sys::napi_env,
   fut: Fut,
@@ -169,7 +170,7 @@ pub fn execute_tokio_future<
           .resolve(env.raw(), v)
           .map(|v| unsafe { JsUnknown::from_raw_unchecked(env.raw(), v) })
       }),
-      Err(e) => deferred.reject(e),
+      Err(e) => deferred.reject(e.into()),
     }
   };
 


### PR DESCRIPTION
Related PR:  https://github.com/napi-rs/napi-rs/pull/1583/files#diff-9da4940f977dd3497a86317635b08bdc76e6586f94bc284a9b18212649a2d543R89

Before, we weren't able to use `anyhow::Result` as the return value in asynchronous functions.
```rs
#[napi]
pub async fn test() -> napi::anyhow::Result<()> {
    Ok(())
}
```

<img width="995" alt="image" src="https://github.com/napi-rs/napi-rs/assets/32590310/b18cbfbc-4078-41e7-aa36-5bda17426fa8">

This pr will make error handling a lot easier for us.