### PR TITLE
perf: use None to replace noop jscb

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/either.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/either.rs
@@ -190,7 +190,7 @@ fn silence_rejected_promise(env: sys::napi_env, promise: sys::napi_value) -> cra
       env,
       c"catch".as_ptr().cast(),
       5,
-      Some(noop),
+      None,
       std::ptr::null_mut(),
       &mut catch_noop_callback,
     )
@@ -206,8 +206,4 @@ fn silence_rejected_promise(env: sys::napi_env, promise: sys::napi_value) -> cra
     )
   })?;
   Ok(())
-}
-
-unsafe extern "C" fn noop(_env: sys::napi_env, _info: sys::napi_callback_info) -> sys::napi_value {
-  std::ptr::null_mut()
 }


### PR DESCRIPTION
Remove unnecessary noop function execution.

![image](https://github.com/user-attachments/assets/3faf5df0-1185-464f-8cf8-06ecdb4b64f0)