### PR TITLE
fix(wasm-runtime): node:events polyfill on browser

### DIFF
--- a/examples/napi/browser/values.spec.ts
+++ b/examples/napi/browser/values.spec.ts
@@ -2,7 +2,7 @@ import { Buffer } from 'buffer'
 
 import { describe, it, expect } from 'vitest'
 
-global.Buffer = Buffer
+globalThis.Buffer = Buffer
 
 // @ts-expect-error
 const {

--- a/examples/napi/vite-entry.js
+++ b/examples/napi/vite-entry.js
@@ -10,7 +10,7 @@ import {
   testWorkers,
 } from './example.wasi-browser'
 
-global.Buffer = Buffer
+globalThis.Buffer = Buffer
 
 console.info(new Animal(Kind.Cat, 'Tom'))
 asyncMultiTwo(200).then((res) => {

--- a/examples/napi/vite.config.js
+++ b/examples/napi/vite.config.js
@@ -1,5 +1,4 @@
 import { defineConfig } from 'vite'
-import { nodePolyfills } from 'vite-plugin-node-polyfills'
 
 export default defineConfig({
   server: {
@@ -9,9 +8,6 @@ export default defineConfig({
     },
   },
   plugins: [
-    nodePolyfills({
-      include: ['events'],
-    }),
     {
       name: 'configure-response-headers',
       enforce: 'pre',

--- a/wasm-runtime/package.json
+++ b/wasm-runtime/package.json
@@ -32,6 +32,7 @@
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-replace": "^6.0.2",
     "buffer": "^6.0.3",
+    "events": "^3.3.0",
     "memfs": "^4.39.0",
     "node-inspect-extracted": "^3.2.1",
     "path-browserify": "^1.0.1",

--- a/wasm-runtime/rollup.config.js
+++ b/wasm-runtime/rollup.config.js
@@ -17,6 +17,7 @@ export default defineConfig([
       commonjs(),
       alias({
         entries: [
+          { find: 'node:events', replacement: 'events' },
           { find: 'node:path', replacement: 'path-browserify' },
           { find: 'node:stream', replacement: 'readable-stream' },
           { find: 'assert', replacement: join(dirname, 'assert.cjs') },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1412,6 +1412,7 @@ __metadata:
     "@rollup/plugin-replace": "npm:^6.0.2"
     "@tybys/wasm-util": "npm:^0.10.1"
     buffer: "npm:^6.0.3"
+    events: "npm:^3.3.0"
     memfs: "npm:^4.39.0"
     node-inspect-extracted: "npm:^3.2.1"
     path-browserify: "npm:^1.0.1"


### PR DESCRIPTION
- Close https://github.com/napi-rs/napi-rs/issues/2953