### PR TITLE
feat(napi): support arraybuffer for de

### DIFF
--- a/crates/napi/src/js_values/arraybuffer.rs
+++ b/crates/napi/src/js_values/arraybuffer.rs
@@ -36,8 +36,8 @@ impl ValidateNapiValue for JsArrayBuffer {
 
 pub struct JsArrayBufferValue {
   pub value: JsArrayBuffer,
-  len: usize,
-  data: *mut c_void,
+  pub(crate) len: usize,
+  pub(crate) data: *mut c_void,
 }
 
 pub struct JsTypedArray(pub(crate) Value);

--- a/crates/napi/src/js_values/mod.rs
+++ b/crates/napi/src/js_values/mod.rs
@@ -260,6 +260,14 @@ macro_rules! impl_js_value_methods {
         Ok(is_buffer)
       }
 
+      pub fn is_arraybuffer(&self) -> Result<bool> {
+        let mut is_buffer = false;
+        check_status!(unsafe {
+          sys::napi_is_arraybuffer(self.0.env, self.0.value, &mut is_buffer)
+        })?;
+        Ok(is_buffer)
+      }
+
       pub fn instanceof<Constructor>(&self, constructor: Constructor) -> Result<bool>
       where
         Constructor: NapiRaw,

--- a/examples/napi/__tests__/values.spec.ts
+++ b/examples/napi/__tests__/values.spec.ts
@@ -780,6 +780,7 @@ test('serde-buffer-bytes', (t) => {
 
   t.is(testSerdeBufferBytes({ code: Buffer.from([1, 2, 3]) }), 3n)
   t.is(testSerdeBufferBytes({ code: Buffer.alloc(0) }), 0n)
+  t.is(testSerdeBufferBytes({ code: new ArrayBuffer(10) }), 10n)
 })
 
 test('buffer', (t) => {


### PR DESCRIPTION
For Buffer and ArrayBuffer, we  need to handle it explicitly instead of using `FromNapiValue`.

Using `FromNapiValue` to convert value will get some error: 
<img width="1229" alt="image" src="https://github.com/user-attachments/assets/95f909d6-7100-44f1-a9c0-dd8d609e2c51">
