### PR TITLE
chore(napi): mark tsfn data as pub and split SendableResolver to independent file

### DIFF
--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -95,8 +95,12 @@ mod tokio_runtime;
 mod value_type;
 #[cfg(feature = "napi3")]
 pub use cleanup_env::CleanupEnvHook;
+#[cfg(not(feature = "noop"))]
+mod sendable_resolver;
 #[cfg(feature = "napi4")]
 pub mod threadsafe_function;
+#[cfg(not(feature = "noop"))]
+pub use sendable_resolver::SendableResolver;
 
 mod version;
 

--- a/crates/napi/src/sendable_resolver.rs
+++ b/crates/napi/src/sendable_resolver.rs
@@ -1,0 +1,35 @@
+use crate::Result;
+use napi_sys as sys;
+use std::marker::PhantomData;
+
+pub struct SendableResolver<
+  Data: 'static + Send,
+  R: 'static + FnOnce(sys::napi_env, Data) -> Result<sys::napi_value>,
+> {
+  inner: R,
+  _data: PhantomData<Data>,
+}
+
+// the `SendableResolver` will be only called in the `threadsafe_function_call_js` callback
+// which means it will be always called in the Node.js JavaScript thread
+// so the inner function is not required to be `Send`
+// but the `Send` bound is required by the `execute_tokio_future` function
+unsafe impl<Data: 'static + Send, R: 'static + FnOnce(sys::napi_env, Data) -> Result<sys::napi_value>>
+  Send for SendableResolver<Data, R>
+{
+}
+
+impl<Data: 'static + Send, R: 'static + FnOnce(sys::napi_env, Data) -> Result<sys::napi_value>>
+  SendableResolver<Data, R>
+{
+  pub fn new(inner: R) -> Self {
+    Self {
+      inner,
+      _data: PhantomData,
+    }
+  }
+
+  pub fn resolve(self, env: sys::napi_env, data: Data) -> Result<sys::napi_value> {
+    (self.inner)(env, data)
+  }
+}

--- a/crates/napi/src/threadsafe_function.rs
+++ b/crates/napi/src/threadsafe_function.rs
@@ -44,7 +44,7 @@ impl From<ThreadsafeFunctionCallMode> for sys::napi_threadsafe_function_call_mod
   }
 }
 
-struct ThreadsafeFunctionHandle {
+pub struct ThreadsafeFunctionHandle {
   raw: AtomicPtr<sys::napi_threadsafe_function__>,
   aborted: RwLock<bool>,
   referred: AtomicBool,
@@ -52,7 +52,7 @@ struct ThreadsafeFunctionHandle {
 
 impl ThreadsafeFunctionHandle {
   /// create a Arc to hold the `ThreadsafeFunctionHandle`
-  fn new(raw: sys::napi_threadsafe_function) -> Arc<Self> {
+  pub fn new(raw: sys::napi_threadsafe_function) -> Arc<Self> {
     Arc::new(Self {
       raw: AtomicPtr::new(raw),
       aborted: RwLock::new(false),
@@ -61,7 +61,7 @@ impl ThreadsafeFunctionHandle {
   }
 
   /// Lock `aborted` with read access, call `f` with the value of `aborted`, then unlock it
-  fn with_read_aborted<RT, F>(&self, f: F) -> RT
+  pub fn with_read_aborted<RT, F>(&self, f: F) -> RT
   where
     F: FnOnce(bool) -> RT,
   {
@@ -73,7 +73,7 @@ impl ThreadsafeFunctionHandle {
   }
 
   /// Lock `aborted` with write access, call `f` with the `RwLockWriteGuard`, then unlock it
-  fn with_write_aborted<RT, F>(&self, f: F) -> RT
+  pub fn with_write_aborted<RT, F>(&self, f: F) -> RT
   where
     F: FnOnce(RwLockWriteGuard<bool>) -> RT,
   {
@@ -85,15 +85,15 @@ impl ThreadsafeFunctionHandle {
   }
 
   #[allow(clippy::arc_with_non_send_sync)]
-  fn null() -> Arc<Self> {
+  pub fn null() -> Arc<Self> {
     Self::new(null_mut())
   }
 
-  fn get_raw(&self) -> sys::napi_threadsafe_function {
+  pub fn get_raw(&self) -> sys::napi_threadsafe_function {
     self.raw.load(Ordering::SeqCst)
   }
 
-  fn set_raw(&self, raw: sys::napi_threadsafe_function) {
+  pub fn set_raw(&self, raw: sys::napi_threadsafe_function) {
     self.raw.store(raw, Ordering::SeqCst)
   }
 }
@@ -123,15 +123,15 @@ impl Drop for ThreadsafeFunctionHandle {
 }
 
 #[repr(u8)]
-enum ThreadsafeFunctionCallVariant {
+pub enum ThreadsafeFunctionCallVariant {
   Direct,
   WithCallback,
 }
 
-struct ThreadsafeFunctionCallJsBackData<T, Return = Unknown<'static>> {
-  data: T,
-  call_variant: ThreadsafeFunctionCallVariant,
-  callback: Box<dyn FnOnce(Result<Return>, Env) -> Result<()>>,
+pub struct ThreadsafeFunctionCallJsBackData<T, Return = Unknown<'static>> {
+  pub data: T,
+  pub call_variant: ThreadsafeFunctionCallVariant,
+  pub callback: Box<dyn FnOnce(Result<Return>, Env) -> Result<()>>,
 }
 
 /// Communicate with the addon's main thread by invoking a JavaScript function from other threads.
@@ -175,7 +175,7 @@ pub struct ThreadsafeFunction<
   const Weak: bool = false,
   const MaxQueueSize: usize = 0,
 > {
-  handle: Arc<ThreadsafeFunctionHandle>,
+  pub handle: Arc<ThreadsafeFunctionHandle>,
   _phantom: PhantomData<(T, CallJsBackArgs, Return, ErrorStatus)>,
 }
 

--- a/crates/napi/src/tokio_runtime.rs
+++ b/crates/napi/src/tokio_runtime.rs
@@ -6,7 +6,7 @@ use tokio::runtime::Runtime;
 
 use crate::{bindgen_runtime::ToNapiValue, sys, Env, Error, Result};
 #[cfg(not(feature = "noop"))]
-use crate::{JsDeferred, Unknown};
+use crate::{JsDeferred, SendableResolver, Unknown};
 
 #[cfg(not(feature = "noop"))]
 fn create_runtime() -> Runtime {
@@ -168,41 +168,6 @@ pub fn within_runtime_if_available<F: FnOnce() -> T, T>(f: F) -> T {
 #[cfg(feature = "noop")]
 pub fn within_runtime_if_available<F: FnOnce() -> T, T>(f: F) -> T {
   f()
-}
-
-#[cfg(not(feature = "noop"))]
-pub struct SendableResolver<
-  Data: 'static + Send,
-  R: 'static + FnOnce(sys::napi_env, Data) -> Result<sys::napi_value>,
-> {
-  inner: R,
-  _data: PhantomData<Data>,
-}
-
-#[cfg(not(feature = "noop"))]
-// the `SendableResolver` will be only called in the `threadsafe_function_call_js` callback
-// which means it will be always called in the Node.js JavaScript thread
-// so the inner function is not required to be `Send`
-// but the `Send` bound is required by the `execute_tokio_future` function
-unsafe impl<Data: 'static + Send, R: 'static + FnOnce(sys::napi_env, Data) -> Result<sys::napi_value>>
-  Send for SendableResolver<Data, R>
-{
-}
-
-#[cfg(not(feature = "noop"))]
-impl<Data: 'static + Send, R: 'static + FnOnce(sys::napi_env, Data) -> Result<sys::napi_value>>
-  SendableResolver<Data, R>
-{
-  pub fn new(inner: R) -> Self {
-    Self {
-      inner,
-      _data: PhantomData,
-    }
-  }
-
-  pub fn resolve(self, env: sys::napi_env, data: Data) -> Result<sys::napi_value> {
-    (self.inner)(env, data)
-  }
 }
 
 #[cfg(feature = "noop")]


### PR DESCRIPTION
This change allows us to extend ThreadsafeFunction based on custom asynchronous runtime, similer to `call_async`.

```rs
pub trait ThreadsafeFunctionCalleeHandleExt {
    type T: 'static;
    type Return: 'static + FromNapiValue;
    type CallJsBackArgs: 'static + JsValuesTupleIntoVec;
    type ErrorStatus: AsRef<str> + From<Status>;
    const CALLEE_HANDLED: bool;
    const WEAK: bool;
    const MAX_QUEUE_SIZE: usize;

    fn call_local(&self, value: Self::T)
    -> impl std::future::Future<Output = Result<Self::Return>>;
}

pub trait ThreadsafeFunctionCalleeUnHandleExt {
    type T: 'static;
    type Return: 'static + FromNapiValue;
    type CallJsBackArgs: 'static + JsValuesTupleIntoVec;
    type ErrorStatus: AsRef<str> + From<Status>;
    const CALLEE_HANDLED: bool;
    const WEAK: bool;
    const MAX_QUEUE_SIZE: usize;

    fn call_local(
        &self,
        value: Result<Self::T, Self::ErrorStatus>,
    ) -> impl std::future::Future<Output = Result<Self::Return>>;
}

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes key ThreadsafeFunction internals public and moves SendableResolver to a dedicated module, updating exports and runtime usage.
> 
> - **ThreadsafeFunction internals** (`crates/napi/src/threadsafe_function.rs`):
>   - Make `ThreadsafeFunctionHandle` public and expose its constructor/accessors (`new`, `with_read_aborted`, `with_write_aborted`, `null`, `get_raw`, `set_raw`).
>   - Make `ThreadsafeFunction.handle` field public.
>   - Make `ThreadsafeFunctionCallVariant` public.
>   - Make `ThreadsafeFunctionCallJsBackData` public and expose its fields (`data`, `call_variant`, `callback`).
> - **SendableResolver extraction**:
>   - New `crates/napi/src/sendable_resolver.rs` with `SendableResolver` type.
>   - Remove in-file definition from `tokio_runtime.rs`; import and use the new module.
>   - Update `lib.rs` to include the module and re-export `SendableResolver` (behind `not(feature = "noop")`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f32d18c715cf1712c023078078db8f0d59e5a03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->