### PR TITLE
fix(cli): replace `.wasm` extension of wasm artifact

### DIFF
--- a/cli/src/api/build.ts
+++ b/cli/src/api/build.ts
@@ -769,7 +769,7 @@ class Builder {
             .parse(await readFileAsync(src))
           const debugWasmBinary = debugWasmModule.emitWasm(true)
           await writeFileAsync(
-            dest.replace('.wasm', '.debug.wasm'),
+            dest.replace(/\.wasm$/, '.debug.wasm'),
             debugWasmBinary,
           )
           debug('Generate release wasm module')


### PR DESCRIPTION
Before: `test.wasm32-wasi.wasm` -> `test.debug.wasm32-wasi.wasm`
After: `test.wasm32-wasi.wasm` -> `test.wasm32-wasi.debug.wasm`

This makes it consistent with https://github.com/napi-rs/napi-rs/blob/ee2ef3bb3d894df89e2f93b82ec71a756f3a7dae/cli/src/api/templates/load-wasi-template.ts#L131C13-L131C18