### PR TITLE
fix(napi,napi-derive): ffi lifetime and pointer sound issues

### DIFF
--- a/crates/backend/src/codegen/struct.rs
+++ b/crates/backend/src/codegen/struct.rs
@@ -281,7 +281,10 @@ impl NapiStruct {
           val: #name
         ) -> napi::Result<napi::bindgen_prelude::sys::napi_value> {
           if let Some(ctor_ref) = napi::__private::get_class_constructor(#js_name_str) {
-            let wrapped_value = Box::into_raw(Box::new(val));
+            let mut wrapped_value = Box::into_raw(Box::new(val));
+            if wrapped_value as usize == 0x1 {
+              wrapped_value = Box::into_raw(Box::new(0u8)).cast();
+            }
             let instance_value = #name::new_instance(env, wrapped_value.cast(), ctor_ref)?;
             #iterator_implementation
             Ok(instance_value)
@@ -299,7 +302,10 @@ impl NapiStruct {
         pub fn into_reference(val: #name, env: napi::Env) -> napi::Result<napi::bindgen_prelude::Reference<#name>> {
           if let Some(ctor_ref) = napi::bindgen_prelude::get_class_constructor(#js_name_str) {
             unsafe {
-              let wrapped_value = Box::into_raw(Box::new(val));
+              let mut wrapped_value = Box::into_raw(Box::new(val));
+              if wrapped_value as usize == 0x1 {
+                wrapped_value = Box::into_raw(Box::new(0u8)).cast();
+              }
               let instance_value = #name::new_instance(env.raw(), wrapped_value.cast(), ctor_ref)?;
               {
                 let env = env.raw();

--- a/crates/napi/src/env.rs
+++ b/crates/napi/src/env.rs
@@ -680,7 +680,7 @@ impl Env {
     check_status!(unsafe {
       sys::napi_throw_error(
         self.0,
-        code.map(|s| s.as_ptr()).unwrap_or(ptr::null_mut()),
+        code.as_ref().map(|s| s.as_ptr()).unwrap_or(ptr::null_mut()),
         msg.as_ptr(),
       )
     })
@@ -693,7 +693,7 @@ impl Env {
     check_status!(unsafe {
       sys::napi_throw_range_error(
         self.0,
-        code.map(|s| s.as_ptr()).unwrap_or(ptr::null_mut()),
+        code.as_ref().map(|s| s.as_ptr()).unwrap_or(ptr::null_mut()),
         msg.as_ptr(),
       )
     })
@@ -706,7 +706,7 @@ impl Env {
     check_status!(unsafe {
       sys::napi_throw_type_error(
         self.0,
-        code.map(|s| s.as_ptr()).unwrap_or(ptr::null_mut()),
+        code.as_ref().map(|s| s.as_ptr()).unwrap_or(ptr::null_mut()),
         msg.as_ptr(),
       )
     })


### PR DESCRIPTION
1、The following code will make an error, the Box::into_raw(empty struct) will return `0x1`
```
#[napi]
pub struct ZeroStruct;

#[napi]
impl ZeroStruct {
  #[napi(constructor)]
  pub fn new() -> Self {
    ZeroStruct
  }
}

#[napi(catch_unwind)]
pub fn return_zero_struct() -> ZeroStruct {
  ZeroStruct
}
```

2、The ownership of the CString passed to cffi will be taken in map function.  When passed to cffi, the ctring memory has already been released