### PR TITLE
fix(napi): memory leak in PromiseRaw cleanup callback

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/promise_raw.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/promise_raw.rs
@@ -115,7 +115,7 @@ impl<'env, T: FromNapiValue> PromiseRaw<'env, T> {
         sys::napi_wrap(
           self.env,
           new_promise,
-          ptr::null_mut(),
+          executed.cast(),
           Some(promise_callback_finalizer::<T, U, Callback>),
           rust_cb.cast(),
           ptr::null_mut(),


### PR DESCRIPTION
This commit fixes a memory leak that occurred when converting a Promise from an Unknown object, specifically manifesting in Deno environments.

The issue was in the `promise_callback_finalizer` function, which had a type mismatch when cleaning up callback allocations:

1. The callback was stored as `Box<(Cb, *mut bool)>` (a tuple containing the callback and an executed flag pointer)
2. The finalizer incorrectly cast it as `Box<Cb>` when trying to free it
3. This caused improper deallocation and memory leaks

The fix ensures:
- The executed flag allocation is always properly cleaned up
- The callback tuple is cast to the correct type `(Cb, *mut bool)` before being dropped
- All allocations are properly freed in both execution paths (callback executed or not executed)

Fixes #2926

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix memory leak by always freeing the executed-flag and correctly dropping `(Cb, *mut bool)` when the Promise callback was never executed.
> 
> - **Memory management in `crates/napi/src/bindgen_runtime/js_values/promise_raw.rs`**:
>   - Update `promise_callback_finalizer` to always free the `executed` flag (`*mut bool`).
>   - When the callback was not executed, correctly drop `finalize_hint` as `Box<(Cb, *mut bool)>` instead of `Box<Cb>` to free all allocations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1cfa4c63c6109b6b72e9a380758318a85e5c322. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->