### PR TITLE
chore: update MSRV in README.md

### DIFF
--- a/crates/napi/README.md
+++ b/crates/napi/README.md
@@ -26,7 +26,7 @@ A framework for building compiled `Node.js` add-ons in `Rust` via Node-API. Webs
 
 ## MSRV
 
-**Rust** `1.82.0`
+**Rust** `1.88.0`
 
 |                       | node12 | node14 | node16 | node18 | node20 | node22 |
 | --------------------- | ------ | ------ | ------ | ------ | ------ | ------ |


### PR DESCRIPTION
The MSRV changed to 1.88.0 as of napi-build 2.3.0 https://crates.io/crates/napi-build/versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated minimum supported Rust version to 1.88.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->