### PR TITLE
Add Eq and PartialEq trait to BigInt

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/bigint.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/bigint.rs
@@ -21,7 +21,7 @@ pub struct i64n(pub i64);
 
 /// <https://nodejs.org/api/n-api.html#napi_create_bigint_words>
 /// The resulting BigInt is calculated as: (–1)^sign_bit (words\[0\] × (2^64)^0 + words\[1\] × (2^64)^1 + …)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BigInt {
   /// true for negative numbers
   pub sign_bit: bool,


### PR DESCRIPTION
With the current implementation of BigInt, we cannot compare two BigInt, despite them representing a numeric value in a strict format. By deriving the Eq and PartialEq traits, we can now compare two BigInt, without the need to convert them to another type first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced BigInt type to support equality comparisons between values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->