### PR TITLE
fix: Fix path escaping issue in metadata parser

### DIFF
--- a/cli/src/utils/metadata.ts
+++ b/cli/src/utils/metadata.ts
@@ -41,19 +41,35 @@ export function parseMetadata(manifestPath: string) {
     throw new Error(`No crate found in manifest: ${manifestPath}`)
   }
 
-  const cmd = `cargo metadata --manifest-path ${manifestPath} --format-version 1 --no-deps`
+  const { stdout, stderr, status, error } = spawnSync(
+    'cargo',
+    [
+      'metadata',
+      '--manifest-path',
+      manifestPath,
+      '--format-version',
+      '1',
+      '--no-deps',
+    ],
+    { encoding: 'utf-8' }, 
+  )
 
-  try {
-    const output = execSync(cmd, {
-      encoding: 'utf-8',
-    })
-    return JSON.parse(output) as CargoWorkspaceMetadata
-  } catch (e) {
+  if (error) {
+    throw new Error('cargo metadata failed to run', { cause: error })
+  }
+  if (status !== 0) {
+    const simpleMessage = `cargo metadata exited with code ${status}`
     throw new Error(
-      `Failed to parse cargo metadata output by command: ${cmd}`,
+      `${simpleMessage} and error message:\n\n${stderr}`,
       {
-        cause: e,
+        cause: new Error(simpleMessage),
       },
     )
+  }
+
+  try {
+    return JSON.parse(stdout) as CargoWorkspaceMetadata
+  } catch (e) {
+    throw new Error('Failed to parse cargo metadata JSON', { cause: e })
   }
 }

--- a/cli/src/utils/metadata.ts
+++ b/cli/src/utils/metadata.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process'
+import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 
 export type CrateTargetKind =


### PR DESCRIPTION
The way the `cargo metadata` command is currently run is prone to failure because the path is not escaped. The best way to handle this is to pass the arguments directly as separate to the `cargo` process through `spawnSync` so there is no need to rely on manual escaping.

Please let me know if there is anything else I should edit before this can be merged!

I am currently using NAPI v3 so I can also put in the work to get it merged to that version following your guidance.

Here is an example of what happens when the project is run in a path that has a space in the name of a folder.
![image](https://github.com/user-attachments/assets/45c6dbd4-a858-4bec-a78d-6e15ae8482c0)