### PR TITLE
chore(sys): add back non dyn-symbols behavior

### DIFF
--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -83,6 +83,7 @@ version = "1"
 [dependencies.napi-sys]
 path = "../sys"
 version = "3.1.1"
+default-features = false
 
 [dependencies.encoding_rs]
 optional = true

--- a/crates/napi/src/bindgen_runtime/js_values/map.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/map.rs
@@ -23,6 +23,7 @@ where
   K: AsRef<str>,
   V: ToNapiValue,
 {
+  #[cfg(not(feature = "noop"))]
   unsafe fn to_napi_value(raw_env: sys::napi_env, val: Self) -> Result<sys::napi_value> {
     let env = Env::from(raw_env);
     #[cfg_attr(feature = "napi10", allow(unused_mut))]
@@ -30,14 +31,16 @@ where
     #[cfg(all(
       feature = "napi10",
       feature = "node_version_detect",
-      feature = "dyn-symbols"
+      feature = "dyn-symbols",
+      not(feature = "noop"),
     ))]
     let node_version = NODE_VERSION.get().unwrap();
     for (k, v) in val.into_iter() {
       #[cfg(all(
         feature = "napi10",
         feature = "node_version_detect",
-        feature = "dyn-symbols"
+        feature = "dyn-symbols",
+        not(feature = "noop"),
       ))]
       {
         if node_version.major >= 20 && node_version.minor >= 18 {
@@ -55,6 +58,11 @@ where
     }
 
     unsafe { Object::to_napi_value(raw_env, obj) }
+  }
+
+  #[cfg(feature = "noop")]
+  unsafe fn to_napi_value(_env: sys::napi_env, _val: Self) -> Result<sys::napi_value> {
+    unimplemented!("HashMap is not supported in noop mode");
   }
 }
 
@@ -95,6 +103,7 @@ where
   K: AsRef<str>,
   V: ToNapiValue,
 {
+  #[cfg(not(feature = "noop"))]
   unsafe fn to_napi_value(raw_env: sys::napi_env, val: Self) -> Result<sys::napi_value> {
     let env = Env::from(raw_env);
     #[cfg_attr(feature = "napi10", allow(unused_mut))]
@@ -102,14 +111,16 @@ where
     #[cfg(all(
       feature = "napi10",
       feature = "node_version_detect",
-      feature = "dyn-symbols"
+      feature = "dyn-symbols",
+      not(feature = "noop"),
     ))]
     let node_version = NODE_VERSION.get().unwrap();
     for (k, v) in val.into_iter() {
       #[cfg(all(
         feature = "napi10",
         feature = "node_version_detect",
-        feature = "dyn-symbols"
+        feature = "dyn-symbols",
+        not(feature = "noop"),
       ))]
       {
         if node_version.major >= 20 && node_version.minor >= 18 {
@@ -127,6 +138,11 @@ where
     }
 
     unsafe { Object::to_napi_value(raw_env, obj) }
+  }
+
+  #[cfg(feature = "noop")]
+  unsafe fn to_napi_value(_env: sys::napi_env, _val: Self) -> Result<sys::napi_value> {
+    unimplemented!("BTreeMap is not supported in noop mode");
   }
 }
 
@@ -169,6 +185,7 @@ where
   V: ToNapiValue,
   S: Default + BuildHasher,
 {
+  #[cfg(not(feature = "noop"))]
   unsafe fn to_napi_value(raw_env: sys::napi_env, val: Self) -> Result<sys::napi_value> {
     let env = Env::from(raw_env);
     #[cfg_attr(feature = "napi10", allow(unused_mut))]
@@ -176,14 +193,16 @@ where
     #[cfg(all(
       feature = "napi10",
       feature = "node_version_detect",
-      feature = "dyn-symbols"
+      feature = "dyn-symbols",
+      not(feature = "noop"),
     ))]
     let node_version = NODE_VERSION.get().unwrap();
     for (k, v) in val.into_iter() {
       #[cfg(all(
         feature = "napi10",
         feature = "node_version_detect",
-        feature = "dyn-symbols"
+        feature = "dyn-symbols",
+        not(feature = "noop"),
       ))]
       {
         if node_version.major >= 20 && node_version.minor >= 18 {
@@ -201,6 +220,11 @@ where
     }
 
     unsafe { Object::to_napi_value(raw_env, obj) }
+  }
+
+  #[cfg(feature = "noop")]
+  unsafe fn to_napi_value(_env: sys::napi_env, _val: Self) -> Result<sys::napi_value> {
+    unimplemented!("BTreeMap is not supported in noop mode");
   }
 }
 
@@ -227,7 +251,8 @@ where
 #[cfg(all(
   feature = "napi10",
   feature = "node_version_detect",
-  feature = "dyn-symbols"
+  feature = "dyn-symbols",
+  not(feature = "noop"),
 ))]
 fn fast_set_property<K: AsRef<str>, V: ToNapiValue>(
   raw_env: sys::napi_env,

--- a/crates/napi/src/bindgen_runtime/module_register.rs
+++ b/crates/napi/src/bindgen_runtime/module_register.rs
@@ -251,7 +251,10 @@ pub unsafe extern "C" fn napi_register_module_v1(
   env: sys::napi_env,
   exports: sys::napi_value,
 ) -> sys::napi_value {
-  #[cfg(not(target_family = "wasm"))]
+  #[cfg(any(
+    target_env = "msvc",
+    all(not(target_family = "wasm"), feature = "dyn-symbols")
+  ))]
   unsafe {
     sys::setup();
   }

--- a/crates/sys/src/functions.rs
+++ b/crates/sys/src/functions.rs
@@ -838,7 +838,7 @@ pub use napi8::*;
 #[cfg(feature = "napi9")]
 pub use napi9::*;
 
-#[cfg(all(windows, not(target_env = "msvc")))]
+#[cfg(all(windows, not(target_env = "msvc"), feature = "dyn-symbols"))]
 fn test_library(
   lib_result: Result<libloading::os::windows::Library, libloading::Error>,
 ) -> Result<libloading::Library, libloading::Error> {
@@ -859,7 +859,7 @@ fn test_library(
   }
 }
 
-#[cfg(all(windows, not(target_env = "msvc")))]
+#[cfg(all(windows, not(target_env = "msvc"), feature = "dyn-symbols"))]
 fn find_node_library() -> Result<libloading::Library, libloading::Error> {
   return unsafe {
     test_library(libloading::os::windows::Library::this())
@@ -876,7 +876,10 @@ fn find_node_library() -> Result<libloading::Library, libloading::Error> {
   };
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(any(
+  target_env = "msvc",
+  all(not(target_family = "wasm"), feature = "dyn-symbols")
+))]
 pub(super) unsafe fn load_all() -> Result<libloading::Library, libloading::Error> {
   #[cfg(all(windows, target_env = "msvc"))]
   let host = libloading::os::windows::Library::this()?.into();

--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -2,7 +2,10 @@
 
 #![allow(ambiguous_glob_reexports)]
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(any(
+  target_env = "msvc",
+  all(not(target_family = "wasm"), feature = "dyn-symbols")
+))]
 macro_rules! generate {
   (@stub_fn $name:ident($($param:ident: $ptype:ty,)*) -> napi_status) => {
     unsafe extern "C" fn $name($(_: $ptype,)*) -> napi_status {
@@ -76,7 +79,10 @@ macro_rules! generate {
   };
 }
 
-#[cfg(target_family = "wasm")]
+#[cfg(any(
+  target_family = "wasm",
+  all(not(target_env = "msvc"), not(feature = "dyn-symbols"))
+))]
 macro_rules! generate {
   (extern "C" {
     $(fn $name:ident($($param:ident: $ptype:ty$(,)?)*)$( -> $rtype:ty)?;)+
@@ -95,7 +101,10 @@ mod types;
 pub use functions::*;
 pub use types::*;
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(any(
+  target_env = "msvc",
+  all(not(target_family = "wasm"), feature = "dyn-symbols")
+))]
 /// Loads N-API symbols from host process.
 /// Must be called at least once before using any functions in bindings or
 /// they will panic

--- a/examples/napi/Cargo.toml
+++ b/examples/napi/Cargo.toml
@@ -48,6 +48,7 @@ napi = { path = "../../crates/napi", default-features = false, features = [
   "node_version_detect",
   "web_stream",
   "error_anyhow",
+  "dyn-symbols",
 ] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined build configuration so dynamic symbol loading is compiled only when supported (MSVC) or when an opt-in feature is enabled; adjusted WebAssembly compilation conditions accordingly.
  * Restricted certain runtime loading paths to builds that enable the opt-in feature or target MSVC.
  * Disabled default features for an internal dependency and enabled the opt-in feature in an example to ensure predictable builds.

Note: No user-facing functionality changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->