### PR TITLE
fix(cli): wasi load in woker_threads

### DIFF
--- a/cli/src/api/templates/load-wasi-template.ts
+++ b/cli/src/api/templates/load-wasi-template.ts
@@ -97,7 +97,7 @@ export const createWasiBinding = (
 const __nodeFs = require('node:fs')
 const __nodePath = require('node:path')
 const { WASI: __nodeWASI } = require('node:wasi')
-const { Worker } = require('node:worker_threads')
+const { Worker, isMainThread } = require('node:worker_threads')
 
 const {
   instantiateNapiModuleSync: __emnapiInstantiateNapiModuleSync,
@@ -116,6 +116,10 @@ const __wasi = new __nodeWASI({
 })
 
 const __emnapiContext = __emnapiGetDefaultContext()
+
+if (!isMainThread) {
+  __emnapiContext.increaseWaitingRequestCounter()
+}
 
 const __sharedMemory = new WebAssembly.Memory({
   initial: ${initialMemory},

--- a/cli/src/api/templates/wasi-worker-template.ts
+++ b/cli/src/api/templates/wasi-worker-template.ts
@@ -51,7 +51,7 @@ const handler = new MessageHandler({
           ...importObject.env,
           ...importObject.napi,
           ...importObject.emnapi,
-          memory: wasmMemory
+          memory: wasmMemory,
         };
       },
     });


### PR DESCRIPTION
Prevent the process.on('beforeExit') hook being called while NAPI-RS
wasi pacakge is loaded in worker_threads