### PR TITLE
feat!(napi): define propertes support symbol as name

### DIFF
--- a/bench/src/get_set_property.rs
+++ b/bench/src/get_set_property.rs
@@ -40,8 +40,6 @@ impl FromStr for LineJoin {
 }
 
 pub fn register_js(exports: &mut JsObject, env: &Env) -> Result<()> {
-  let line_join_symbol = env.create_symbol(Some("lineJoins"))?;
-
   let test_class = env.define_class::<bindgen_prelude::Unknown>(
     "TestClass",
     test_class_constructor,
@@ -62,14 +60,9 @@ pub fn register_js(exports: &mut JsObject, env: &Env) -> Result<()> {
         .with_utf8_name("lineJoin")?
         .with_getter(get_line_join)
         .with_setter(set_line_join),
-      Property::new()
-        .with_name(env, line_join_symbol)?
-        .with_getter(get_line_join)
-        .with_setter(set_line_join),
     ],
   )?;
   exports.set_named_property("TestClass", test_class)?;
-  exports.set_named_property("lineJoinSymbol", line_join_symbol)?;
   Ok(())
 }
 

--- a/bench/src/get_set_property.rs
+++ b/bench/src/get_set_property.rs
@@ -40,25 +40,36 @@ impl FromStr for LineJoin {
 }
 
 pub fn register_js(exports: &mut JsObject, env: &Env) -> Result<()> {
+  let line_join_symbol = env.create_symbol(Some("lineJoins"))?;
+
   let test_class = env.define_class::<bindgen_prelude::Unknown>(
     "TestClass",
     test_class_constructor,
     &[
-      Property::new("miterNative")?
+      Property::new()
+        .with_utf8_name("miterNative")?
         .with_getter(get_miter_native)
         .with_setter(set_miter_native),
-      Property::new("miter")?
+      Property::new()
+        .with_utf8_name("miter")?
         .with_getter(get_miter)
         .with_setter(set_miter),
-      Property::new("lineJoinNative")?
+      Property::new()
+        .with_utf8_name("lineJoinNative")?
         .with_getter(get_line_join_native)
         .with_setter(set_line_join_native),
-      Property::new("lineJoin")?
+      Property::new()
+        .with_utf8_name("lineJoin")?
+        .with_getter(get_line_join)
+        .with_setter(set_line_join),
+      Property::new()
+        .with_name(env, line_join_symbol)?
         .with_getter(get_line_join)
         .with_setter(set_line_join),
     ],
   )?;
   exports.set_named_property("TestClass", test_class)?;
+  exports.set_named_property("lineJoinSymbol", line_join_symbol)?;
   Ok(())
 }
 

--- a/crates/backend/src/codegen/struct.rs
+++ b/crates/backend/src/codegen/struct.rs
@@ -815,7 +815,7 @@ impl NapiStruct {
     let mut props = vec![];
 
     if class.ctor {
-      props.push(quote! { napi::bindgen_prelude::Property::new("constructor").unwrap().with_ctor(constructor) });
+      props.push(quote! { napi::bindgen_prelude::Property::new().with_utf8_name("constructor").unwrap().with_ctor(constructor) });
     }
 
     for field in class.fields.iter() {
@@ -841,7 +841,7 @@ impl NapiStruct {
       }
 
       let mut prop = quote! {
-        napi::bindgen_prelude::Property::new(#js_name)
+        napi::bindgen_prelude::Property::new().with_utf8_name(#js_name)
           .unwrap()
           .with_property_attributes(napi::bindgen_prelude::PropertyAttributes::from_bits(#attribute).unwrap())
       };
@@ -1369,7 +1369,7 @@ impl NapiImpl {
 
       let prop = props.entry(&item.js_name).or_insert_with(|| {
         quote! {
-          napi::bindgen_prelude::Property::new(#js_name).unwrap().with_property_attributes(napi::bindgen_prelude::PropertyAttributes::from_bits(#attribute).unwrap())
+          napi::bindgen_prelude::Property::new().with_utf8_name(#js_name).unwrap().with_property_attributes(napi::bindgen_prelude::PropertyAttributes::from_bits(#attribute).unwrap())
         }
       });
 

--- a/crates/napi/src/bindgen_runtime/js_values/class.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/class.rs
@@ -140,7 +140,8 @@ impl<'env, T: 'env> ClassInstance<'env, T> {
     'this: 'env,
     U: FromNapiValue + JsValue<'this>,
   {
-    let property = Property::new(name)?
+    let property = Property::new()
+      .with_utf8_name(name)?
       .with_value(self)
       .with_property_attributes(attributes);
 

--- a/crates/napi/src/js_values/object_property.rs
+++ b/crates/napi/src/js_values/object_property.rs
@@ -29,7 +29,8 @@ impl Default for PropertyClosures {
 
 #[derive(Clone)]
 pub struct Property {
-  pub name: CString,
+  utf8_name: CString,
+  name: sys::napi_value,
   getter: sys::napi_callback,
   setter: sys::napi_callback,
   method: sys::napi_callback,
@@ -43,6 +44,7 @@ pub struct Property {
 impl Default for Property {
   fn default() -> Self {
     Property {
+      utf8_name: Default::default(),
       name: Default::default(),
       getter: Default::default(),
       setter: Default::default(),
@@ -82,13 +84,18 @@ impl From<PropertyAttributes> for sys::napi_property_attributes {
 impl Property {
   pub fn new(name: &str) -> Result<Self> {
     Ok(Property {
-      name: CString::new(name)?,
+      utf8_name: CString::new(name)?,
       ..Default::default()
     })
   }
 
-  pub fn with_name(mut self, name: &str) -> Self {
-    self.name = CString::new(name).unwrap();
+  pub fn with_utf8_name(mut self, name: &str) -> Self {
+    self.utf8_name = CString::new(name).unwrap();
+    self
+  }
+
+  pub fn with_name<T: ToNapiValue>(mut self, env: &Env, name: T) -> Self {
+    self.name = unsafe { T::to_napi_value(env.0, name).unwrap() };
     self
   }
 
@@ -156,8 +163,8 @@ impl Property {
     #[cfg(feature = "napi5")]
     let closures = Box::into_raw(Box::new(self.closures));
     sys::napi_property_descriptor {
-      utf8name: self.name.as_ptr(),
-      name: ptr::null_mut(),
+      utf8name: self.utf8_name.as_ptr(),
+      name: self.name,
       method: self.method,
       getter: self.getter,
       setter: self.setter,

--- a/crates/napi/src/js_values/object_property.rs
+++ b/crates/napi/src/js_values/object_property.rs
@@ -82,21 +82,18 @@ impl From<PropertyAttributes> for sys::napi_property_attributes {
 }
 
 impl Property {
-  pub fn new(name: &str) -> Result<Self> {
-    Ok(Property {
-      utf8_name: CString::new(name)?,
-      ..Default::default()
-    })
+  pub fn new() -> Self {
+    Default::default()
   }
 
-  pub fn with_utf8_name(mut self, name: &str) -> Self {
-    self.utf8_name = CString::new(name).unwrap();
-    self
+  pub fn with_utf8_name(mut self, name: &str) -> Result<Self> {
+    self.utf8_name = CString::new(name)?;
+    Ok(self)
   }
 
-  pub fn with_name<T: ToNapiValue>(mut self, env: &Env, name: T) -> Self {
-    self.name = unsafe { T::to_napi_value(env.0, name).unwrap() };
-    self
+  pub fn with_name<T: ToNapiValue>(mut self, env: &Env, name: T) -> Result<Self> {
+    self.name = unsafe { T::to_napi_value(env.0, name)? };
+    Ok(self)
   }
 
   pub fn with_method(mut self, callback: Callback) -> Self {

--- a/examples/napi-compat-mode/src/class.rs
+++ b/examples/napi-compat-mode/src/class.rs
@@ -11,9 +11,15 @@ struct NativeClass {
 
 #[js_function(1)]
 fn create_test_class(ctx: CallContext) -> Result<Function<Unknown, Unknown>> {
-  let add_count_method = Property::new("addCount")?.with_method(add_count);
-  let add_native_count = Property::new("addNativeCount")?.with_method(add_native_count);
-  let renew_wrapped = Property::new("renewWrapped")?.with_method(renew_wrapped);
+  let add_count_method = Property::new()
+    .with_utf8_name("addCount")?
+    .with_method(add_count);
+  let add_native_count = Property::new()
+    .with_utf8_name("addNativeCount")?
+    .with_method(add_native_count);
+  let renew_wrapped = Property::new()
+    .with_utf8_name("renewWrapped")?
+    .with_method(renew_wrapped);
   ctx.env.define_class(
     "TestClass",
     test_class_constructor,

--- a/examples/napi-compat-mode/src/napi4/mod.rs
+++ b/examples/napi-compat-mode/src/napi4/mod.rs
@@ -17,7 +17,7 @@ pub fn register_js(exports: &mut JsObject, env: &Env) -> Result<()> {
   let obj = env.define_class::<Unknown>(
     "A",
     constructor,
-    &[Property::new("call")?.with_method(call)],
+    &[Property::new().with_utf8_name("call")?.with_method(call)],
   )?;
 
   exports.set_named_property("A", obj)?;

--- a/examples/napi-compat-mode/src/object.rs
+++ b/examples/napi-compat-mode/src/object.rs
@@ -133,8 +133,10 @@ fn test_delete_element(ctx: CallContext) -> Result<JsBoolean> {
 #[js_function(1)]
 fn test_define_properties(ctx: CallContext) -> Result<()> {
   let mut obj = ctx.get::<JsObject>(0)?;
-  let add_method = Property::new("add")?.with_method(add);
-  let readonly_property = Property::new("ro")?.with_getter(readonly_getter);
+  let add_method = Property::new().with_utf8_name("add")?.with_method(add);
+  let readonly_property = Property::new()
+    .with_utf8_name("ro")?
+    .with_getter(readonly_getter);
   let properties = vec![add_method, readonly_property];
   obj.define_properties(&properties)?;
   obj.set_named_property("count", ctx.env.create_int32(0)?)?;

--- a/examples/napi/__tests__/values.spec.ts
+++ b/examples/napi/__tests__/values.spec.ts
@@ -1513,6 +1513,8 @@ Napi5Test('Class with getter setter closures', (t) => {
   t.is(instance.name, `I'm Allie`)
   // @ts-expect-error
   t.is(instance.age, 0.3)
+  // @ts-expect-error
+  t.is(instance[instance.ageSymbol], 0.3)
 })
 
 Napi5Test('Date to chrono::NativeDateTime test', (t) => {

--- a/examples/napi/src/class.rs
+++ b/examples/napi/src/class.rs
@@ -429,13 +429,16 @@ impl GetterSetterWithClosures {
   #[napi(constructor)]
   pub fn new(mut this: This) -> Result<Self> {
     this.define_properties(&[
-      Property::new("name")?
+      Property::new()
+        .with_utf8_name("name")?
         .with_setter_closure(move |_env, mut this, value: String| {
           this.set_named_property("_name", format!("I'm {}", value))?;
           Ok(())
         })
         .with_getter_closure(|_env, this| this.get_named_property_unchecked::<Unknown>("_name")),
-      Property::new("age")?.with_getter_closure(|_env, _this| Ok(0.3)),
+      Property::new()
+        .with_utf8_name("age")?
+        .with_getter_closure(|_env, _this| Ok(0.3)),
     ])?;
     Ok(Self {})
   }

--- a/examples/napi/src/class.rs
+++ b/examples/napi/src/class.rs
@@ -427,7 +427,9 @@ pub struct GetterSetterWithClosures {}
 #[napi]
 impl GetterSetterWithClosures {
   #[napi(constructor)]
-  pub fn new(mut this: This) -> Result<Self> {
+  pub fn new(env: &Env, mut this: This) -> Result<Self> {
+    let age_symbol = env.create_symbol(Some("age"))?;
+
     this.define_properties(&[
       Property::new()
         .with_utf8_name("name")?
@@ -439,7 +441,12 @@ impl GetterSetterWithClosures {
       Property::new()
         .with_utf8_name("age")?
         .with_getter_closure(|_env, _this| Ok(0.3)),
+      Property::new()
+        .with_name(env, age_symbol)?
+        .with_getter_closure(|_env, _this| Ok(0.3)),
     ])?;
+
+    this.set_property(env.create_string("ageSymbol")?, age_symbol)?;
     Ok(Self {})
   }
 }

--- a/examples/napi/src/object.rs
+++ b/examples/napi/src/object.rs
@@ -91,8 +91,12 @@ pub fn create_obj_with_property(env: &Env) -> Result<Object> {
   let mut obj = Object::new(env)?;
   let arraybuffer = ArrayBuffer::from_data(env, vec![0; 10])?;
   obj.define_properties(&[
-    Property::new("value")?.with_value(&arraybuffer),
-    Property::new("getter")?.with_getter(get_c_callback(getter_from_obj_js_function)?),
+    Property::new()
+      .with_utf8_name("value")?
+      .with_value(&arraybuffer),
+    Property::new()
+      .with_utf8_name("getter")?
+      .with_getter(get_c_callback(getter_from_obj_js_function)?),
   ])?;
   Ok(obj)
 }


### PR DESCRIPTION
Refactor the `Property` struct and can pass symbol as name.

when pass symbol as name
```rust
let line_join_symbol = env.create_symbol(Some("lineJoins"))?;
Property::new()
        .with_name(env, line_join_symbol)?;
```

when pass str as name
```rust
Property::new()
        .with_utf8_name("miterNative")?;
```