### PR TITLE
fix: refer deprecated notice is misleading

### DIFF
--- a/crates/napi/src/threadsafe_function.rs
+++ b/crates/napi/src/threadsafe_function.rs
@@ -321,13 +321,9 @@ impl<
     })
   }
 
-  #[deprecated(
-    since = "2.17.0",
-    note = "Please use `ThreadsafeFunction::clone` instead of manually increasing the reference count"
-  )]
+  /// Note that "ref" is not used to increase the reference count. Instead, it’s used to keep the uv loop active. As a result, calling "refer" multiple times is idempotent.
   /// See [napi_ref_threadsafe_function](https://nodejs.org/api/n-api.html#n_api_napi_ref_threadsafe_function)
   /// for more information.
-  ///
   /// "ref" is a keyword so that we use "refer" here.
   pub fn refer(&mut self, env: &Env) -> Result<()> {
     self.handle.with_read_aborted(|aborted| {


### PR DESCRIPTION
As the docs says, it seems napi_ref_threadsafe_function is not used to increase reference count, so the current deprecate notice seems misleading, also it seems tsfn clone can't replace the current refer semantic, so I'm not sure whether this api should be deprecated.
> This API is used to indicate that the event loop running on the main thread should not exit until func has been destroyed. Similar to [uv_ref](https://docs.libuv.org/en/v1.x/handle.html#c.uv_ref) it is also idempotent.
 Neither does napi_unref_threadsafe_function mark the thread-safe functions as able to be destroyed nor does napi_ref_threadsafe_function prevent it from being destroyed. napi_acquire_threadsafe_function and napi_release_threadsafe_function are available for that purpose.