### PR TITLE
refactor(cli): reuse buffer in `@napi-fs/wasm-time/fs`

### DIFF
--- a/cli/src/api/templates/load-wasi-template.ts
+++ b/cli/src/api/templates/load-wasi-template.ts
@@ -6,12 +6,12 @@ export const createWasiBrowserBinding = (
   asyncInit = false,
   buffer = false,
 ) => {
-  const fsImport = fs ? `import { memfs } from '@napi-rs/wasm-runtime/fs'` : ''
-  const bufferImport = buffer
-    ? fs
-      ? ``
-      : `import { Buffer } from 'buffer'`
+  const fsImport = fs
+    ? buffer
+      ? `import { memfs, Buffer } from '@napi-rs/wasm-runtime/fs'`
+      : `import { memfs } from '@napi-rs/wasm-runtime/fs'`
     : ''
+  const bufferImport = buffer && !fs ? `import { Buffer } from 'buffer'` : ''
   const wasiCreation = fs
     ? `
 export const { fs: __fs, vol: __volume } = memfs()

--- a/wasm-runtime/fs.js
+++ b/wasm-runtime/fs.js
@@ -1,5 +1,6 @@
 import * as memfsExported from 'memfs'
+import { Buffer } from 'buffer'
 
 const { createFsFromVolume, Volume, fs, memfs } = memfsExported
 
-export { createFsFromVolume, Volume, fs, memfs, memfsExported }
+export { createFsFromVolume, Volume, fs, memfs, memfsExported, Buffer }


### PR DESCRIPTION
I think the buffer import is needed because there's no guarantee that the buffer injection is always before init the emnapiContext.

Here could be a better way to reuse the `Buffer` in `@napi-rs/wasm-time/fs`.