### PR TITLE
feat(napi): implement `ValidateNapiValue` for HashMap with any hasher

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/map.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/map.rs
@@ -16,7 +16,7 @@ impl<K, V, S> TypeName for HashMap<K, V, S> {
   }
 }
 
-impl<K: From<String> + Eq + Hash, V: FromNapiValue> ValidateNapiValue for HashMap<K, V> {}
+impl<K: From<String> + Eq + Hash, V: FromNapiValue, S> ValidateNapiValue for HashMap<K, V, S> {}
 
 impl<K, V, S> ToNapiValue for HashMap<K, V, S>
 where


### PR DESCRIPTION
For example, `FromNapiValue` and `ToNapiValue` was implemented for `HashMap<K, V, BuildHasherDefault<FxHasher>>`, but `ValidateNapiValue` was not.