### PR TITLE
fix(napi): tokio runtime shutdown at exit

### DIFF
--- a/crates/napi/src/bindgen_runtime/mod.rs
+++ b/crates/napi/src/bindgen_runtime/mod.rs
@@ -2,7 +2,6 @@ use std::ffi::c_void;
 use std::rc::Rc;
 
 pub use callback_info::*;
-pub use ctor::ctor;
 pub use env::*;
 pub use iterator::Generator;
 pub use js_values::*;


### PR DESCRIPTION
This is a proposal to fix https://github.com/napi-rs/napi-rs/issues/2970

I found that https://github.com/mmastrac/rust-ctor/issues/304#issuecomment-2571568746 and https://github.com/mmastrac/rust-ctor/wiki/FAQ:-Life%E2%80%90before-and-life%E2%80%90after-main#important-considerations, discourage using `#[dtor]`  to cleanup tokio runtime, which might explain the issue.

Disclaimer: I'm not very familiar with `napi-rs`. I'm not sure why the second `thread_cleanup()` was added in #2850 and whether or not it was an integral part of fixing that particular issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed public re-export of the `ctor` macro from the bindgen runtime module.

* **Refactor**
  * Simplified conditional compilation logic for module registration and thread cleanup.
  * Updated thread cleanup function signature and implementation for improved C ABI compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->