### PR TITLE
feat(napi): support setting `error_status` of `ThreadsafeFunctionBuilder`

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/function.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/function.rs
@@ -217,22 +217,6 @@ impl<Args: JsValuesTupleIntoVec, Return> Function<'_, Args, Return> {
       _return: std::marker::PhantomData,
     }
   }
-
-  #[cfg(feature = "napi4")]
-  /// Create a threadsafe function from the JavaScript function.
-  pub fn build_threadsafe_function_with_status<
-    T: 'static,
-    ErrorStatus: AsRef<str> + From<Status>,
-  >(
-    &self,
-  ) -> ThreadsafeFunctionBuilder<T, Args, Return, ErrorStatus> {
-    ThreadsafeFunctionBuilder {
-      env: self.env,
-      value: self.value,
-      _args: std::marker::PhantomData,
-      _return: std::marker::PhantomData,
-    }
-  }
 }
 
 impl<Args: JsValuesTupleIntoVec, Return: FromNapiValue> Function<'_, Args, Return> {
@@ -350,6 +334,26 @@ impl<
   >
   ThreadsafeFunctionBuilder<'env, T, Args, Return, ErrorStatus, CalleeHandled, Weak, MaxQueueSize>
 {
+  pub fn error_status<NewErrorStatus: AsRef<str> + From<Status>>(
+    self,
+  ) -> ThreadsafeFunctionBuilder<
+    'env,
+    T,
+    Args,
+    Return,
+    NewErrorStatus,
+    CalleeHandled,
+    Weak,
+    MaxQueueSize,
+  > {
+    ThreadsafeFunctionBuilder {
+      env: self.env,
+      value: self.value,
+      _args: std::marker::PhantomData,
+      _return: std::marker::PhantomData,
+    }
+  }
+
   pub fn weak<const NewWeak: bool>(
     self,
   ) -> ThreadsafeFunctionBuilder<

--- a/crates/napi/src/threadsafe_function.rs
+++ b/crates/napi/src/threadsafe_function.rs
@@ -179,7 +179,7 @@ unsafe impl<
     T: 'static,
     Return: FromNapiValue,
     CallJsBackArgs: 'static + JsValuesTupleIntoVec,
-    ErrorStatus: AsRef<str>,
+    ErrorStatus: AsRef<str> + From<Status>,
     const CalleeHandled: bool,
     const Weak: bool,
     const MaxQueueSize: usize,
@@ -193,8 +193,6 @@ unsafe impl<
     { Weak },
     { MaxQueueSize },
   >
-where
-  ErrorStatus: From<Status>,
 {
 }
 

--- a/examples/napi/src/threadsafe_function.rs
+++ b/examples/napi/src/threadsafe_function.rs
@@ -82,7 +82,8 @@ pub fn threadsafe_function_throw_error_with_status(
 #[napi]
 pub fn threadsafe_function_build_throw_error_with_status(cb: Function<'static>) -> Result<()> {
   let tsfn = cb
-    .build_threadsafe_function_with_status::<_, ErrorStatus>()
+    .build_threadsafe_function()
+    .error_status::<ErrorStatus>()
     .callee_handled::<true>()
     .build()?;
   thread::spawn(move || {


### PR DESCRIPTION
Continue on the comment of https://github.com/napi-rs/napi-rs/pull/2694
Related comment: https://github.com/napi-rs/napi-rs/pull/2694#issuecomment-2944864476

Reverted https://github.com/napi-rs/napi-rs/pull/2694. Won't consider this as a breaking change either, since we've removed the old implementation and the old one haven't been released yet.