### PR TITLE
feat(napi): mark create_buffer as deprecated & use BufferSlice to replace JsBuffer for ser

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/buffer.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/buffer.rs
@@ -23,7 +23,7 @@ thread_local! {
 /// If you want to use Node.js Buffer in async context or want to extend the lifetime, use `Buffer` instead.
 pub struct BufferSlice<'scope> {
   pub(crate) inner: &'scope mut [u8],
-  raw_value: sys::napi_value,
+  pub(crate) raw_value: sys::napi_value,
 }
 
 impl<'scope> BufferSlice<'scope> {

--- a/crates/napi/src/env.rs
+++ b/crates/napi/src/env.rs
@@ -255,6 +255,7 @@ impl Env {
     Ok(unsafe { JsObject::from_raw_unchecked(self.0, raw_value) })
   }
 
+  #[deprecated(since = "3.0.0", note = "Use `Buffer` instead")]
   /// This API allocates a node::Buffer object. While this is still a fully-supported data structure, in most cases using a TypedArray will suffice.
   pub fn create_buffer(&self, length: usize) -> Result<JsBufferValue> {
     let mut raw_value = ptr::null_mut();

--- a/crates/napi/src/js_values/ser.rs
+++ b/crates/napi/src/js_values/ser.rs
@@ -3,7 +3,7 @@ use std::result::Result as StdResult;
 use serde::{ser, Serialize, Serializer};
 
 use super::*;
-use crate::{Env, Error, Result};
+use crate::{bindgen_runtime::BufferSlice, Env, Error, Result};
 
 pub struct Ser<'env>(pub(crate) &'env Env);
 
@@ -30,10 +30,11 @@ impl<'env> Serializer for Ser<'env> {
   }
 
   fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok> {
-    self
-      .0
-      .create_buffer_with_data(v.to_owned())
-      .map(|js_value| js_value.value.0)
+    BufferSlice::from_data(self.0, v.to_owned()).map(|bs| Value {
+      env: self.0.raw(),
+      value: bs.raw_value,
+      value_type: ValueType::Object,
+    })
   }
 
   fn serialize_char(self, v: char) -> Result<Self::Ok> {


### PR DESCRIPTION
mark create_buffer as deprecated & use BufferSlice to replace JsBuffer for ser