### PR TITLE
chore: update MSRV in README.md

### DIFF
--- a/crates/napi/README.md
+++ b/crates/napi/README.md
@@ -23,7 +23,7 @@ A framework for building compiled `Node.js` add-ons in `Rust` via Node-API. Webs
 
 ## MSRV
 
-**Rust** `1.65.0`
+**Rust** `1.80.0`
 
 |                       | node12 | node14 | node16 | node18 | node20 |
 | --------------------- | ------ | ------ | ------ | ------ | ------ |


### PR DESCRIPTION
Hey there :wave:

First of all thanks for the awesome tool, it's making it easy to keep working on important stuff instead of updating glue code all the time.
The new crate versions require rust 1.80.0.
I'm not sure what the policy on this is, aren't MSRV increases supposed to be at least a minor bump?

This broke our builds since we're still on 1.78.0 for a bit and cargo picked up  the new napi-build patch version. (I'm going to go check in the Cargo.lock now)