### PR TITLE
feat!: support node 22

### DIFF
--- a/cli/esbuild.mjs
+++ b/cli/esbuild.mjs
@@ -1,7 +1,7 @@
 import * as esbuild from 'esbuild'
 import { pull } from 'lodash-es'
 
-import packageJson from './package.json' assert { type: 'json' }
+import packageJson from './package.json' with { type: 'json' }
 
 await esbuild.build({
   entryPoints: ['./dist/index.js'],

--- a/cli/package.json
+++ b/cli/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": ">= 16"
+    "node": ">= 18"
   },
   "bin": {
     "napi": "./dist/cli.js",

--- a/cli/src/utils/misc.ts
+++ b/cli/src/utils/misc.ts
@@ -6,27 +6,19 @@ import {
   unlink,
   stat,
   readdir,
-} from 'node:fs'
-import { createRequire } from 'node:module'
-import { promisify } from 'node:util'
+} from 'node:fs/promises'
 
 import { debug } from './log.js'
 
-const require = createRequire(import.meta.url)
-// NOTE:
-//   import pkgJson from '@napi-rs/cli/package.json' assert { type: 'json' }
-//   is experimental feature now, avoid using it.
-//   see: https://nodejs.org/api/esm.html#import-assertions
-// eslint-disable-next-line import/no-extraneous-dependencies
-const pkgJson = require('@napi-rs/cli/package.json')
+import pkgJson from '@napi-rs/cli/package.json' with { type: 'json' }
 
-export const readFileAsync = promisify(readFile)
-export const writeFileAsync = promisify(writeFile)
-export const unlinkAsync = promisify(unlink)
-export const copyFileAsync = promisify(copyFile)
-export const mkdirAsync = promisify(mkdir)
-export const statAsync = promisify(stat)
-export const readdirAsync = promisify(readdir)
+export const readFileAsync = readFile
+export const writeFileAsync = writeFile
+export const unlinkAsync = unlink
+export const copyFileAsync = copyFile
+export const mkdirAsync = mkdir
+export const statAsync = stat
+export const readdirAsync = readdir
 
 export async function fileExists(path: string) {
   const exists = await statAsync(path)
@@ -51,7 +43,7 @@ export async function updatePackageJson(
     debug(`File not exists ${path}`)
     return
   }
-  const old = require(path)
+  const old = await import(path, { with: { type: 'json' } })
   await writeFileAsync(path, JSON.stringify({ ...old, ...partial }, null, 2))
 }
 


### PR DESCRIPTION
- Replace "import assertions" with "import attributes" (see https://nodejs.org/dist/v18.20.4/docs/api/esm.html#import-attributes)
  - Replacing import assertions breaks support for now-unsupported node 16
- Replace promisified `node:fs` functions with `node:fs/promises` functions
- Update supported engines to drop support for node 16 (which is not supported anymore see https://nodejs.org/en/about/previous-releases#release-schedule)

BREAKING CHANGE:
- Drop support for node 16