### PR TITLE
chore: implement serde::Serialize for Either

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/either.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/either.rs
@@ -150,6 +150,18 @@ macro_rules! either_n {
         }
       }
     }
+
+    #[cfg(feature = "serde-json")]
+    impl< $( $parameter: serde::Serialize ),+ > serde::Serialize for $either_name< $( $parameter ),+ > {
+      fn serialize<Ser>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error>
+      where
+        Ser: serde::Serializer
+      {
+        match &self {
+          $( Self:: $parameter (v) => serializer.serialize_some(v) ),+
+        }
+      }
+    }
   };
 }
 


### PR DESCRIPTION
This adds an implementation of serde::Serialize for all the Either types. Long term, we might want to use the either crate, but for now this makes this implementation usable with serde.

If this sgty @Brooooooklyn - can it be added to napi2? :)