### PR TITLE
feat(napi): allow us to create nest function from closure

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/function.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/function.rs
@@ -406,7 +406,7 @@ impl<Args: JsValuesTupleIntoVec, Return: FromNapiValue> ValidateNapiValue
 pub struct FunctionCallContext<'scope> {
   pub(crate) args: &'scope [sys::napi_value],
   pub(crate) this: sys::napi_value,
-  pub(crate) env: &'scope mut Env,
+  pub env: &'scope mut Env,
 }
 
 impl FunctionCallContext<'_> {

--- a/examples/napi-compat-mode/__tests__/function.spec.ts
+++ b/examples/napi-compat-mode/__tests__/function.spec.ts
@@ -42,3 +42,19 @@ test('should be able to create function from closure', (t) => {
     )
   }
 })
+
+test('should be able to create nest function from closure', (t) => {
+  let callbackExecuted = false
+
+  const mockObject = {
+    on: (event: string, callback: Function) => {
+      t.is(event, 'on', 'Event name should be "on"')
+      callback()
+      callbackExecuted = true
+    },
+  }
+
+  const handle = bindings.testNestCreateFunctionFromClosure()
+  handle(mockObject)
+  t.true(callbackExecuted, 'Nested callback should have been executed')
+})


### PR DESCRIPTION
We need to create nested functions to meet the ability of multi-level callback listening.

Here is an example to explain, `abilityCallback` is created by native and we need to add callback for `window.on("windowStageEvent")`

```ts
    const abilityCallback = {
      onAbilityForeground: ability => {
        hilog.info(0x0000, "test", "onAbilityForeground")
      },
      onWindowStageCreate: (ability, window) => {
        window.on("windowStageEvent", type => {
          console.log(`${type}`)
        })
      }
    } as AbilityLifecycleCallback;

    applicationContext.on("abilityLifecycle", abilityCallback as AbilityLifecycleCallback)
```