### PR TITLE
fix(build): export `emnapi_thread_crashed`

### DIFF
--- a/crates/build/src/wasi.rs
+++ b/crates/build/src/wasi.rs
@@ -12,6 +12,7 @@ pub fn setup() {
   println!("cargo:rustc-link-arg=--export-table");
   println!("cargo:rustc-link-arg=--export=emnapi_async_worker_create");
   println!("cargo:rustc-link-arg=--export=emnapi_async_worker_init");
+  println!("cargo:rustc-link-arg=--export=emnapi_thread_crashed");
   println!("cargo:rustc-link-arg=--import-memory");
   println!("cargo:rustc-link-arg=--import-undefined");
   println!("cargo:rustc-link-arg=--max-memory=4294967296");


### PR DESCRIPTION
emnapi 1.5.0 allows calling wasi-libc's blocking calls in browser main thread (will work in rust 1.90.0 according to https://github.com/toyobayashi/emnapi/issues/159#issuecomment-3175658724).

More context:

- https://github.com/toyobayashi/emnapi/issues/159
- https://github.com/toyobayashi/emnapi/pull/160
- https://github.com/napi-rs/napi-rs/issues/2809#issuecomment-3163916783