### PR TITLE
fix: (wasm-runtime) fs race condition

### DIFF
--- a/wasm-runtime/fs-proxy.cjs
+++ b/wasm-runtime/fs-proxy.cjs
@@ -152,20 +152,20 @@ module.exports.createOnMessage = (fs) => function onMessage(e) {
     const fn = fs[type]
     try {
       const ret = fn.apply(fs, payload)
-      Atomics.store(sab, 0, 0)
       const t = getType(ret)
       Atomics.store(sab, 1, t)
       const v = encodeValue(fs, ret, t)
       Atomics.store(sab, 2, v.length)
       new Uint8Array(sab.buffer).set(v, 16)
+      Atomics.store(sab, 0, 0) // success
 
     } catch (/** @type {any} */ err) {
-      Atomics.store(sab, 0, 1)
       const t = getType(err)
       Atomics.store(sab, 1, t)
       const v = encodeValue(fs, err, t)
       Atomics.store(sab, 2, v.length)
       new Uint8Array(sab.buffer).set(v, 16)
+      Atomics.store(sab, 0, 1) // error
     } finally {
       Atomics.notify(sab, 0)
     }


### PR DESCRIPTION
the `encodeValue` is expensive, and it seems Chrome may do out-of-order execution, causing the Worker fails to get the length and content.

The `Atomics.store` blocks any other read or write operation against the array.
Updating the status code after writing data might be feasible. 

POC: https://stackblitz.com/edit/stackblitz-starters-nmf8pm43