### PR TITLE
chore: set napi.rs as homepage in package.json

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -3,7 +3,7 @@
   "version": "3.5.0",
   "description": "Cli tools for napi-rs",
   "author": "LongYinan <lynweklm@gmail.com>",
-  "homepage": "https://github.com/napi-rs/napi-rs",
+  "homepage": "https://napi.rs/",
   "license": "MIT",
   "type": "module",
   "engines": {

--- a/triples/package.json
+++ b/triples/package.json
@@ -11,7 +11,7 @@
     "napi-rs"
   ],
   "author": "LongYinan <lynweklm@gmail.com>",
-  "homepage": "https://github.com/napi-rs/napi-rs/tree/main/triples#readme",
+  "homepage": "https://napi.rs/",
   "license": "MIT",
   "type": "module",
   "main": "./index.js",
@@ -39,7 +39,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/napi-rs/napi-rs.git"
+    "url": "git+https://github.com/napi-rs/napi-rs.git",
+    "directory": "triples"
   },
   "bugs": {
     "url": "https://github.com/napi-rs/napi-rs/issues"

--- a/wasm-runtime/package.json
+++ b/wasm-runtime/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.0",
   "type": "module",
   "description": "Runtime and polyfill for wasm targets",
+  "homepage": "https://napi.rs/",
   "author": {
     "name": "LongYinan",
     "url": "https://github.com/Brooooooklyn"


### PR DESCRIPTION
Adds napi website as homepage in package.json

This will allow users viewing napi-rs projects on npmjs website to access the website directly.
It's similar to how [vite](https://www.npmjs.com/package/vite) links to [vitejs.dev](https://vitejs.dev/) under homepage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project homepage URLs across modules to reference the official project website
  * Added repository directory configuration for better package management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->