### PR TITLE
perf(macro): constructor don't support asynchronous function

### DIFF
--- a/crates/macro/src/parser/mod.rs
+++ b/crates/macro/src/parser/mod.rs
@@ -690,6 +690,10 @@ fn napi_fn_from_decl(
       );
     }
 
+    if matches!(kind, FnKind::Constructor) && asyncness.is_some() {
+      bail_span!(sig.ident, "Constructor don't support asynchronous function");
+    }
+
     Ok(NapiFn {
       name: ident.clone(),
       js_name,


### PR DESCRIPTION
Using asynchronous function for constructor will cause error.

<img width="925" alt="image" src="https://github.com/user-attachments/assets/48a22041-4181-4d05-aa0b-6bacc35df3b5">
