### PR TITLE
fix(derive): fix clippy warning with newer rust version

### DIFF
--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -152,7 +152,7 @@ pub fn module_exports(_attr: TokenStream, input: TokenStream) -> TokenStream {
 
   let register = quote! {
     #[cfg_attr(not(target_family = "wasm"), napi::bindgen_prelude::ctor)]
-    fn __napi__explicit_module_register() {
+    fn __napi_explicit_module_register() {
       unsafe fn register(raw_env: napi::sys::napi_env, raw_exports: napi::sys::napi_value) -> napi::Result<()> {
         use napi::{Env, JsObject, NapiValue};
 


### PR DESCRIPTION
<img width="807" alt="image" src="https://github.com/user-attachments/assets/625fed03-bcf0-4fd3-aea8-2cce486f4522">
