### PR TITLE
fix(napi): check NAPI status before using pointers in fallback paths

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/buffer.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/buffer.rs
@@ -14,7 +14,7 @@ use crate::{
   bindgen_prelude::*, check_status, env::EMPTY_VEC, sys, JsValue, Result, Value, ValueType,
 };
 
-#[cfg(all(debug_assertions, not(windows)))]
+#[cfg(all(debug_assertions, not(windows), not(target_family = "wasm")))]
 thread_local! {
   pub (crate) static BUFFER_DATA: Mutex<HashSet<*mut u8>> = Default::default();
 }


### PR DESCRIPTION
In fallback paths for `napi_no_external_buffers_allowed` (primarily
Electron environments), the code was using pointers returned from
`napi_create_arraybuffer` before checking the status. This could lead
to undefined behavior if:

1. The NAPI call failed (pointer would be undefined)
2. Length was 0 (Node.js may return NULL per documented behavior in
   nodejs/node#32089)

This fix ensures:
- Status is checked immediately after `napi_create_arraybuffer`
- Copy operations are guarded with `len > 0` checks
- `std::slice::from_raw_parts_mut` is never called with potentially
  NULL pointers

Affected locations:
- ArrayBuffer::from_data, from_external
- ToNapiValue for TypedArray (impl_typed_array! macro)
- ToNapiValue for &mut TypedArray (impl_typed_array! macro)
- impl_from_slice! macro (from_data, from_external)
- Uint8ClampedSlice::from_data, from_external
- Env::create_arraybuffer_with_data (deprecated)
- Env::create_arraybuffer_with_borrowed_data (deprecated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens safety and error handling in ArrayBuffer/TypedArray creation, especially in environments that disallow external buffers (e.g., Electron).
> 
> - Immediate `check_status!` after `napi_create_arraybuffer` before using returned pointers; copy operations now guarded with `len > 0`
> - Ensures finalize callbacks are always invoked in fallback paths, even on error, and avoids constructing slices from NULL pointers
> - Refactors `ToNapiValue` for `TypedArray` and `&mut TypedArray` to handle `napi_no_external_buffers_allowed` with explicit status checks and safe copy
> - Applies the same fixes to `impl_from_slice!`-generated methods and `Uint8ClampedSlice` (`from_data`, `from_external`)
> - Updates deprecated `Env::{create_arraybuffer_with_data,create_arraybuffer_with_borrowed_data}` to mirror the above safety checks
> - Disables debug-only `BUFFER_DATA` tracking on `wasm` targets
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f43d03e965834a38629833a5d0db3c1b5c052b20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added guards to skip copies for zero-length buffers/arraybuffers and ensured consistent finalization and explicit error/status checks so creation failures surface reliably.
  * Disabled debug-only buffer diagnostics on WebAssembly targets to avoid incorrect debug paths.

* **Refactor**
  * Consolidated external vs internal buffer/arraybuffer creation flows with explicit status handling and consistent fallbacks for more reliable error propagation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->