### PR TITLE
feat(cli): add `buffer` to wasi browser template

### DIFF
--- a/cli/src/api/build.ts
+++ b/cli/src/api/build.ts
@@ -1056,6 +1056,7 @@ export type TypedArray = Int8Array | Uint8Array | Uint8ClampedArray | Int16Array
           this.config.wasm?.maximumMemory,
           this.config.wasm?.browser?.fs,
           this.config.wasm?.browser?.asyncInit,
+          this.config.wasm?.browser?.buffer,
         ) +
           `export default __napiModule.exports\n` +
           idents

--- a/cli/src/utils/config.ts
+++ b/cli/src/utils/config.ts
@@ -79,6 +79,10 @@ export interface UserNapiConfig {
        * Whether to initialize wasm asynchronously
        */
       asyncInit?: boolean
+      /**
+       * Whether to inject `buffer` to emnapi context
+       */
+      buffer?: boolean
     }
   }
 


### PR DESCRIPTION
From https://emnapi-docs.vercel.app/reference/list.html#buffer-related we should the Buffer polyfill is needed in browser for Buffer related api.

I'm not sure whether bundle `buffer` to `@napi-rs/wasm-runtime` is a better choice.