### PR TITLE
chore(cli): replace find-up with empathic

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -68,8 +68,8 @@
     "colorette": "^2.0.20",
     "debug": "^4.4.1",
     "emnapi": "^1.5.0",
+    "empathic": "^2.0.0",
     "es-toolkit": "^1.39.10",
-    "find-up": "^8.0.0",
     "js-yaml": "^4.1.0",
     "semver": "^7.7.2",
     "typanion": "^3.14.0"

--- a/cli/src/api/rename.ts
+++ b/cli/src/api/rename.ts
@@ -5,7 +5,7 @@ import { resolve, join } from 'node:path'
 import { parse as parseToml, stringify as stringifyToml } from '@std/toml'
 import { load as yamlParse, dump as yamlStringify } from 'js-yaml'
 import { isNil, merge, omitBy, pick } from 'es-toolkit'
-import { findUp } from 'find-up'
+import * as find from 'empathic/find'
 
 import { applyDefaultRenameOptions, RenameOptions } from '../def/rename.js'
 import { readConfig, readFileAsync, writeFileAsync } from '../utils/index.js'
@@ -74,9 +74,8 @@ export async function renameProject(userOptions: RenameOptions) {
 
   await writeFileAsync(cargoTomlPath, updatedTomlContent)
   if (oldName !== options.binaryName) {
-    const githubActionsPath = await findUp('.github', {
+    const githubActionsPath = find.dir('.github', {
       cwd: options.cwd,
-      type: 'directory',
     })
     if (githubActionsPath) {
       const githubActionsCIYmlPath = join(

--- a/yarn.lock
+++ b/yarn.lock
@@ -910,9 +910,9 @@ __metadata:
     colorette: "npm:^2.0.20"
     debug: "npm:^4.4.1"
     emnapi: "npm:^1.5.0"
+    empathic: "npm:^2.0.0"
     env-paths: "npm:^3.0.0"
     es-toolkit: "npm:^1.39.10"
-    find-up: "npm:^8.0.0"
     js-yaml: "npm:^4.1.0"
     prettier: "npm:^3.6.2"
     semver: "npm:^7.7.2"
@@ -6576,16 +6576,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-up@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "find-up@npm:8.0.0"
-  dependencies:
-    locate-path: "npm:^8.0.0"
-    unicorn-magic: "npm:^0.3.0"
-  checksum: 10c0/4c6d2cb92f74bd42ec7344c881a46f6455010d3993f8f55b09bb64298c0a13e11e10200147624db8938590890a15ade69c40f0172698388d0999899f0f2a70a5
-  languageName: node
-  linkType: hard
-
 "flat@npm:^5.0.2":
   version: 5.0.2
   resolution: "flat@npm:5.0.2"
@@ -8388,15 +8378,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"locate-path@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "locate-path@npm:8.0.0"
-  dependencies:
-    p-locate: "npm:^6.0.0"
-  checksum: 10c0/4c837878b6d1b8557c5d1c624d11d6721d77f4627c14bd84182c85cbb9ec8fc01b5b5f089e21fab17b30fc5ecc14216a3d31f754dfcc5299f1fe9f4c83482fee
-  languageName: node
-  linkType: hard
-
 "lodash.camelcase@npm:^4.3.0":
   version: 4.3.0
   resolution: "lodash.camelcase@npm:4.3.0"
@@ -9837,15 +9818,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-limit@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "p-limit@npm:4.0.0"
-  dependencies:
-    yocto-queue: "npm:^1.0.0"
-  checksum: 10c0/a56af34a77f8df2ff61ddfb29431044557fcbcb7642d5a3233143ebba805fc7306ac1d448de724352861cb99de934bc9ab74f0d16fe6a5460bdbdf938de875ad
-  languageName: node
-  linkType: hard
-
 "p-locate@npm:^2.0.0":
   version: 2.0.0
   resolution: "p-locate@npm:2.0.0"
@@ -9870,15 +9842,6 @@ __metadata:
   dependencies:
     p-limit: "npm:^3.0.2"
   checksum: 10c0/2290d627ab7903b8b70d11d384fee714b797f6040d9278932754a6860845c4d3190603a0772a663c8cb5a7b21d1b16acb3a6487ebcafa9773094edc3dfe6009a
-  languageName: node
-  linkType: hard
-
-"p-locate@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "p-locate@npm:6.0.0"
-  dependencies:
-    p-limit: "npm:^4.0.0"
-  checksum: 10c0/d72fa2f41adce59c198270aa4d3c832536c87a1806e0f69dffb7c1a7ca998fb053915ca833d90f166a8c082d3859eabfed95f01698a3214c20df6bb8de046312
   languageName: node
   linkType: hard
 
@@ -13340,13 +13303,6 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
-  languageName: node
-  linkType: hard
-
-"yocto-queue@npm:^1.0.0":
-  version: 1.2.1
-  resolution: "yocto-queue@npm:1.2.1"
-  checksum: 10c0/5762caa3d0b421f4bdb7a1926b2ae2189fc6e4a14469258f183600028eb16db3e9e0306f46e8ebf5a52ff4b81a881f22637afefbef5399d6ad440824e9b27f9f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replace `find-up` (5 deps) with `empathic` (0 deps) for searching directories upwards. This reduces the dependencies installed for `@napi-rs/cli`

The source code for empathic's find function can be found [here](https://github.com/lukeed/empathic/blob/f5f944a06f9a411168a0073c3fe14e517031d098/src/find.ts#L77-L88).

