### PR TITLE
chore(cli): add type imports

### DIFF
--- a/cli/src/api/artifacts.ts
+++ b/cli/src/api/artifacts.ts
@@ -4,7 +4,7 @@ import * as colors from 'colorette'
 
 import {
   applyDefaultArtifactsOptions,
-  ArtifactsOptions,
+  type ArtifactsOptions,
 } from '../def/artifacts.js'
 import {
   readNapiConfig,

--- a/cli/src/api/build.ts
+++ b/cli/src/api/build.ts
@@ -7,31 +7,31 @@ import { parse, join, resolve } from 'node:path'
 
 import * as colors from 'colorette'
 
-import { BuildOptions as RawBuildOptions } from '../def/build.js'
+import type { BuildOptions as RawBuildOptions } from '../def/build.js'
 import {
   CLI_VERSION,
   copyFileAsync,
-  Crate,
+  type Crate,
   debugFactory,
   DEFAULT_TYPE_DEF_HEADER,
   fileExists,
   getSystemDefaultTarget,
   getTargetLinker,
   mkdirAsync,
-  NapiConfig,
+  type NapiConfig,
   parseMetadata,
   parseTriple,
   processTypeDef,
   readFileAsync,
   readNapiConfig,
-  Target,
+  type Target,
   targetToEnvVar,
   tryInstallCargoBinary,
   unlinkAsync,
   writeFileAsync,
   dirExistsAsync,
   readdirAsync,
-  CargoWorkspaceMetadata,
+  type CargoWorkspaceMetadata,
 } from '../utils/index.js'
 
 import { createCjsBinding, createEsmBinding } from './templates/index.js'

--- a/cli/src/api/create-npm-dirs.ts
+++ b/cli/src/api/create-npm-dirs.ts
@@ -4,7 +4,7 @@ import { parse } from 'semver'
 
 import {
   applyDefaultCreateNpmDirsOptions,
-  CreateNpmDirsOptions,
+  type CreateNpmDirsOptions,
 } from '../def/create-npm-dirs.js'
 import {
   debugFactory,
@@ -12,7 +12,7 @@ import {
   mkdirAsync as rawMkdirAsync,
   pick,
   writeFileAsync as rawWriteFileAsync,
-  Target,
+  type Target,
   type CommonPackageJsonFields,
 } from '../utils/index.js'
 

--- a/cli/src/api/new.ts
+++ b/cli/src/api/new.ts
@@ -8,7 +8,7 @@ import { load as yamlLoad, dump as yamlDump } from 'js-yaml'
 
 import {
   applyDefaultNewOptions,
-  NewOptions as RawNewOptions,
+  type NewOptions as RawNewOptions,
 } from '../def/new.js'
 import {
   AVAILABLE_TARGETS,
@@ -17,7 +17,7 @@ import {
   mkdirAsync,
   readdirAsync,
   statAsync,
-  SupportedPackageManager,
+  type SupportedPackageManager,
 } from '../utils/index.js'
 import { napiEngineRequirement } from '../utils/version.js'
 import { renameProject } from './rename.js'
@@ -469,4 +469,4 @@ function getBinaryName(name: string): string {
   return name.split('/').pop()!
 }
 
-export { NewOptions }
+export type { NewOptions }

--- a/cli/src/api/pre-publish.ts
+++ b/cli/src/api/pre-publish.ts
@@ -6,7 +6,7 @@ import { Octokit } from '@octokit/rest'
 
 import {
   applyDefaultPrePublishOptions,
-  PrePublishOptions,
+  type PrePublishOptions,
 } from '../def/pre-publish.js'
 import {
   readFileAsync,

--- a/cli/src/api/rename.ts
+++ b/cli/src/api/rename.ts
@@ -7,7 +7,7 @@ import { load as yamlParse, dump as yamlStringify } from 'js-yaml'
 import { isNil, merge, omitBy, pick } from 'es-toolkit'
 import * as find from 'empathic/find'
 
-import { applyDefaultRenameOptions, RenameOptions } from '../def/rename.js'
+import { applyDefaultRenameOptions, type RenameOptions } from '../def/rename.js'
 import { readConfig, readFileAsync, writeFileAsync } from '../utils/index.js'
 
 export async function renameProject(userOptions: RenameOptions) {

--- a/cli/src/api/universalize.ts
+++ b/cli/src/api/universalize.ts
@@ -3,7 +3,7 @@ import { join, resolve } from 'node:path'
 
 import {
   applyDefaultUniversalizeOptions,
-  UniversalizeOptions,
+  type UniversalizeOptions,
 } from '../def/universalize.js'
 import { readNapiConfig } from '../utils/config.js'
 import { debugFactory } from '../utils/log.js'

--- a/cli/src/api/version.ts
+++ b/cli/src/api/version.ts
@@ -1,6 +1,9 @@
 import { join, resolve } from 'node:path'
 
-import { applyDefaultVersionOptions, VersionOptions } from '../def/version.js'
+import {
+  applyDefaultVersionOptions,
+  type VersionOptions,
+} from '../def/version.js'
 import {
   readNapiConfig,
   debugFactory,

--- a/cli/src/commands/new.ts
+++ b/cli/src/commands/new.ts
@@ -9,7 +9,7 @@ import {
   AVAILABLE_TARGETS,
   debugFactory,
   DEFAULT_TARGETS,
-  TargetTriple,
+  type TargetTriple,
 } from '../utils/index.js'
 import { napiEngineRequirement } from '../utils/version.js'
 

--- a/cli/src/utils/config.ts
+++ b/cli/src/utils/config.ts
@@ -2,7 +2,7 @@ import { underline, yellow } from 'colorette'
 import { merge, omit } from 'es-toolkit'
 
 import { fileExists, readFileAsync } from './misc.js'
-import { DEFAULT_TARGETS, parseTriple, Target } from './target.js'
+import { DEFAULT_TARGETS, parseTriple, type Target } from './target.js'
 
 export type ValueOfConstArray<T> = T[Exclude<keyof T, keyof Array<any>>]
 

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -7,6 +7,7 @@
     "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
+    "verbatimModuleSyntax": true,
     "declaration": true,
     "rootDir": "./src",
     "baseUrl": ".",


### PR DESCRIPTION
When running `yarn build` in `cli/`, I notice there were many warnings such as:

```
[MISSING_EXPORT] Warning: "UniversalizeOptions" is not exported by "src/def/universalize.ts".
   ╭─[ src/api/universalize.ts:6:3 ]
   │
 6 │   UniversalizeOptions,
   │   ─────────┬─────────  
   │            ╰─────────── Missing export
   │ 
   │ Note: If you meant to import a type rather than a value, make sure to add the `type` modifier (e.g. `import { type Foo } from '../def/universalize.js'`).
───╯
```

So I added the type imports to fix the warnings. I also add `"verbatimModuleSyntax": true` to `cli/tsconfig.json` so the errors are shown in the IDE / before-build directly.