### PR TITLE
fix: wasm url

### DIFF
--- a/cli/src/api/templates/load-wasi-template.ts
+++ b/cli/src/api/templates/load-wasi-template.ts
@@ -40,9 +40,9 @@ const __wasi = new __WASI({
   WASI as __WASI,
 } from '@napi-rs/wasm-runtime'
 ${fsImport}
-import __wasmUrl from './${wasiFilename}.wasm?url'
 ${wasiCreation}
 
+const __wasmUrl = new URL('./${wasiFilename}.wasm', import.meta.url).href
 const __emnapiContext = __emnapiGetDefaultContext()
 
 const __sharedMemory = new WebAssembly.Memory({

--- a/examples/napi/example.wasi-browser.js
+++ b/examples/napi/example.wasi-browser.js
@@ -5,7 +5,6 @@ import {
   WASI as __WASI,
 } from '@napi-rs/wasm-runtime'
 import { memfs } from '@napi-rs/wasm-runtime/fs'
-import __wasmUrl from './example.wasm32-wasi.wasm?url'
 
 export const { fs: __fs, vol: __volume } = memfs()
 
@@ -17,6 +16,7 @@ const __wasi = new __WASI({
   },
 })
 
+const __wasmUrl = new URL('./example.wasm32-wasi.wasm', import.meta.url).href
 const __emnapiContext = __emnapiGetDefaultContext()
 
 const __sharedMemory = new WebAssembly.Memory({


### PR DESCRIPTION
Use standard `new URL`, instead of import statement.

See also https://vite.dev/guide/assets.html#new-url-url-import-meta-url