### PR TITLE
nwjs support and nwjs example

### DIFF
--- a/crates/sys/src/functions.rs
+++ b/crates/sys/src/functions.rs
@@ -816,7 +816,7 @@ pub use napi8::*;
 #[cfg(feature = "napi9")]
 pub use napi9::*;
 
-#[cfg(all(windows, not(target_env = "msvc"), feature = "dyn-symbols"))]
+#[cfg(windows)]
 fn test_library(
   lib_result: Result<libloading::os::windows::Library, libloading::Error>,
 ) -> Result<libloading::Library, libloading::Error> {
@@ -837,7 +837,7 @@ fn test_library(
   }
 }
 
-#[cfg(all(windows, not(target_env = "msvc"), feature = "dyn-symbols"))]
+#[cfg(windows)]
 fn find_node_library() -> Result<libloading::Library, libloading::Error> {
   return unsafe {
     test_library(libloading::os::windows::Library::this())
@@ -857,7 +857,7 @@ fn find_node_library() -> Result<libloading::Library, libloading::Error> {
 #[cfg(any(target_env = "msvc", feature = "dyn-symbols"))]
 pub(super) unsafe fn load_all() -> Result<libloading::Library, libloading::Error> {
   #[cfg(all(windows, target_env = "msvc"))]
-  let host = libloading::os::windows::Library::this()?.into();
+  let host = find_node_library()?.into();
 
   #[cfg(all(windows, not(target_env = "msvc")))]
   let host = find_node_library()?.into();

--- a/examples/napi/nw-renderer/README.md
+++ b/examples/napi/nw-renderer/README.md
@@ -1,0 +1,51 @@
+# NW.js Renderer Test for napi-rs
+
+This test demonstrates running napi-rs native modules in NW.js's renderer process on Windows.
+
+## Building the Example
+
+Build the napi-rs example:
+
+```bash
+cd examples/napi
+yarn build
+```
+
+## Running the Test
+
+From the examples/napi directory, run:
+
+````bash
+# Using npm script
+yarn test:nwjs
+
+## How it Works
+
+This test loads the napi-rs native module in NW.js and executes various functions to ensure compatibility. The test verifies:
+
+1. Loading native modules in NW.js context
+2. Calling threadsafe functions
+3. Using abort controllers
+4. Working with file I/O
+5. Creating and using typed arrays
+
+The test will:
+1. Automatically locate the locally installed NW.js executable
+2. Launch NW.js with the test app
+3. Execute the tests in both Node.js and NW.js contexts
+4. Close after completion
+
+## For CI/CD Integration
+
+For CI/CD pipelines, simply add these steps:
+
+```yaml
+- name: Install dependencies
+  run: cd examples/napi && yarn install
+
+- name: Build example
+  run: cd examples/napi && yarn build
+
+- name: Run NW.js test
+  run: cd examples/napi && yarn test:nwjs
+````

--- a/examples/napi/nw-renderer/index.html
+++ b/examples/napi/nw-renderer/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NW.js test</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+        padding: 20px;
+        background-color: #f5f5f5;
+      }
+      h1 {
+        color: #333;
+      }
+      .status {
+        margin-top: 20px;
+        padding: 15px;
+        background-color: #fff;
+        border-radius: 4px;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+      }
+      .success {
+        color: #0a0;
+      }
+      .error {
+        color: #d00;
+      }
+      #results {
+        margin-top: 20px;
+      }
+      .array-result {
+        background-color: #fff;
+        padding: 15px;
+        margin-top: 10px;
+        border-radius: 4px;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+      }
+      .array-label {
+        font-weight: bold;
+        margin-bottom: 5px;
+      }
+      .array-value {
+        font-family: monospace;
+        background-color: #f8f8f8;
+        padding: 10px;
+        border-radius: 4px;
+        border: 1px solid #eee;
+        overflow-x: auto;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>NW.js Native Module Test</h1>
+    <div class="status">Status: <span id="status">Loading...</span></div>
+    <div id="results"></div>
+    
+    <script src="./index.js"></script>
+  </body>
+</html> 

--- a/examples/napi/nw-renderer/index.js
+++ b/examples/napi/nw-renderer/index.js
@@ -1,0 +1,112 @@
+// Set status element for reporting
+function setStatus(message, isError = false) {
+  const statusElement = document.getElementById('status')
+  statusElement.textContent = message
+  statusElement.className = isError ? 'error' : 'success'
+
+  console.log(`Status: ${message}`)
+}
+
+// Add a result message
+function addResult(message, isError = false) {
+  const resultsElement = document.getElementById('results')
+  const resultElement = document.createElement('div')
+  resultElement.textContent = message
+  resultElement.className = isError ? 'error' : ''
+  resultsElement.appendChild(resultElement)
+
+  console.log(`Result: ${message}`)
+}
+
+// Add a formatted result for arrays
+function addArrayResult(label, array) {
+  const resultsElement = document.getElementById('results')
+
+  // Create container
+  const container = document.createElement('div')
+  container.className = 'array-result'
+
+  // Add label
+  const labelElement = document.createElement('div')
+  labelElement.className = 'array-label'
+  labelElement.textContent = label
+  container.appendChild(labelElement)
+
+  // Add value
+  const valueElement = document.createElement('pre')
+  valueElement.className = 'array-value'
+  valueElement.textContent = `[${array.join(', ')}]`
+  container.appendChild(valueElement)
+
+  // Add to results
+  resultsElement.appendChild(container)
+
+  console.log(`${label}:`, array)
+}
+
+// Run the NW.js tests
+try {
+  // Access NW.js API
+  const nw = window.nw || require('nw.gui')
+
+  if (!nw) {
+    throw new Error('NW.js API not available')
+  }
+
+  const win = nw.Window.get()
+
+  // Set timeout to close the window after 8 seconds
+  setTimeout(() => {
+    addResult('Test completed, closing window...')
+    win.close(true) // Force close
+  }, 2000)
+
+  // Try to directly call the native module
+  try {
+    // Import the native module
+    const nativeModule = require('../index.cjs')
+    setStatus('Native module loaded successfully')
+    addResult('Successfully required the native module')
+
+    // Call the threadsafe function
+    nativeModule.callLongThreadsafeFunction(() => {
+      addResult('Callback from threadsafe function executed')
+    })
+
+    // MAIN PART: Call the createExternalTypedArray function directly
+    try {
+      const typedArray = nativeModule.createExternalTypedArray()
+
+      addResult(
+        'Successfully created Uint32Array directly in the renderer process',
+      )
+      addArrayResult('Uint32Array from napi function', Array.from(typedArray))
+
+      // Show the type of the result
+      addResult(`Result type: ${typedArray.constructor.name}`)
+      addResult(`Array length: ${typedArray.length}`)
+
+      // Add individual elements for clarity
+      for (let i = 0; i < typedArray.length; i++) {
+        addResult(`Element ${i}: ${typedArray[i]}`)
+      }
+
+      // Show available functions from the module at the end
+      addResult(`Available functions: ${Object.keys(nativeModule).join(', ')}`)
+    } catch (typedArrayErr) {
+      addResult(`Error creating Uint32Array: ${typedArrayErr.message}`, true)
+      console.error('TypedArray error:', typedArrayErr)
+
+      // Still show available functions even if the typed array failed
+      addResult(`Available functions: ${Object.keys(nativeModule).join(', ')}`)
+    }
+  } catch (moduleErr) {
+    setStatus('Failed to load or use native module', true)
+    addResult(`Module error: ${moduleErr.message}`, true)
+    console.error('Module error:', moduleErr)
+  }
+} catch (nwErr) {
+  setStatus('Failed to initialize NW.js environment', true)
+  addResult(`NW.js error: ${nwErr.message}`, true)
+  console.error('NW.js error:', nwErr)
+}

--- a/examples/napi/nw-renderer/package.json
+++ b/examples/napi/nw-renderer/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "napi-rs-nwjs-test",
+  "version": "1.0.0",
+  "main": "index.html",
+  "window": {
+    "width": 800,
+    "height": 600,
+    "show": true
+  },
+  "node-remote": [
+    "<all_urls>"
+  ],
+  "chromium-args": "--enable-node-worker"
+}

--- a/examples/napi/nwjs.cjs
+++ b/examples/napi/nwjs.cjs
@@ -1,0 +1,140 @@
+const assert = require('node:assert');
+const { readFileSync, existsSync } = require('node:fs');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+const FILE_CONTENT = readFileSync(__filename, 'utf8');
+
+// Function to launch NW.js with our app
+const createWindowAndReload = async () => {
+  return new Promise((resolve, reject) => {
+    // Find the NW.js executable path
+    // First try the local node_modules (installed as devDependency)
+    let nwPath;
+    const isWindows = process.platform === 'win32';
+    
+    // Check various possible locations for the NW.js executable
+    const possiblePaths = [
+      // Local install in node_modules
+      path.resolve(__dirname, 'node_modules/.bin/nw' + (isWindows ? '.cmd' : '')),
+      // Install in parent directory's node_modules
+      path.resolve(__dirname, '../../node_modules/.bin/nw' + (isWindows ? '.cmd' : '')),
+      // Global install (fallback)
+      'nw' + (isWindows ? '.cmd' : '')
+    ];
+    
+    // Find the first path that exists
+    for (const possiblePath of possiblePaths) {
+      if (existsSync(possiblePath)) {
+        nwPath = possiblePath;
+        break;
+      }
+    }
+    
+    if (!nwPath) {
+      console.error('NW.js executable not found. Please install NW.js:');
+      console.error('npm install --save-dev nw');
+      return reject(new Error('NW.js executable not found'));
+    }
+    
+    const nwAppPath = path.resolve(__dirname, 'nw-renderer');
+    
+    console.log(`Starting NW.js at: ${nwPath}`);
+    console.log(`App path: ${nwAppPath}`);
+    
+    // Add special arguments for debugging if needed
+    const nwArgs = [
+      nwAppPath,
+      // Uncomment for more verbose logging
+      // '--enable-logging=stderr',
+      // '--v=1'
+    ];
+    
+    const nw = spawn(nwPath, nwArgs, {
+      stdio: 'inherit',
+      shell: true,
+      windowsHide: false
+    });
+    
+    console.log('NW.js window should be visible now');
+    console.log('The renderer process will directly call the createExternalTypedArray() function');
+    console.log('Check the NW.js window for test results');
+    
+    // For tests, we can use a longer timeout to make sure everything loads properly
+    // and give more time to see the test results in the window
+    // The window will close itself from within the renderer after 8 seconds
+    setTimeout(() => {
+      console.log('Waiting for NW.js window to close itself...');
+    }, 2000);
+    
+    // Wait for the process to exit naturally when the window is closed
+    nw.on('error', (err) => {
+      console.error('Failed to start NW.js:', err);
+      reject(err);
+    });
+    
+    nw.on('exit', (code) => {
+      console.log('NW.js process exited');
+      if (code !== 0 && code !== null) {
+        reject(new Error(`NW.js exited with code ${code}`));
+      } else {
+        resolve();
+      }
+    });
+  });
+};
+
+async function main() {
+  const {
+    readFileAsync,
+    callThreadsafeFunction,
+    withAbortController,
+    createExternalTypedArray,
+  } = require('./index.cjs');
+
+  const ctrl = new AbortController();
+  const promise = withAbortController(1, 2, ctrl.signal);
+  try {
+    ctrl.abort();
+    await promise;
+    throw new Error('Should throw AbortError');
+  } catch (err) {
+    assert(err.message === 'AbortError');
+  }
+
+  const buf = await readFileAsync(__filename);
+  assert(FILE_CONTENT === buf.toString('utf8'));
+
+  const value = await new Promise((resolve, reject) => {
+    let i = 0;
+    let value = 0;
+    callThreadsafeFunction((err, v) => {
+      if (err != null) {
+        reject(err);
+        return;
+      }
+      i++;
+      value += v;
+      if (i === 100) {
+        resolve(value);
+      }
+    });
+  });
+
+  assert(
+    value ===
+      Array.from({ length: 100 }, (_, i) => i).reduce((a, b) => a + b),
+  );
+  
+  // Log the typed array result in the main process as well
+  console.info('Main process Uint32Array result:', createExternalTypedArray());
+}
+
+Promise.all([main(), createWindowAndReload()])
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  }); 

--- a/examples/napi/package.json
+++ b/examples/napi/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "browser": "vite",
     "build": "napi-raw build --platform --js index.cjs --dts index.d.cts",
-    "test": "cross-env TS_NODE_PROJECT=./tsconfig.json node --enable-source-maps --import @oxc-node/core/register ../../node_modules/ava/entrypoints/cli.mjs"
+    "test": "cross-env TS_NODE_PROJECT=./tsconfig.json node --enable-source-maps --import @oxc-node/core/register ../../node_modules/ava/entrypoints/cli.mjs",
+    "test:nwjs": "node nwjs.cjs"
   },
   "napi": {
     "binaryName": "example",
@@ -38,6 +39,7 @@
     "cross-env": "7.0.3",
     "electron": "^35.0.2",
     "lodash": "^4.17.21",
+    "nw": "^0.85.0-sdk",
     "playwright": "^1.51.0",
     "rxjs": "^7.8.2",
     "sinon": "^20.0.0",


### PR DESCRIPTION
Added support for nwjs node library using the same function testing method used for gnu windows, which also defaults to the node and electron methods, before searching for the nwjs node library.

An example of nw.js was also added as an example for testing.