### PR TITLE
feat: remove NapiRaw and NapiValue cfg and add implement for Object

### DIFF
--- a/crates/napi/src/js_values/mod.rs
+++ b/crates/napi/src/js_values/mod.rs
@@ -677,13 +677,11 @@ macro_rules! impl_object_methods {
   };
 }
 
-#[cfg(feature = "compat-mode")]
 pub trait NapiRaw {
   #[allow(clippy::missing_safety_doc)]
   unsafe fn raw(&self) -> sys::napi_value;
 }
 
-#[cfg(feature = "compat-mode")]
 pub trait NapiValue: Sized + NapiRaw {
   #[allow(clippy::missing_safety_doc)]
   unsafe fn from_raw(env: sys::napi_env, value: sys::napi_value) -> Result<Self>;

--- a/examples/napi-compat-mode/src/napi4/tsfn.rs
+++ b/examples/napi-compat-mode/src/napi4/tsfn.rs
@@ -90,12 +90,7 @@ pub fn test_tsfn_with_ref(ctx: CallContext) -> Result<()> {
   let tsfn = callback
     .build_threadsafe_function::<Ref<Object>>()
     .callee_handled::<true>()
-    .build_callback(move |mut ctx| {
-      ctx
-        .env
-        .get_reference_value_unchecked::<Object>(&ctx.value)
-        .and_then(|obj| ctx.value.unref(&ctx.env).map(|_| obj))
-    })?;
+    .build_callback(move |ctx| Ref::get_value(&ctx.value, &ctx.env))?;
 
   thread::spawn(move || {
     tsfn.call(option_ref, ThreadsafeFunctionCallMode::Blocking);

--- a/examples/napi-compat-mode/src/napi4/tsfn_dua_instance.rs
+++ b/examples/napi-compat-mode/src/napi4/tsfn_dua_instance.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use napi::{
-  bindgen_prelude::Function, threadsafe_function::ThreadsafeFunction, CallContext, JsObject, Status,
+  bindgen_prelude::{Function, JsObjectValue, Object},
+  threadsafe_function::ThreadsafeFunction,
+  CallContext, Status,
 };
 use napi_derive::js_function;
 
@@ -21,17 +23,17 @@ pub fn constructor(ctx: CallContext) -> napi::Result<()> {
       .build()?,
   );
 
-  let mut this: JsObject = ctx.this_unchecked();
+  let mut this = ctx.this_unchecked::<Object<'_>>();
   let obj = A { cb };
 
-  ctx.env.wrap(&mut this, obj, None)?;
+  this.wrap(obj, None)?;
   Ok(())
 }
 
 #[js_function]
 pub fn call(ctx: CallContext) -> napi::Result<()> {
-  let this = ctx.this_unchecked();
-  let obj = ctx.env.unwrap::<A>(&this)?;
+  let this = ctx.this_unchecked::<Object<'_>>();
+  let obj = this.unwrap::<A>()?;
   obj.cb.call(
     "ThreadsafeFunction NonBlocking Call".to_owned(),
     napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,


### PR DESCRIPTION
Allow Object to implement the `NapiRaw` and `NapiValue` can help us to remove `JsObject` which is marked as `deprecated`