### PR TITLE
refactor: replace `lodash-es` with `es-toolkit`

### DIFF
--- a/cli/codegen/index.ts
+++ b/cli/codegen/index.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { kebabCase, startCase } from 'lodash-es'
+import { kebabCase, startCase } from 'es-toolkit'
 
 import { commandDefines, CommandSchema, OptionSchema } from './commands.js'
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -67,9 +67,9 @@
     "colorette": "^2.0.20",
     "debug": "^4.4.0",
     "emnapi": "^1.4.0",
+    "es-toolkit": "^1.39.8",
     "find-up": "^7.0.0",
     "js-yaml": "^4.1.0",
-    "lodash-es": "^4.17.21",
     "semver": "^7.7.1",
     "typanion": "^3.14.0"
   },
@@ -81,7 +81,6 @@
     "@types/debug": "^4.1.12",
     "@types/inquirer": "^9.0.7",
     "@types/js-yaml": "^4.0.9",
-    "@types/lodash-es": "^4.17.12",
     "@types/node": "^22.13.16",
     "@types/semver": "^7.7.0",
     "ava": "^6.2.0",

--- a/cli/src/api/rename.ts
+++ b/cli/src/api/rename.ts
@@ -4,7 +4,7 @@ import { resolve, join } from 'node:path'
 
 import { parse as parseToml, stringify as stringifyToml } from '@std/toml'
 import { load as yamlParse, dump as yamlStringify } from 'js-yaml'
-import { isNil, merge, omitBy, pick } from 'lodash-es'
+import { isNil, merge, omitBy, pick } from 'es-toolkit'
 import { findUp } from 'find-up'
 
 import { applyDefaultRenameOptions, RenameOptions } from '../def/rename.js'
@@ -22,8 +22,14 @@ export async function renameProject(userOptions: RenameOptions) {
   const packageJsonData = JSON.parse(packageJsonContent)
 
   merge(
-    packageJsonData,
-    omitBy(pick(options, ['name', 'description', 'author', 'license']), isNil),
+    merge(
+      packageJsonData,
+      // @ts-expect-error missing fields: author and license
+      omitBy(
+        pick(options, ['name', 'description', 'author', 'license']),
+        isNil,
+      ),
+    ),
     {
       napi: omitBy(
         {

--- a/cli/src/api/rename.ts
+++ b/cli/src/api/rename.ts
@@ -24,8 +24,8 @@ export async function renameProject(userOptions: RenameOptions) {
   merge(
     merge(
       packageJsonData,
-      // @ts-expect-error missing fields: author and license
       omitBy(
+        // @ts-expect-error missing fields: author and license
         pick(options, ['name', 'description', 'author', 'license']),
         isNil,
       ),

--- a/cli/src/utils/config.ts
+++ b/cli/src/utils/config.ts
@@ -1,5 +1,5 @@
 import { underline, yellow } from 'colorette'
-import { merge, omit } from 'lodash-es'
+import { merge, omit } from 'es-toolkit'
 
 import { fileExists, readFileAsync } from './misc.js'
 import { DEFAULT_TARGETS, parseTriple, Target } from './target.js'
@@ -208,7 +208,7 @@ export async function readNapiConfig(
       packageJson: pkgJson,
       npmClient: 'npm',
     },
-    omit(userNapiConfig, 'targets'),
+    omit(userNapiConfig, ['targets']),
   )
 
   let targets: string[] = userNapiConfig.targets ?? []

--- a/cli/src/utils/typegen.ts
+++ b/cli/src/utils/typegen.ts
@@ -1,4 +1,4 @@
-import { sortBy } from 'lodash-es'
+import { sortBy } from 'es-toolkit'
 
 import { readFileAsync } from './misc.js'
 
@@ -94,7 +94,7 @@ export async function processTypeDef(
   const groupedDefs = preprocessTypeDef(defs)
 
   const dts =
-    sortBy(Array.from(groupedDefs), ([namespace]) => namespace)
+    sortBy(Array.from(groupedDefs), [([namespace]) => namespace])
       .map(([namespace, defs]) => {
         if (namespace === TOP_LEVEL_NAMESPACE) {
           return defs

--- a/cli/tsdown.config.ts
+++ b/cli/tsdown.config.ts
@@ -9,7 +9,7 @@ export default defineConfig([
     sourcemap: 'inline',
     inputOptions(options, format) {
       if (format === 'cjs') {
-        options.external = ['@octokit/rest', 'lodash-es']
+        options.external = ['@octokit/rest']
       }
       return options
     },

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "@oxc-node/core": "^0.0.32",
     "@taplo/cli": "^0.7.0",
     "@types/debug": "^4.1.12",
-    "@types/lodash-es": "^4.17.12",
     "@types/node": "^22.13.16",
     "@types/sinon": "^17.0.4",
     "ava": "^6.2.0",

--- a/triples/generate-triple-list.ts
+++ b/triples/generate-triple-list.ts
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync } from 'fs'
 import { join, resolve } from 'path'
 import { fileURLToPath } from 'url'
 
-import { groupBy, mapValues } from 'lodash-es'
+import { groupBy, mapValues } from 'es-toolkit'
 
 import { parseTriple } from '@napi-rs/cli'
 
@@ -19,11 +19,11 @@ const SUPPORTED_PLATFORM = new Set([
   'freebsd',
 ])
 
-const tripleLists: { [key: string]: { platform?: string } } = RAW_LIST.trim()
+const tripleLists = RAW_LIST.trim()
   .split('\n')
   .filter((line) => !line.startsWith('wasm') && line.trim().length > 0)
   .map(parseTriple)
-  .reduce((acc: Record<string, { platform?: string }>, cur) => {
+  .reduce((acc: Record<string, { platform: string; arch: string }>, cur) => {
     acc[cur.triple] = cur
     return acc
   }, {})
@@ -31,11 +31,11 @@ const tripleLists: { [key: string]: { platform?: string } } = RAW_LIST.trim()
 const platformArchTriples = mapValues(
   groupBy(
     Object.values(tripleLists).filter((k) =>
-      SUPPORTED_PLATFORM.has(k.platform!),
+      SUPPORTED_PLATFORM.has(k.platform),
     ),
-    'platform',
+    (x) => x.platform,
   ),
-  (v) => groupBy(v, 'arch'),
+  (v) => groupBy(v, (v) => v.arch),
 )
 
 const mjsContent = `

--- a/triples/package.json
+++ b/triples/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@napi-rs/cli": "workspace:*",
     "@types/node": "^22.13.16",
-    "lodash-es": "^4.17.21",
+    "es-toolkit": "^1.39.8",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -871,7 +871,6 @@ __metadata:
     "@types/debug": "npm:^4.1.12"
     "@types/inquirer": "npm:^9.0.7"
     "@types/js-yaml": "npm:^4.0.9"
-    "@types/lodash-es": "npm:^4.17.12"
     "@types/node": "npm:^22.13.16"
     "@types/semver": "npm:^7.7.0"
     ava: "npm:^6.2.0"
@@ -880,9 +879,9 @@ __metadata:
     debug: "npm:^4.4.0"
     emnapi: "npm:^1.4.0"
     env-paths: "npm:^3.0.0"
+    es-toolkit: "npm:^1.39.8"
     find-up: "npm:^7.0.0"
     js-yaml: "npm:^4.1.0"
-    lodash-es: "npm:^4.17.21"
     prettier: "npm:^3.5.3"
     semver: "npm:^7.7.1"
     tsdown: "npm:^0.14.0"
@@ -1292,7 +1291,7 @@ __metadata:
   dependencies:
     "@napi-rs/cli": "workspace:*"
     "@types/node": "npm:^22.13.16"
-    lodash-es: "npm:^4.17.21"
+    es-toolkit: "npm:^1.39.8"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.8.2"
   languageName: unknown
@@ -3145,16 +3144,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash-es@npm:^4.17.12":
-  version: 4.17.12
-  resolution: "@types/lodash-es@npm:4.17.12"
-  dependencies:
-    "@types/lodash": "npm:*"
-  checksum: 10c0/5d12d2cede07f07ab067541371ed1b838a33edb3c35cb81b73284e93c6fd0c4bbeaefee984e69294bffb53f62d7272c5d679fdba8e595ff71e11d00f2601dde0
-  languageName: node
-  linkType: hard
-
-"@types/lodash@npm:*, @types/lodash@npm:^4.17.16":
+"@types/lodash@npm:^4.17.16":
   version: 4.17.20
   resolution: "@types/lodash@npm:4.17.20"
   checksum: 10c0/98cdd0faae22cbb8079a01a3bb65aa8f8c41143367486c1cbf5adc83f16c9272a2a5d2c1f541f61d0d73da543c16ee1d21cf2ef86cb93cd0cc0ac3bced6dd88f
@@ -6067,6 +6057,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-toolkit@npm:^1.39.8":
+  version: 1.39.8
+  resolution: "es-toolkit@npm:1.39.8"
+  dependenciesMeta:
+    "@trivago/prettier-plugin-sort-imports@4.3.0":
+      unplugged: true
+    prettier-plugin-sort-re-exports@0.0.1:
+      unplugged: true
+  checksum: 10c0/a13f50433959ae784d9eef467c7a3883f28bd40c651d6f62a11c93a0b7460b070a72a8c9c8d4423039d5d441a777cf2b9850113d9b3d04d1f65a79dccec04f31
+  languageName: node
+  linkType: hard
+
 "es6-error@npm:^4.1.1":
   version: 4.1.1
   resolution: "es6-error@npm:4.1.1"
@@ -8394,13 +8396,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:^4.17.21":
-  version: 4.17.21
-  resolution: "lodash-es@npm:4.17.21"
-  checksum: 10c0/fb407355f7e6cd523a9383e76e6b455321f0f153a6c9625e21a8827d10c54c2a2341bd2ae8d034358b60e07325e1330c14c224ff582d04612a46a4f0479ff2f2
-  languageName: node
-  linkType: hard
-
 "lodash.camelcase@npm:^4.3.0":
   version: 4.3.0
   resolution: "lodash.camelcase@npm:4.3.0"
@@ -9134,7 +9129,6 @@ __metadata:
     "@oxc-node/core": "npm:^0.0.32"
     "@taplo/cli": "npm:^0.7.0"
     "@types/debug": "npm:^4.1.12"
-    "@types/lodash-es": "npm:^4.17.12"
     "@types/node": "npm:^22.13.16"
     "@types/sinon": "npm:^17.0.4"
     ava: "npm:^6.2.0"


### PR DESCRIPTION
Merge #2860 first

[`es-toolkit`](https://es-toolkit.dev/) is a modern alternative to `lodash`, offering dual module format support and a significantly smaller bundle size.