### PR TITLE
fix(sys): always require libloading because of msvc

### DIFF
--- a/crates/sys/Cargo.toml
+++ b/crates/sys/Cargo.toml
@@ -13,7 +13,7 @@ version = "3.2.0"
 
 [features]
 default = ["dyn-symbols"]
-dyn-symbols = ["dep:libloading"]
+dyn-symbols = []
 experimental = []
 napi1 = []
 napi2 = ["napi1"]
@@ -30,4 +30,4 @@ napi10 = ["napi9"]
 independent = true
 
 [dependencies]
-libloading = { version = "0.9", optional = true }
+libloading = { version = "0.9" }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended N-API version support through napi10, enabling compatibility with additional Node.js native module versions and greater version targeting flexibility.

* **Chores**
  * Updated library dependency structure and dynamic symbol loading configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->