### PR TITLE
feat(wasm-runtime): never refer handles of workers 

### DIFF
--- a/cli/src/api/templates/load-wasi-template.ts
+++ b/cli/src/api/templates/load-wasi-template.ts
@@ -160,6 +160,29 @@ const { instance: __napiInstance, module: __wasiModule, napiModule: __napiModule
     worker.onmessage = ({ data }) => {
       __wasmCreateOnMessageForFsProxy(__nodeFs)(data)
     }
+
+    // The main thread of Node.js waits for all the active handles before exiting.
+    // But Rust threads are never waited without \`thread::join\`.
+    // So here we hack the code of Node.js to prevent the workers from being referenced (active).
+    // According to https://github.com/nodejs/node/blob/19e0d472728c79d418b74bddff588bea70a403d0/lib/internal/worker.js#L415,
+    // a worker is consist of two handles: kPublicPort and kHandle.
+    {
+      const kPublicPort = Object.getOwnPropertySymbols(worker).find(s =>
+        s.toString().includes("kPublicPort")
+      );
+      if (kPublicPort) {
+        worker[kPublicPort].ref = () => {};
+      }
+
+      const kHandle = Object.getOwnPropertySymbols(worker).find(s =>
+        s.toString().includes("kHandle")
+      );
+      if (kPublicPort) {
+        worker[kHandle].ref = () => {};
+      }
+
+      worker.unref();
+    }
     return worker
   },
   overwriteImports(importObject) {


### PR DESCRIPTION
Native thread never waits for others without `join`, but Node.js main thread will be stuck if there's any referred worker. Workers are auto referred when listeners are attached, which is very hard to control. So this pr uses a hacky way to align the behaviors between native threads and Node.js workers.  Noted that Rspack has used this hack for a while.

I think many problems with hangs in the wasm target can be solved with this pr.
1. There's no need to shutdown tokio runtime manually. When the Node.js main thread quits, all the workers are released.
2. The thread pool of rayon can exit like that in native addon. Normally rayon threads run and steal works until the main thread exits. However, if the workers are referred by Node.js main thread, they will prevent the main thread exiting forever. I notice that rolldown contains `rayon` shims for wasm, they could be removed later if they are used for preventing the hang. 