### PR TITLE
perf(napi): Use linkme instead of ctor for module register

### DIFF
--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -152,18 +152,15 @@ pub fn module_exports(_attr: TokenStream, input: TokenStream) -> TokenStream {
   };
 
   let register = quote! {
-    #[cfg_attr(not(target_family = "wasm"), napi::ctor::ctor(crate_path=napi::ctor))]
-    fn __napi_explicit_module_register() {
-      unsafe fn register(raw_env: napi::sys::napi_env, raw_exports: napi::sys::napi_value) -> napi::Result<()> {
-        use napi::{Env, JsObject, NapiValue};
+    #[cfg_attr(not(target_family = "wasm"), napi::linkme::distributed_slice(napi::bindgen_prelude::MODULE_EXPORTS_LINKME))]
+    #[cfg_attr(not(target_family = "wasm"), linkme(crate = napi::linkme))]
+    unsafe fn register(raw_env: napi::sys::napi_env, raw_exports: napi::sys::napi_value) -> napi::Result<()> {
+      use napi::{Env, JsObject, NapiValue};
 
-        let env = Env::from_raw(raw_env);
-        let exports = JsObject::from_raw_unchecked(raw_env, raw_exports);
+      let env = Env::from_raw(raw_env);
+      let exports = JsObject::from_raw_unchecked(raw_env, raw_exports);
 
-        #call_expr
-      }
-
-      napi::bindgen_prelude::register_module_exports(register)
+      #call_expr
     }
   };
 

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -72,6 +72,7 @@ node_version_detect = []
 [dependencies]
 bitflags = "2"
 ctor = "0.4.1"
+linkme = "0.3"
 nohash-hasher = "0.2.0"
 rustc-hash = "2.1.1"
 

--- a/crates/napi/src/bindgen_runtime/module_register.rs
+++ b/crates/napi/src/bindgen_runtime/module_register.rs
@@ -142,6 +142,14 @@ fn wait_first_thread_registered() {
 #[linkme::distributed_slice]
 pub static MODULE_EXPORTS_LINKME: [ModuleExportsCallback];
 
+#[cfg(all(feature = "compat-mode", not(feature = "noop")))]
+#[linkme::distributed_slice(MODULE_EXPORTS_LINKME)]
+unsafe fn noop_linkme(_env: sys::napi_env, _exports: sys::napi_value) -> Result<()> {
+  // nothing
+
+  Ok(())
+}
+
 #[doc(hidden)]
 #[cfg(all(feature = "compat-mode", not(feature = "noop")))]
 // compatibility for #[module_exports]

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -153,7 +153,7 @@ macro_rules! assert_type_of {
 
 pub mod bindgen_prelude {
   #[cfg(all(feature = "compat-mode", not(feature = "noop")))]
-  pub use crate::bindgen_runtime::register_module_exports;
+  pub use crate::bindgen_runtime::{ register_module_exports, MODULE_EXPORTS_LINKME };
   #[cfg(feature = "tokio_rt")]
   pub use crate::tokio_runtime::*;
   pub use crate::{
@@ -214,6 +214,7 @@ pub mod __private {
 }
 
 pub extern crate ctor;
+pub extern crate linkme;
 
 #[cfg(feature = "tokio_rt")]
 pub extern crate tokio;

--- a/examples/napi-compat-mode/Cargo.toml
+++ b/examples/napi-compat-mode/Cargo.toml
@@ -20,6 +20,7 @@ napi = { path = "../../crates/napi", features = [
   "serde-json",
   "latin1",
   "compat-mode",
+  "napi5",
 ] }
 napi-derive = { path = "../../crates/macro", features = ["compat-mode"] }
 serde = "1"


### PR DESCRIPTION
This is a draft that attempts to use linkme instead of ctor for module register.

It has several advantages
1. Faster, the module exports list is determined at compile time and does not need to be created by ctor at startup
2. Smaller, which avoids create a lot of ctor functions
3. Safer, the execution order of ctor is hard to determine, and many regular codes cannot run in it, which is why it is required to be unsafe.

The problem with linkme is that it doesn't support wasm, but that doesn't seem to affect us.

I also keep old ctor style interface so that old versions of napi-macro can still be used.