### PR TITLE
perf(build): remove `--export-dynamic` flag in wasi compilation

### DIFF
--- a/crates/build/src/wasi.rs
+++ b/crates/build/src/wasi.rs
@@ -6,7 +6,6 @@ pub fn setup() {
   println!("cargo:rerun-if-env-changed=WASI_REGISTER_TMP_PATH");
   println!("cargo:rustc-link-search={link_dir}");
   println!("cargo:rustc-link-lib=static=emnapi-basic-mt");
-  println!("cargo:rustc-link-arg=--export-dynamic");
   println!("cargo:rustc-link-arg=--export=malloc");
   println!("cargo:rustc-link-arg=--export=free");
   println!("cargo:rustc-link-arg=--export=napi_register_wasm_v1");


### PR DESCRIPTION
From my study, `--export-dynamic` isn't usually used when compiling to dynamic libraries. With this flag enable, there are many unused symbols exported from the wasm artifact. 

Rspack suffers from this with ~130,000 exported symbols, due to the 100,000 limitation of node.js, although currently there is no problem in rolldown with ~20,000 exported symbols. 

**I'm not sure whether this flag is necessary. But at least we need to find some ways to control the exports.**

I also build rolldown without this flag, and the examples in the repo can be still successfully built. Here is some data for comparison:
Data | Before | After
-- | -- | --
compilation time | 71.13s | 70.98s
export count | 20,025 | 80
wasm size(debug) | 169.93MB | 167.15MB
wasm size | 14.99MB |  11.91MB

Example | Before (ms) | After (ms)
-- | -- | --
basic-typescript | 57.51 | 46.34
basic-vue | 97.39 | 84.74
module-federation-host | 152.89 | 130.17
module-federation-remote | 93.33 | 87.27
rollup-plugin-esbuild | 68.16 | 67.07

Before:
<img width="810" alt="image" src="https://github.com/user-attachments/assets/c1ab48cc-c5c6-4ed5-9309-f638fcdd197c" />

After: 
<img width="606" alt="image" src="https://github.com/user-attachments/assets/9853da40-0594-4225-a6f0-ef0b9b04b5c6" />
