### PR TITLE
fix(cli): use jsPackageName from cli options

### DIFF
--- a/cli/src/api/build.ts
+++ b/cli/src/api/build.ts
@@ -915,7 +915,7 @@ class Builder {
       jsBinding: this.options.jsBinding,
       esm: this.options.esm,
       binaryName: this.config.binaryName,
-      packageName: this.config.packageName,
+      packageName: this.options.jsPackageName ?? this.config.packageName,
       version: process.env.npm_new_version ?? this.config.packageJson.version,
       outputDir: this.outputDir,
     })


### PR DESCRIPTION
After upgrading to v3, even after setting the CLI option `--js-package-name`, napi cli still generates the bindings.js using the npm package name.

This fix makes sure the bindings.js are generated using the jsPackageName if a value exists, else uses npm package name as previously.