### PR TITLE
fix(cli): use `new URL` instead of `?url` for browser wasm fetching

### DIFF
--- a/cli/src/api/templates/load-wasi-template.ts
+++ b/cli/src/api/templates/load-wasi-template.ts
@@ -32,7 +32,7 @@ const __wasi = new __WASI({
   createOnMessage as __wasmCreateOnMessageForFsProxy,
 } from '@napi-rs/wasm-runtime'
 ${fsImport}
-import __wasmUrl from './${wasiFilename}.wasm?url'
+const __wasmUrl = new URL('./${wasiFilename}.wasm', import.meta.url)
 ${wasiCreation}
 
 const __emnapiContext = __emnapiGetDefaultContext()

--- a/examples/napi/example.wasi-browser.js
+++ b/examples/napi/example.wasi-browser.js
@@ -5,7 +5,7 @@ import {
   createOnMessage as __wasmCreateOnMessageForFsProxy,
 } from '@napi-rs/wasm-runtime'
 import { memfs } from '@napi-rs/wasm-runtime/fs'
-import __wasmUrl from './example.wasm32-wasi.wasm?url'
+const __wasmUrl = new URL('./example.wasm32-wasi.wasm', import.meta.url)
 
 export const { fs: __fs, vol: __volume } = memfs()
 


### PR DESCRIPTION
Related https://github.com/vitejs/vite/issues/19639, https://github.com/oxc-project/oxc/issues/9783

I was testing napi-rs oxc-parser package on browser (see sample app in https://github.com/oxc-project/oxc/issues/9783) and noticed that `?url` is causing some issues on Vite. Using `new URL` works around the issue and also I think it's better to avoid `?url` since it requires a special bundler side convention.