### PR TITLE
fix(triples): include index.cjs in package files for proper CJS support

### DIFF
--- a/triples/package.json
+++ b/triples/package.json
@@ -34,6 +34,7 @@
   },
   "files": [
     "index.js",
+    "index.cjs",
     "index.d.ts"
   ],
   "repository": {


### PR DESCRIPTION
The ‎`"exports"` field exposes ‎`index.cjs` for CommonJS consumers, but the file was missing from the ‎`"files"` array. As a result, ‎`index.cjs` would not be published to npm, causing ‎`require()` imports to fail.