### PR TITLE
fix(napi): data maybe null in custom_gc

### DIFF
--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -4,6 +4,8 @@ env:
   DEBUG: 'napi:*'
   RUST_BACKTRACE: 1
   CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
+  # https://github.com/nodejs/node/issues/51555#issuecomment-2290742072
+  DISABLE_V8_COMPILE_CACHE: 1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/crates/napi/src/bindgen_runtime/module_register.rs
+++ b/crates/napi/src/bindgen_runtime/module_register.rs
@@ -557,7 +557,9 @@ extern "C" fn custom_gc(
   data: *mut std::ffi::c_void,
 ) {
   // current thread was destroyed
-  if THREADS_CAN_ACCESS_ENV.borrow_mut(|m| m.get(&std::thread::current().id()) == Some(&false)) {
+  if THREADS_CAN_ACCESS_ENV.borrow_mut(|m| m.get(&std::thread::current().id()) == Some(&false))
+    || data.is_null()
+  {
     return;
   }
   let mut ref_count = 0;


### PR DESCRIPTION
Sometimes thread has not been disposed but the objects on it have been
recycled, we need to check if the data has been pointed to null before
unref it.

See https://github.com/napi-rs/napi-rs/issues/2300 for context