### PR TITLE
feat(derive): make `#[module_exports]` available in wasm

### DIFF
--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -151,9 +151,30 @@ pub fn module_exports(_attr: TokenStream, input: TokenStream) -> TokenStream {
     panic!("Arguments length of #[module_exports] function must be 1 or 2");
   };
 
+  #[allow(unused)]
+  let register_name = {
+    use parser::get_register_ident;
+    get_register_ident("explicit_module_exports")
+  };
+
   let register = quote! {
     #[cfg_attr(not(target_family = "wasm"), napi::ctor::ctor(crate_path=napi::ctor))]
     fn __napi_explicit_module_register() {
+      unsafe fn register(raw_env: napi::sys::napi_env, raw_exports: napi::sys::napi_value) -> napi::Result<()> {
+        use napi::{Env, JsObject, NapiValue};
+
+        let env = Env::from_raw(raw_env);
+        let exports = JsObject::from_raw_unchecked(raw_env, raw_exports);
+
+        #call_expr
+      }
+
+      napi::bindgen_prelude::register_module_exports(register)
+    }
+
+    #[cfg(target_family = "wasm")]
+    #[no_mangle]
+    unsafe extern "C" fn #register_name() {
       unsafe fn register(raw_env: napi::sys::napi_env, raw_exports: napi::sys::napi_value) -> napi::Result<()> {
         use napi::{Env, JsObject, NapiValue};
 

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -154,7 +154,7 @@ pub fn module_exports(_attr: TokenStream, input: TokenStream) -> TokenStream {
   #[allow(unused)]
   let register_name = {
     use parser::get_register_ident;
-    get_register_ident("explicit_module_exports")
+    get_register_ident("explicit_module_register")
   };
 
   let register = quote! {

--- a/crates/macro/src/parser/mod.rs
+++ b/crates/macro/src/parser/mod.rs
@@ -30,7 +30,7 @@ static GENERATOR_STRUCT: OnceLock<Mutex<HashMap<String, bool>>> = OnceLock::new(
 
 static REGISTER_INDEX: AtomicUsize = AtomicUsize::new(0);
 
-fn get_register_ident(name: &str) -> Ident {
+pub(crate) fn get_register_ident(name: &str) -> Ident {
   let new_name = format!(
     "__napi_register__{}_{}",
     rm_raw_prefix(name),


### PR DESCRIPTION
This makes `#[module_exports]` work in wasm.