### PR TITLE
feat: add loongarch64 support for nodejs-rust

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -104,6 +104,50 @@ jobs:
           tags: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
           context: .
 
+  build-debian-loongarch64-image:
+    name: Build debian image
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_CONTAINER_UNAME }}
+          password: ${{ secrets.GH_TOKEN }}
+
+      - name: Install latest libc++-dev for cross build
+        run: >-
+          docker run --rm
+          --platform linux/loong64 --user 0:0 -e GITHUB_TOKEN
+          -v ${{ github.workspace }}/lib/llvm-18:/usr/lib/llvm-18
+          ghcr.io/loong64/node:lts-trixie-slim
+          sh -c 'apt-get update &&
+          apt-get install -y wget gnupg2 &&
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc &&
+          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" >> /etc/apt/sources.list &&
+          echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" >> /etc/apt/sources.list &&
+          apt-get update &&
+          apt-get install libc++-18-dev libc++abi-18-dev -y --fix-missing --no-install-recommends &&
+          rm /usr/lib/llvm-18/lib/libc++abi.so'
+
+      - name: Build and push debian loongarch64 cross
+        uses: docker/build-push-action@v7
+        with:
+          file: debian-loongarch64.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-loongarch64
+          context: .
+
   build-zig-image:
     name: Build zig image
     runs-on: ubuntu-latest

--- a/debian-loongarch64.Dockerfile
+++ b/debian-loongarch64.Dockerfile
@@ -1,0 +1,45 @@
+FROM messense/manylinux_2_36-cross:loongarch64
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+  CARGO_HOME=/usr/local/cargo \
+  PATH=/usr/local/cargo/bin:$PATH \
+  CC=clang \
+  CC_loongarch64_unknown_linux_gnu=clang \
+  CXX=clang++ \
+  CXX_loongarch64_unknown_linux_gnu=clang++ \
+  CFLAGS="--sysroot=/usr/loongarch64-unknown-linux-gnu/loongarch64-unknown-linux-gnu/sysroot" \
+  CXXFLAGS="--sysroot=/usr/loongarch64-unknown-linux-gnu/loongarch64-unknown-linux-gnu/sysroot" \
+  C_INCLUDE_PATH="/usr/loongarch64-unknown-linux-gnu/loongarch64-unknown-linux-gnu/sysroot/usr/include" \
+  LDFLAGS="-L/usr/loongarch64-unknown-linux-gnu/lib/llvm-18/lib"
+
+ADD ./lib/llvm-18 /usr/loongarch64-unknown-linux-gnu/lib/llvm-18
+
+RUN apt-get update && \
+  apt-get install -y --fix-missing --no-install-recommends curl gnupg gpg-agent ca-certificates openssl && \
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+  curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm-snapshot.gpg && \
+  echo "deb [signed-by=/etc/apt/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" >> /etc/apt/sources.list && \
+  echo "deb-src [signed-by=/etc/apt/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" >> /etc/apt/sources.list && \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
+  apt-get update && \
+  apt-get install -y --fix-missing --no-install-recommends \
+  llvm-18 \
+  clang-18 \
+  lld-18 \
+  libc++-18-dev \
+  libc++abi-18-dev \
+  nodejs \
+  xz-utils \
+  rcs \
+  git \
+  make \
+  cmake \
+  ninja-build && \
+  apt-get autoremove -y && \
+  curl https://sh.rustup.rs -sSf | sh -s -- -y && \
+  rustup target add loongarch64-unknown-linux-gnu && \
+  corepack enable && \
+  ln -sf /usr/bin/clang-18 /usr/bin/clang && \
+  ln -sf /usr/bin/clang++-18 /usr/bin/clang++ && \
+  ln -sf /usr/bin/lld-18 /usr/bin/lld && \
+  ln -sf /usr/bin/clang-18 /usr/bin/cc


### PR DESCRIPTION
Please note that `messense/manylinux2014-cross` doesn't support loongarch64, so we are using `messense/manylinux_2_36-cross:loongarch64` and, since there is no official Node.js image for LoongArch, the one from `ghcr.io/loong64/node:lts-trixie-slim` is used instead.

The image built in [this workflow](https://github.com/SkyBird233/napi-rs/actions/runs/17995983749) has been smoke tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI support to build and publish a Debian-based LoongArch64 cross-compilation Docker image. The image provides Node.js and a Rust cross-toolchain, includes an LLVM snapshot to enable LoongArch64 builds, and installs common build tools for compiling native modules. Continuous build/publish steps were added to automate image delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->