### PR TITLE
fix(napi-derive): call flush on the BufWriter

### DIFF
--- a/crates/macro/src/expand/napi.rs
+++ b/crates/macro/src/expand/napi.rs
@@ -149,7 +149,8 @@ fn output_type_def(napi: &Napi) {
         .and_then(|file| {
           let mut writer = BufWriter::<fs::File>::new(file);
           writer.write_all(type_def.to_string().as_bytes())?;
-          writer.write_all("\n".as_bytes())
+          writer.write_all("\n".as_bytes())?;
+          writer.flush()
         })
         .unwrap_or_else(|e| {
           println!("Failed to write type def file: {:?}", e);


### PR DESCRIPTION
This is mandated by the Rust doc of the BufWriter. We've also seen bugs where the data doesn't seem to be flushed properly, and thus the CLI fails to parse JSONs emitted by napi-derive. This might be it, or not, but flushing shouldn't hurt.

@Brooooooklyn could this be added on napi2 too please? 🙏 