### PR TITLE
chore(napi): expose functions which turn raw pointer into External

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/external.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/external.rs
@@ -45,6 +45,10 @@ impl<T: 'static> External<T> {
     }
   }
 
+  /// Turn a raw pointer (from napi) pointing to an External into a reference to the inner object.
+  ///
+  /// # Safety
+  /// The `unknown_tagged_object` raw pointer must point to an `External<T>` struct.
   unsafe fn from_raw_impl(
     unknown_tagged_object: *mut std::ffi::c_void,
   ) -> Option<&'static mut Self> {
@@ -58,6 +62,9 @@ impl<T: 'static> External<T> {
   }
 
   /// Turn a raw pointer (from napi) pointing to an External into a mutable reference to the inner object.
+  ///
+  /// # Safety
+  /// The `unknown_tagged_object` raw pointer must point to an `External<T>` struct.
   pub unsafe fn inner_from_raw_mut(
     unknown_tagged_object: *mut std::ffi::c_void,
   ) -> Option<&'static mut T> {
@@ -65,6 +72,9 @@ impl<T: 'static> External<T> {
   }
 
   /// Turn a raw pointer (from napi) pointing to an External into a reference inner object.
+  ///
+  /// # Safety
+  /// The `unknown_tagged_object` raw pointer must point to an `External<T>` struct.
   pub unsafe fn inner_from_raw(unknown_tagged_object: *mut std::ffi::c_void) -> Option<&'static T> {
     Self::from_raw_impl(unknown_tagged_object).map(|external| &external.obj)
   }

--- a/crates/napi/src/bindgen_runtime/js_values/external.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/external.rs
@@ -45,6 +45,30 @@ impl<T: 'static> External<T> {
     }
   }
 
+  unsafe fn from_raw_impl(
+    unknown_tagged_object: *mut std::ffi::c_void,
+  ) -> Option<&'static mut Self> {
+    let type_id = unknown_tagged_object as *const TypeId;
+    if unsafe { *type_id } == TypeId::of::<T>() {
+      let tagged_object = unknown_tagged_object as *mut External<T>;
+      Some(Box::leak(unsafe { Box::from_raw(tagged_object) }))
+    } else {
+      None
+    }
+  }
+
+  /// Turn a raw pointer (from napi) pointing to an External into a mutable reference to the inner object.
+  pub unsafe fn inner_from_raw_mut(
+    unknown_tagged_object: *mut std::ffi::c_void,
+  ) -> Option<&'static mut T> {
+    Self::from_raw_impl(unknown_tagged_object).map(|external| &mut external.obj)
+  }
+
+  /// Turn a raw pointer (from napi) pointing to an External into a reference inner object.
+  pub unsafe fn inner_from_raw(unknown_tagged_object: *mut std::ffi::c_void) -> Option<&'static T> {
+    Self::from_raw_impl(unknown_tagged_object).map(|external| &external.obj)
+  }
+
   /// `size_hint` is a value to tell Node.js GC how much memory is used by this `External` object.
   ///
   /// If getting the exact `size_hint` is difficult, you can provide an approximate value, it's only effect to the GC.
@@ -71,18 +95,15 @@ impl<T: 'static> FromNapiMutRef for External<T> {
       "Failed to get external value"
     )?;
 
-    let type_id = unknown_tagged_object as *const TypeId;
-    if unsafe { *type_id } == TypeId::of::<T>() {
-      let tagged_object = unknown_tagged_object as *mut External<T>;
-      Ok(Box::leak(unsafe { Box::from_raw(tagged_object) }))
-    } else {
-      Err(Error::new(
+    match Self::from_raw_impl(unknown_tagged_object) {
+      Some(external) => Ok(external),
+      None => Err(Error::new(
         Status::InvalidArg,
         format!(
           "<{}> on `External` is not the type of wrapped object",
           std::any::type_name::<T>()
         ),
-      ))
+      )),
     }
   }
 }


### PR DESCRIPTION
Hi, we recently shipped a [native bundler plugin API](https://bun.sh/docs/bundler/plugins#native-plugins) for Bun, with a Rust crate which exposes a convenient way to create native bundler plugins for Bun ([here](https://github.com/oven-sh/bun/tree/main/packages/bun-native-plugin-rs)).

Native bundler plugins in Bun are NAPI modules which expose an additional symbol to a function which implements the bundler plugin code.

To make this nicer to write in Rust, we want to allow users to integrate it with `napi-rs`.

We want to allow users to use `napi-rs` `External` type when writing native bundler plugins. Native bundler plugins can carry around the raw pointer to the napi external.

However, `napi-rs` does not mark the fields of `External` as `pub` or export anyway to go from `*mut c_void -> External<T>`.

Currently in `bun-native-plugin-rs` we do something like this to do that:
```rs
/// Copy-pasted from napi-rs, not ideal
#[repr(C)]
pub struct TaggedObject<T> {
    type_id: TypeId,
    pub(crate) object: Option<T>,
}

pub unsafe fn external<T: 'static + Sync>(&self) -> PluginResult<Option<&'static T>> {

        // ...
        
        let external: *mut TaggedObject<T> =
            unsafe { (*self.args_raw).external as *mut TaggedObject<T> };
            
         // ...
}
```

This is obviously bad as `napi-rs` could change `TaggedObject`.

So this PR exports function which exposes some logic to go from `*mut c_void -> Option<&T>`, where T is the inner type of the `External<T>`.