### PR TITLE
perf(napi): PersistedPerInstanceHashMap can be thread local

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/arraybuffer.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/arraybuffer.rs
@@ -369,8 +369,7 @@ macro_rules! impl_typed_array {
             if CUSTOM_GC_TSFN_DESTROYED.load(Ordering::SeqCst) {
               return;
             }
-            if !THREADS_CAN_ACCESS_ENV.borrow_mut(|m| m.get(&std::thread::current().id()).is_some())
-            {
+            if !THREADS_CAN_ACCESS_ENV.with(|cell| cell.get()) {
               let status = unsafe {
                 sys::napi_call_threadsafe_function(
                   CUSTOM_GC_TSFN.load(std::sync::atomic::Ordering::SeqCst),

--- a/crates/napi/src/bindgen_runtime/js_values/buffer.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/buffer.rs
@@ -315,7 +315,7 @@ impl Drop for Buffer {
           return;
         }
         // Check if the current thread is the JavaScript thread
-        if !THREADS_CAN_ACCESS_ENV.borrow_mut(|m| m.get(&std::thread::current().id()).is_some()) {
+        if !THREADS_CAN_ACCESS_ENV.with(|cell| cell.get()) {
           let status = unsafe {
             sys::napi_call_threadsafe_function(
               CUSTOM_GC_TSFN.load(std::sync::atomic::Ordering::SeqCst),

--- a/crates/napi/src/bindgen_runtime/mod.rs
+++ b/crates/napi/src/bindgen_runtime/mod.rs
@@ -43,7 +43,7 @@ pub(crate) unsafe extern "C" fn raw_finalize_unchecked<T: ObjectFinalize>(
     return;
   }
   if let Some((_, ref_val, finalize_callbacks_ptr)) =
-    REFERENCE_MAP.borrow_mut(|reference_map| reference_map.remove(&finalize_data))
+    REFERENCE_MAP.with(|cell| cell.borrow_mut(|reference_map| reference_map.remove(&finalize_data)))
   {
     let finalize_callbacks_rc = unsafe { Rc::from_raw(finalize_callbacks_ptr) };
 


### PR DESCRIPTION
Performance analysis revealed unexpected overhead in `napi::bindgen_runtime::module_register::PersistedPerInstanceHashMap<K,V>::borrow_mut`.

Optimizations

1. Lock mechanism refinement for PersistedPerInstanceHashMap
Replaced internal `RwLock` with `RefCell` since this struct doesn't require Send + Sync implementation, eliminating thread synchronization overhead.

2. Thread-local initialization
Initialized the following global variables via `thread_local!` macro for thread safety:
    - REGISTERED_CLASSES
    - FN_REGISTER_MAP
    - THREADS_CAN_ACCESS_ENV

3. Cross-thread sharing enhancement
Refactored `ModuleClassProperty` into a struct guarded by `RwLock` to enable safe sharing between JS main thread and worker threads via `MODULE_CLASS_PROPERTIES`.

![image](https://github.com/user-attachments/assets/67851e1d-7f39-4244-ac77-e915ed3f86a8)
