### PR TITLE
Enable corepack in Debian base Dockerfile

### DIFF
--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update && \
   cmake \
   ninja-build && \
   apt-get autoremove -y && \
+  corepack enable && \
   curl https://sh.rustup.rs -sSf | sh -s -- -y && \
   npm install -g npm yarn pnpm && \
   ln -sf /usr/bin/clang-18 /usr/bin/clang && \


### PR DESCRIPTION
Otherwise, the yarn version preinstalled would be too old, and yarn will complain about this:

```
Digest: sha256:c44d63d56ad0c8015af0f74d870a3e6d6307d3032251d85c5d5f7525e283e92f
Status: Downloaded newer image for ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
error This project's package.json defines "packageManager": "yarn@4.4.1". However the current global version of Yarn is 1.22.22.
```

https://github.com/stevefan1999-personal/bbclash-rs/actions/runs/10860272412/job/30140659466