### PR TITLE
chore: show NAPI options on new command

### DIFF
--- a/cli/src/commands/new.ts
+++ b/cli/src/commands/new.ts
@@ -76,6 +76,7 @@ export class NewCommand extends BaseNewCommand {
     return select({
       message: 'Minimum node-api version (with node version requirement)',
       loop: false,
+      pageSize: 10,
       choices: Array.from({ length: 8 }, (_, i) => ({
         name: `napi${i + 1} (${napiEngineRequirement(i + 1)})`,
         value: i + 1,

--- a/crates/napi/src/bindgen_runtime/js_values/promise.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/promise.rs
@@ -16,7 +16,7 @@ use super::{CallbackContext, FromNapiValue, PromiseRaw, TypeName, Unknown, Valid
 /// The JavaScript Promise object representation
 ///
 /// This `Promise<T>` can be awaited in the Rust
-/// THis `Promise<T>` can also be passed from `#[napi]` fn
+/// This `Promise<T>` can also be passed from `#[napi]` fn
 ///
 /// example:
 ///


### PR DESCRIPTION
- Fix typo "THis" → "This" in promise.rs documentation
- Add pageSize option to NAPI version selection in CLI new command

Before

```bash
? Minimum node-api version (with node version requirement)
  napi1 (>= 8.6.0 < 9 || >= 9.0.0 < 10 || >= 10.0.0)
  napi2 (>= 8.10.0 < 9 || >= 9.3.0 < 10 || >= 10.0.0)
❯ napi3 (>= 6.14.2 < 7 || >= 8.11.2 < 9 || >= 9.11.0 < 10 || >= 10.0.0)
  napi4 (>= 10.16.0 < 11 || >= 11.8.0 < 12 || >= 12.0.0)
  napi5 (>= 10.17.0 < 11 || >= 12.11.0 < 13 || >= 13.0.0)
  napi6 (>= 10.20.0 < 11 || >= 12.17.0 < 13 || >= 14.0.0)
  napi7 (>= 10.23.0 < 11 || >= 12.19.0 < 13 || >= 14.12.0 < 15 || >= 15.0.0)
```

After

```bash
? Minimum node-api version (with node version requirement)
  napi1 (>= 8.6.0 < 9 || >= 9.0.0 < 10 || >= 10.0.0)
  napi2 (>= 8.10.0 < 9 || >= 9.3.0 < 10 || >= 10.0.0)
❯ napi3 (>= 6.14.2 < 7 || >= 8.11.2 < 9 || >= 9.11.0 < 10 || >= 10.0.0)
  napi4 (>= 10.16.0 < 11 || >= 11.8.0 < 12 || >= 12.0.0)
  napi5 (>= 10.17.0 < 11 || >= 12.11.0 < 13 || >= 13.0.0)
  napi6 (>= 10.20.0 < 11 || >= 12.17.0 < 13 || >= 14.0.0)
  napi7 (>= 10.23.0 < 11 || >= 12.19.0 < 13 || >= 14.12.0 < 15 || >= 15.0.0)
  napi8 (>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0)
```

🤖 Generated with [Claude Code](https://claude.ai/code)