### PR TITLE
fix: install libc6-dev in debian docker container

### DIFF
--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && \
   lld-18 \
   libc++-18-dev \
   libc++abi-18-dev \
+  libc6-dev \
   nodejs \
   xz-utils \
   rcs \


### PR DESCRIPTION
This header includes `endian.h`, which was missing previously, causing tree-sitter to fail to build in this container.

See https://github.com/ast-grep/ast-grep/pull/1924