### PR TITLE
chore(napi): mark SendableResolver and PromiseRaw as pub

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/promise_raw.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/promise_raw.rs
@@ -56,7 +56,7 @@ impl<T> FromNapiValue for PromiseRaw<'_, T> {
 }
 
 impl<T> PromiseRaw<'_, T> {
-  pub(crate) fn new(env: sys::napi_env, inner: sys::napi_value) -> Self {
+  pub fn new(env: sys::napi_env, inner: sys::napi_value) -> Self {
     Self {
       inner,
       env,

--- a/crates/napi/src/tokio_runtime.rs
+++ b/crates/napi/src/tokio_runtime.rs
@@ -171,7 +171,7 @@ pub fn within_runtime_if_available<F: FnOnce() -> T, T>(f: F) -> T {
 }
 
 #[cfg(not(feature = "noop"))]
-struct SendableResolver<
+pub struct SendableResolver<
   Data: 'static + Send,
   R: 'static + FnOnce(sys::napi_env, Data) -> Result<sys::napi_value>,
 > {
@@ -193,14 +193,14 @@ unsafe impl<Data: 'static + Send, R: 'static + FnOnce(sys::napi_env, Data) -> Re
 impl<Data: 'static + Send, R: 'static + FnOnce(sys::napi_env, Data) -> Result<sys::napi_value>>
   SendableResolver<Data, R>
 {
-  fn new(inner: R) -> Self {
+  pub fn new(inner: R) -> Self {
     Self {
       inner,
       _data: PhantomData,
     }
   }
 
-  fn resolve(self, env: sys::napi_env, data: Data) -> Result<sys::napi_value> {
+  pub fn resolve(self, env: sys::napi_env, data: Data) -> Result<sys::napi_value> {
     (self.inner)(env, data)
   }
 }


### PR DESCRIPTION
We can use SendableResolver and PromiseRaw to implement the custom `spwan_future` with custom runtime. Here is an example: https://github.com/alshdavid/napi_ext