### PR TITLE
chore(napi-derive): remove unused dependency `regex` from `napi-derive-backend`

### DIFF
--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -15,17 +15,13 @@ independent = true
 [features]
 noop = []
 strict = []
-type-def = ["regex", "semver"]
+type-def = ["semver"]
 
 [dependencies]
 convert_case = "0.6"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["fold", "full", "extra-traits"] }
-
-[dependencies.regex]
-optional = true
-version = "1"
 
 [dependencies.semver]
 optional = true


### PR DESCRIPTION
This isn't referenced in the code of the `backend` crate and is bloating the build graph unnecessarily. It seems like an oversight to me.

Tested with `cargo test` locally

```sh
grep regex -r crates/backend 
# finds no results

cargo test
# passes with some warnings in unrelated crates
```