### PR TITLE
test: panic on throw in callback of threadsafe function with CalleeHandled=false

### DIFF
--- a/examples/napi/__tests__/values.spec.ts
+++ b/examples/napi/__tests__/values.spec.ts
@@ -92,6 +92,7 @@ import {
   tsfnCallWithCallback,
   tsfnAsyncCall,
   tsfnThrowFromJs,
+  tsfnThrowFromJs2,
   asyncPlus100,
   getGlobal,
   getUndefined,
@@ -1569,6 +1570,16 @@ test('Throw from ThreadsafeFunction JavaScript callback', async (t) => {
       }),
     {
       message: errMsg,
+    },
+  )
+
+  await t.throwsAsync(
+    () =>
+      tsfnThrowFromJs2((errMsg) => {
+        throw new Error(errMsg)
+      }),
+    {
+      message: 'foo',
     },
   )
 

--- a/examples/napi/example.wasi-browser.js
+++ b/examples/napi/example.wasi-browser.js
@@ -349,6 +349,7 @@ export const tsfnInEither = __napiModule.exports.tsfnInEither
 export const tsfnReturnPromise = __napiModule.exports.tsfnReturnPromise
 export const tsfnReturnPromiseTimeout = __napiModule.exports.tsfnReturnPromiseTimeout
 export const tsfnThrowFromJs = __napiModule.exports.tsfnThrowFromJs
+export const tsfnThrowFromJs2 = __napiModule.exports.tsfnThrowFromJs2
 export const tsfnThrowFromJsCallbackContainsTsfn = __napiModule.exports.tsfnThrowFromJsCallbackContainsTsfn
 export const tsRename = __napiModule.exports.tsRename
 export const u16ArrayToArray = __napiModule.exports.u16ArrayToArray

--- a/examples/napi/example.wasi.cjs
+++ b/examples/napi/example.wasi.cjs
@@ -394,6 +394,7 @@ module.exports.tsfnInEither = __napiModule.exports.tsfnInEither
 module.exports.tsfnReturnPromise = __napiModule.exports.tsfnReturnPromise
 module.exports.tsfnReturnPromiseTimeout = __napiModule.exports.tsfnReturnPromiseTimeout
 module.exports.tsfnThrowFromJs = __napiModule.exports.tsfnThrowFromJs
+module.exports.tsfnThrowFromJs2 = __napiModule.exports.tsfnThrowFromJs2
 module.exports.tsfnThrowFromJsCallbackContainsTsfn = __napiModule.exports.tsfnThrowFromJsCallbackContainsTsfn
 module.exports.tsRename = __napiModule.exports.tsRename
 module.exports.u16ArrayToArray = __napiModule.exports.u16ArrayToArray

--- a/examples/napi/index.cjs
+++ b/examples/napi/index.cjs
@@ -679,6 +679,7 @@ module.exports.tsfnInEither = nativeBinding.tsfnInEither
 module.exports.tsfnReturnPromise = nativeBinding.tsfnReturnPromise
 module.exports.tsfnReturnPromiseTimeout = nativeBinding.tsfnReturnPromiseTimeout
 module.exports.tsfnThrowFromJs = nativeBinding.tsfnThrowFromJs
+module.exports.tsfnThrowFromJs2 = nativeBinding.tsfnThrowFromJs2
 module.exports.tsfnThrowFromJsCallbackContainsTsfn = nativeBinding.tsfnThrowFromJsCallbackContainsTsfn
 module.exports.tsRename = nativeBinding.tsRename
 module.exports.u16ArrayToArray = nativeBinding.u16ArrayToArray

--- a/examples/napi/index.d.cts
+++ b/examples/napi/index.d.cts
@@ -959,6 +959,8 @@ export declare function tsfnReturnPromiseTimeout(func: ((err: Error | null, arg:
 
 export declare function tsfnThrowFromJs(tsfn: ((err: Error | null, arg: number) => Promise<number>)): Promise<number>
 
+export declare function tsfnThrowFromJs2(tsfn: ((arg0: string) => void)): Promise<void>
+
 export declare function tsfnThrowFromJsCallbackContainsTsfn(tsfn: ((err: Error | null, arg: number) => Promise<number>)): Promise<void>
 
 export declare function tsRename(a: { foo: number }): string[]

--- a/examples/napi/src/threadsafe_function.rs
+++ b/examples/napi/src/threadsafe_function.rs
@@ -247,6 +247,13 @@ pub async fn tsfn_throw_from_js(tsfn: ThreadsafeFunction<u32, Promise<u32>>) -> 
 }
 
 #[napi]
+pub async fn tsfn_throw_from_js2(
+  tsfn: ThreadsafeFunction<FnArgs<(String,)>, (), FnArgs<(String,)>, Status, false>,
+) -> napi::Result<()> {
+  tsfn.call_async(("foo".to_string(),).into()).await
+}
+
+#[napi]
 pub async fn tsfn_throw_from_js_callback_contains_tsfn(
   tsfn: ThreadsafeFunction<u32, Promise<u32>>,
 ) {


### PR DESCRIPTION
This test crashes with `fatal runtime error: failed to initiate panic, error 5`.
Is this expected?

The documents does not say whether it is unsafe to throw inside the callback.
https://napi.rs/docs/concepts/threadsafe-function.en#errorstrategy
