### PR TITLE
fix(cli): properly load WASM package in JS binding template

### DIFF
--- a/cli/src/api/templates/js-binding.ts
+++ b/cli/src/api/templates/js-binding.ts
@@ -238,7 +238,7 @@ if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
       wasiBindingError = err
     }
   }
-  if (!nativeBinding) {
+  if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
     try {
       wasiBinding = require('${pkgName}-wasm32-wasi')
       nativeBinding = wasiBinding

--- a/cli/src/api/templates/load-wasi-template.ts
+++ b/cli/src/api/templates/load-wasi-template.ts
@@ -144,11 +144,7 @@ const __wasmDebugFilePath = __nodePath.join(__dirname, '${wasmFileName}.debug.wa
 if (__nodeFs.existsSync(__wasmDebugFilePath)) {
   __wasmFilePath = __wasmDebugFilePath
 } else if (!__nodeFs.existsSync(__wasmFilePath)) {
-  try {
-    __wasmFilePath = __nodePath.resolve('${packageName}-wasm32-wasi')
-  } catch {
-    throw new Error('Cannot find ${wasmFileName}.wasm file, and ${packageName}-wasm32-wasi package is not installed.')
-  }
+  __wasmFilePath = __nodePath.resolve('node_modules/${packageName}-wasm32-wasi/${wasmFileName}.debug.wasm')
 }
 
 const { instance: __napiInstance, module: __wasiModule, napiModule: __napiModule } = __emnapiInstantiateNapiModuleSync(__nodeFs.readFileSync(__wasmFilePath), {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Made module loading and WebAssembly path selection more deterministic for more reliable startup.
* **Bug Fixes / Behavior**
  * Added support for an environment override that forces the WASI runtime to be used when requested, improving control over runtime selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->