### PR TITLE
feat(cli): resolve command from args

### DIFF
--- a/cli/src/api/__tests__/build.spec.ts
+++ b/cli/src/api/__tests__/build.spec.ts
@@ -138,9 +138,8 @@ napi-build = { path = "${napiBuildPath}" }
   const files = await readdir(typeDefDir)
   t.true(files.length > 0, 'type definition files should be generated')
 
-  const exports = await generateTypeDef({
+  const { exports, dts } = await generateTypeDef({
     typeDefDir,
-    outputDir: projectDir,
     cwd: projectDir,
   })
 
@@ -177,13 +176,7 @@ napi-build = { path = "${napiBuildPath}" }
   const nodeStat = await stat(destPath)
   t.true(nodeStat.size > 0)
 
-  const dtsPath = join(projectDir, 'index.d.ts')
-  t.true(existsSync(dtsPath))
-  const dtsContent = await readFile(dtsPath, 'utf-8')
-  t.regex(
-    dtsContent,
-    /export declare function sum\(a: number, b: number\): number/,
-  )
+  t.regex(dts, /export declare function sum\(a: number, b: number\): number/)
 
   const jsPath = join(projectDir, 'index.js')
   t.true(existsSync(jsPath))

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -57,6 +57,40 @@ export class NapiCli {
   version = version
 }
 
+export function createBuildCommand(args: string[]): BuildCommand {
+  return cli.process(['build', ...args]) as BuildCommand
+}
+
+export function createArtifactsCommand(args: string[]): ArtifactsCommand {
+  return cli.process(['artifacts', ...args]) as ArtifactsCommand
+}
+
+export function createCreateNpmDirsCommand(
+  args: string[],
+): CreateNpmDirsCommand {
+  return cli.process(['create-npm-dirs', ...args]) as CreateNpmDirsCommand
+}
+
+export function createPrePublishCommand(args: string[]): PrePublishCommand {
+  return cli.process(['pre-publish', ...args]) as PrePublishCommand
+}
+
+export function createRenameCommand(args: string[]): RenameCommand {
+  return cli.process(['rename', ...args]) as RenameCommand
+}
+
+export function createUniversalizeCommand(args: string[]): UniversalizeCommand {
+  return cli.process(['universalize', ...args]) as UniversalizeCommand
+}
+
+export function createVersionCommand(args: string[]): VersionCommand {
+  return cli.process(['version', ...args]) as VersionCommand
+}
+
+export function createNewCommand(args: string[]): NewCommand {
+  return cli.process(['new', ...args]) as NewCommand
+}
+
 export { parseTriple } from './utils/target.js'
 export {
   type GenerateTypeDefOptions,
@@ -64,3 +98,4 @@ export {
   writeJsBinding,
   generateTypeDef,
 } from './api/build.js'
+export { readNapiConfig } from './utils/config.js'


### PR DESCRIPTION
Example:

```js
import { writeFile } from 'node:fs/promises'
import path from 'node:path'

import {
  createBuildCommand,
  writeJsBinding,
  generateTypeDef,
  readNapiConfig,
} from '@napi-rs/cli'

const buildCommand = createBuildCommand(process.argv.slice(2))

const options = buildCommand.getOptions()

const { exports, dts } = await generateTypeDef({
  typeDefDir: process.env.NAPI_TYPE_DEF_TMP_FOLDER,
  dts: options.dts,
  dtsHeader: options.dtsHeader,
})

const cwd = options.cwd ?? process.cwd()

const napiConfig = await readNapiConfig(
  path.resolve(cwd, options.packageJsonPath ?? 'package.json'),
  options.configPath ? path.resolve(cwd, options.configPath) : undefined,
)

await writeFile(path.join(options.outputDir, options.dts ?? 'index.d.ts'), dts)

await writeJsBinding({
  platform: options.platform,
  idents: exports,
  binaryName: napiConfig.binaryName,
  packageName: napiConfig.packageName,
  version: napiConfig.packageJson.version,
  outputDir: options.outputDir,
  esm: options.esm,
})

```

- Close https://github.com/napi-rs/napi-rs/issues/2709