### PR TITLE
chore(napi): display the real info for TypedArray

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/arraybuffer.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/arraybuffer.rs
@@ -343,7 +343,11 @@ macro_rules! impl_typed_array {
         if typed_array_type != $typed_array_type as i32 {
           return Err(Error::new(
             Status::InvalidArg,
-            format!("Expected $name, got {}", typed_array_type),
+            format!(
+              "Expected {}, got {}Array",
+              stringify!($name),
+              TypedArrayType::from(typed_array_type).as_ref()
+            ),
           ));
         }
         Ok($name {

--- a/crates/napi/src/js_values/arraybuffer.rs
+++ b/crates/napi/src/js_values/arraybuffer.rs
@@ -101,6 +101,27 @@ pub enum TypedArrayType {
   Unknown = 1024,
 }
 
+impl AsRef<str> for TypedArrayType {
+  fn as_ref(&self) -> &str {
+    match self {
+      TypedArrayType::Int8 => "Int8",
+      TypedArrayType::Uint8 => "Uint8",
+      TypedArrayType::Uint8Clamped => "Uint8Clamped",
+      TypedArrayType::Int16 => "Int16",
+      TypedArrayType::Uint16 => "Uint16",
+      TypedArrayType::Int32 => "Int32",
+      TypedArrayType::Uint32 => "Uint32",
+      TypedArrayType::Float32 => "Float32",
+      TypedArrayType::Float64 => "Float64",
+      #[cfg(feature = "napi6")]
+      TypedArrayType::BigInt64 => "BigInt64",
+      #[cfg(feature = "napi6")]
+      TypedArrayType::BigUint64 => "BigUint64",
+      TypedArrayType::Unknown => "Unknown",
+    }
+  }
+}
+
 impl From<sys::napi_typedarray_type> for TypedArrayType {
   fn from(value: sys::napi_typedarray_type) -> Self {
     match value {


### PR DESCRIPTION
When we use `Uint8Array` in rust and pass into a `Uint16Array`, it will throw error info:


```
Error: Expected $name, got 4
    at Object.<anonymous> (/Users/ranger/Desktop/project/test/napi-test/test.js:11:11)
    at Module._compile (node:internal/modules/cjs/loader:1364:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
    at Module.load (node:internal/modules/cjs/loader:1203:32)
    at Module._load (node:internal/modules/cjs/loader:1019:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:128:12)
    at node:internal/main/run_main_module:28:49 {
  code: 'InvalidArg'
}
```

It should be `Error: Expected Uint8Array, got Uint16Array`