### PR TITLE
feat!(cli): drop cjs build, require Node 20.19+

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -7,20 +7,18 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": ">= 16"
+    "node": ">= 20.19"
   },
   "bin": {
-    "napi": "./dist/cli.js",
+    "napi": "./dist/cli.mjs",
     "napi-raw": "./cli.mjs"
   },
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
-    },
+    ".": "./dist/index.mjs",
+    "./cli": "./dist/cli.mjs",
     "./package.json": "./package.json"
   },
   "files": [

--- a/cli/tsdown.config.ts
+++ b/cli/tsdown.config.ts
@@ -1,24 +1,7 @@
 import { defineConfig } from 'tsdown'
 
-export default defineConfig([
-  {
-    entry: './src/index.ts',
-    fixedExtension: false,
-    format: ['esm', 'cjs'],
-    target: 'node16',
-    sourcemap: 'inline',
-    inputOptions(options, format) {
-      if (format === 'cjs') {
-        options.external = ['@octokit/rest']
-      }
-      return options
-    },
-  },
-  {
-    entry: './src/cli.ts',
-    sourcemap: 'inline',
-    target: 'node16',
-    dts: false,
-    fixedExtension: false,
-  },
-])
+export default defineConfig({
+  entry: './src/{index,cli}.ts',
+  sourcemap: 'inline',
+  exports: true,
+})


### PR DESCRIPTION
- Drop the CJS build
- Require Node.js 20.19+ (`require(esm)`)
- Simplify the tsdown configuration

Since the CLI is typically used as an entry point, this won’t affect most users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js version requirement to 20.19 or higher.
  * Streamlined build configuration and export paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->