### PR TITLE
fix(napi): reference should not impl send trait

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/value_ref.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/value_ref.rs
@@ -31,7 +31,6 @@ pub struct Reference<T: 'static> {
   finalize_callbacks: Rc<Cell<*mut dyn FnOnce()>>,
 }
 
-unsafe impl<T: Send> Send for Reference<T> {}
 unsafe impl<T: Sync> Sync for Reference<T> {}
 
 impl<T> Drop for Reference<T> {


### PR DESCRIPTION
`Reference` should not implement the `Send` trait

Reasons:
1. Thread Safety with Node-API:
The `napi_reference_unref` function is not recommended to be called outside the JavaScript thread, as Node-API operations are generally thread-unsafe unless explicitly documented.

2. Non-Deterministic `Rc` Behavior:
The Reference type internally uses `Rc` for reference counting. When cloned and moved across threads (as shown below), the `Rc` count becomes non-deterministic, leading to potential memory safety issues or undefined behavior:

```rust
let reference1 = reference.clone(env).unwrap();
let reference2 = reference.clone(env).unwrap();
let reference3 = reference.clone(env).unwrap();
let reference4 = reference.clone(env).unwrap();
let reference5 = reference.clone(env).unwrap();
let reference6 = reference.clone(env).unwrap();
spawn(move || {
  reference1;
  reference2;
  reference3;
});

spawn(move || {
  reference4;
  reference5;
  reference6;
});
```
