### PR TITLE
chore(wasm-runtime): update @tybys/wasm-util in order to avoid runtime error with access to process.env.NODE_DEBUG_NATIVE

### DIFF
--- a/wasm-runtime/package.json
+++ b/wasm-runtime/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@emnapi/core": "^1.5.0",
     "@emnapi/runtime": "^1.5.0",
-    "@tybys/wasm-util": "^0.10.0"
+    "@tybys/wasm-util": "^0.10.1"
   },
   "scripts": {
     "build": "rollup -c rollup.config.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1363,7 +1363,7 @@ __metadata:
     "@rollup/plugin-json": "npm:^6.1.0"
     "@rollup/plugin-node-resolve": "npm:^16.0.1"
     "@rollup/plugin-replace": "npm:^6.0.2"
-    "@tybys/wasm-util": "npm:^0.10.0"
+    "@tybys/wasm-util": "npm:^0.10.1"
     buffer: "npm:^6.0.3"
     memfs: "npm:^4.39.0"
     node-inspect-extracted: "npm:^3.2.1"
@@ -3036,12 +3036,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tybys/wasm-util@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "@tybys/wasm-util@npm:0.10.0"
+"@tybys/wasm-util@npm:^0.10.1":
+  version: 0.10.1
+  resolution: "@tybys/wasm-util@npm:0.10.1"
   dependencies:
     tslib: "npm:^2.4.0"
-  checksum: 10c0/044feba55c1e2af703aa4946139969badb183ce1a659a75ed60bc195a90e73a3f3fc53bcd643497c9954597763ddb051fec62f80962b2ca6fc716ba897dc696e
+  checksum: 10c0/b255094f293794c6d2289300c5fbcafbb5532a3aed3a5ffd2f8dc1828e639b88d75f6a376dd8f94347a44813fd7a7149d8463477a9a49525c8b2dcaa38c2d1e8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates `@tybys/wasm-util` package to the latest version 0.10.1
In this version `process.env` access were handled gracefully in order to not fail at runtime for some bundlers

See https://github.com/toyobayashi/wasm-util/issues/4 for more details

Closes https://github.com/napi-rs/napi-rs/issues/2867