### PR TITLE
feat(napi): implement `ValidateNapiValue` for HashSet with any hasher

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/set.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/set.rs
@@ -13,7 +13,7 @@ impl<V, S> TypeName for HashSet<V, S> {
   }
 }
 
-impl<V: FromNapiValue> ValidateNapiValue for HashSet<V> {}
+impl<V: FromNapiValue, S> ValidateNapiValue for HashSet<V, S> {}
 
 impl<V, S> ToNapiValue for HashSet<V, S>
 where


### PR DESCRIPTION
I just noticed that it was missing for HashSet as well. I should have sent this together with #2374.