### PR TITLE
fix: ClassInstance as_object lifecycle

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/class.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/class.rs
@@ -87,7 +87,7 @@ impl<'env, T: 'env> ClassInstance<'env, T> {
     }
   }
 
-  pub fn as_object(&self, env: &Env) -> Object {
+  pub fn as_object<'a>(&self, env: &'a Env) -> Object<'a> {
     Object(
       Value {
         env: env.raw(),


### PR DESCRIPTION
Fix lifetime specification for ClassInstance::as_object method

The returned Object's lifetime should be tied to the input Env's lifetime, not the ClassInstance itself.