### PR TITLE
Patch napi-cli: Add freebsd arm64 support

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@napi-rs/cli",
-  "version": "2.18.4",
+  "version": "2.18.5",
   "description": "Cli tools for napi-rs",
   "keywords": [
     "cli",

--- a/cli/src/js-binding-template.ts
+++ b/cli/src/js-binding-template.ts
@@ -152,18 +152,33 @@ switch (platform) {
     }
     break
   case 'freebsd':
-    if (arch !== 'x64') {
-      throw new Error(\`Unsupported architecture on FreeBSD: \${arch}\`)
-    }
-    localFileExisted = existsSync(join(__dirname, '${localName}.freebsd-x64.node'))
-    try {
-      if (localFileExisted) {
-        nativeBinding = require('./${localName}.freebsd-x64.node')
-      } else {
-        nativeBinding = require('${pkgName}-freebsd-x64')
-      }
-    } catch (e) {
-      loadError = e
+    switch (arch) {
+      case 'x64':
+        localFileExisted = existsSync(join(__dirname, '${localName}.freebsd-x64.node'))
+        try {
+          if (localFileExisted) {
+            nativeBinding = require('./${localName}.freebsd-x64.node')
+          } else {
+            nativeBinding = require('${pkgName}-freebsd-x64')
+          }
+        } catch (e) {
+          loadError = e
+        }
+        break
+      case 'arm64':
+        localFileExisted = existsSync(join(__dirname, '${localName}.freebsd-arm64.node'))
+        try {
+          if (localFileExisted) {
+            nativeBinding = require('./${localName}.freebsd-arm64.node')
+          } else {
+            nativeBinding = require('${pkgName}-freebsd-arm64')
+          }
+        } catch (e) {
+          loadError = e
+        }
+        break
+      default:
+        throw new Error(\`Unsupported architecture on FreeBSD: \${arch}\`)
     }
     break
   case 'linux':


### PR DESCRIPTION
This support is currently on 3.0.0 alpha.

We would like to have it on the stable version of napi-cli.

Thank you.