### PR TITLE
fix: disable wasm shared memory on wasm32-wasip1 target

### DIFF
--- a/cli/src/api/build.ts
+++ b/cli/src/api/build.ts
@@ -944,6 +944,9 @@ class Builder {
           (ident) => `module.exports.${ident} = __napiModule.exports.${ident}`,
         )
         .join('\n')
+      const hasThreads = this.config.targets.some(
+        (t) => t.triple === 'wasm32-wasip1-threads',
+      )
       await writeFileAsync(
         bindingPath,
         createWasiBinding(
@@ -964,6 +967,7 @@ class Builder {
           this.config.wasm?.maximumMemory,
           this.config.wasm?.browser?.fs,
           this.config.wasm?.browser?.asyncInit,
+          hasThreads,
         ) +
           idents
             .map(

--- a/crates/build/src/wasi.rs
+++ b/crates/build/src/wasi.rs
@@ -5,7 +5,12 @@ pub fn setup() {
   println!("cargo:rerun-if-env-changed=EMNAPI_LINK_DIR");
   println!("cargo:rerun-if-env-changed=WASI_REGISTER_TMP_PATH");
   println!("cargo:rustc-link-search={link_dir}");
-  println!("cargo:rustc-link-lib=static=emnapi-basic-mt");
+  let target = env::var("TARGET").expect("TARGET must be set by Cargo");
+  if target == "wasm32-wasip1-threads" {
+    println!("cargo:rustc-link-lib=static=emnapi-basic-mt");
+  } else {
+    println!("cargo:rustc-link-lib=static=emnapi-basic");
+  }
   println!("cargo:rustc-link-arg=--export-dynamic");
   println!("cargo:rustc-link-arg=--export=malloc");
   println!("cargo:rustc-link-arg=--export=free");
@@ -22,7 +27,6 @@ pub fn setup() {
   println!("cargo:rustc-link-arg=-zstack-size=6400000");
   println!("cargo:rustc-link-arg=--no-check-features");
   let rustc_path = env::var("RUSTC").expect("RUSTC must be set by Cargo");
-  let target = env::var("TARGET").expect("TARGET must be set by Cargo");
   let crt_reactor_path = Path::new(&rustc_path)
     .parent()
     .and_then(|p| p.parent())


### PR DESCRIPTION
- Closes https://github.com/napi-rs/napi-rs/issues/2521

I tested locally by:

- edit `examples/napi/package.json` to replace `wasm32-wasip1-threads` with `wasm32-wasip1`
- edit `examples/napi/vite.config.ts` to remove `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy`
- build `yarn --cwd examples/napi build --target wasm32-wasip1  --release`
- run `yarn --cwd examples/napi browser`
  - `console.info(new Animal(Kind.Cat, 'Tom'))` works
  - `asyncMultiTwo` panics

I'm not sure if I'm missing some other cases worker is used or shared memory is essential. I would appreciate a review :pray: 