### PR TITLE
fix(napi): validate status before copying in remaining TypedArray fallback paths

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/arraybuffer.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/arraybuffer.rs
@@ -819,57 +819,70 @@ macro_rules! impl_typed_array {
         let length = val_length * ratio;
         let val_data = val.data;
         let mut copied_val = None;
-        check_status!(
-          if length == 0 {
-            // Rust uses 0x1 as the data pointer for empty buffers,
-            // but NAPI/V8 only allows multiple buffers to have
-            // the same data pointer if it's 0x0.
+        if length == 0 {
+          // Rust uses 0x1 as the data pointer for empty buffers,
+          // but NAPI/V8 only allows multiple buffers to have
+          // the same data pointer if it's 0x0.
+          check_status!(
             unsafe {
               sys::napi_create_arraybuffer(env, length, ptr::null_mut(), &mut arraybuffer_value)
-            }
-          } else {
-            // manually copy the data instead of implement `Clone` & `Copy` for TypedArray
-            // the TypedArray can't be copied if raw is not None
-            let val_copy = $name {
-              data: val.data,
-              length: val.length,
-              capacity: val.capacity,
-              byte_offset: val.byte_offset,
-              raw: None,
-              finalizer_notify: val.finalizer_notify,
-            };
-            let hint_ref: &mut $name = Box::leak(Box::new(val_copy));
-            let hint_ptr = hint_ref as *mut $name;
-            copied_val = Some(hint_ref);
-            let status = unsafe {
-              sys::napi_create_external_arraybuffer(
+            },
+            "Create external arraybuffer failed"
+          )?;
+        } else {
+          // manually copy the data instead of implement `Clone` & `Copy` for TypedArray
+          // the TypedArray can't be copied if raw is not None
+          let val_copy = $name {
+            data: val.data,
+            length: val.length,
+            capacity: val.capacity,
+            byte_offset: val.byte_offset,
+            raw: None,
+            finalizer_notify: val.finalizer_notify,
+          };
+          let hint_ref: &mut $name = Box::leak(Box::new(val_copy));
+          let hint_ptr = hint_ref as *mut $name;
+          copied_val = Some(hint_ref);
+          let mut status = unsafe {
+            sys::napi_create_external_arraybuffer(
+              env,
+              val_data.cast(),
+              length,
+              Some(finalizer::<$rust_type, $name>),
+              hint_ptr.cast(),
+              &mut arraybuffer_value,
+            )
+          };
+          if status == napi_sys::Status::napi_no_external_buffers_allowed {
+            let hint = unsafe { Box::from_raw(hint_ptr) };
+            // Reset copied_val since hint is being reclaimed and will be dropped
+            copied_val = None;
+            // Clear val's data fields IMMEDIATELY after reclaiming hint.
+            // hint now owns the data and will free it when dropped (including on early return).
+            // We must clear val's fields before any check_status! that could return early,
+            // otherwise val would have dangling pointers if we return with an error.
+            // Note: hint.data still has the valid pointer for the copy operation below.
+            val.data = ptr::null_mut();
+            val.length = 0;
+            val.capacity = 0;
+            val.finalizer_notify = ptr::null_mut::<fn(*mut $rust_type, usize)>();
+            let mut underlying_data = ptr::null_mut();
+            status = unsafe {
+              sys::napi_create_arraybuffer(
                 env,
-                val_data.cast(),
                 length,
-                Some(finalizer::<$rust_type, $name>),
-                hint_ptr.cast(),
+                &mut underlying_data,
                 &mut arraybuffer_value,
               )
             };
-            if status == napi_sys::Status::napi_no_external_buffers_allowed {
-              let hint = unsafe { Box::from_raw(hint_ptr) };
-              let mut underlying_data = ptr::null_mut();
-              let status = unsafe {
-                sys::napi_create_arraybuffer(
-                  env,
-                  length,
-                  &mut underlying_data,
-                  &mut arraybuffer_value,
-                )
-              };
+            check_status!(status, "Create external arraybuffer failed")?;
+            if length > 0 {
               unsafe { std::ptr::copy_nonoverlapping(hint.data.cast(), underlying_data, length) };
-              status
-            } else {
-              status
             }
-          },
-          "Create external arraybuffer failed"
-        )?;
+          } else {
+            check_status!(status, "Create external arraybuffer failed")?;
+          }
+        }
         let mut napi_val = ptr::null_mut();
         check_status!(
           unsafe {
@@ -961,14 +974,17 @@ macro_rules! impl_from_slice {
               &mut buf,
             )
           };
-          let underlying_slice: &mut [u8] =
-            unsafe { std::slice::from_raw_parts_mut(underlying_data.cast(), data.len()) };
-          underlying_slice.copy_from_slice(unsafe { core::slice::from_raw_parts(inner_ptr.cast(), array_buffer_len) });
+          check_status!(status, "Failed to create buffer slice from data")?;
+          if array_buffer_len > 0 {
+            let underlying_slice: &mut [u8] =
+              unsafe { std::slice::from_raw_parts_mut(underlying_data.cast(), array_buffer_len) };
+            underlying_slice.copy_from_slice(unsafe { core::slice::from_raw_parts(inner_ptr.cast(), array_buffer_len) });
+          }
           inner_ptr = underlying_data.cast();
         } else {
+          check_status!(status, "Failed to create buffer slice from data")?;
           mem::forget(data);
         }
-        check_status!(status, "Failed to create buffer slice from data")?;
 
         let mut napi_val = ptr::null_mut();
         check_status!(
@@ -1052,10 +1068,10 @@ macro_rules! impl_from_slice {
             &mut arraybuffer_value,
           )
         };
-        status = if status == sys::Status::napi_no_external_buffers_allowed {
+        if status == sys::Status::napi_no_external_buffers_allowed {
           let (hint, finalize) = *Box::from_raw(hint_ptr);
           let mut underlying_data = ptr::null_mut();
-          let status = unsafe {
+          status = unsafe {
             sys::napi_create_arraybuffer(
               env.0,
               array_buffer_len,
@@ -1063,15 +1079,18 @@ macro_rules! impl_from_slice {
               &mut arraybuffer_value,
             )
           };
-          let underlying_slice: &mut [u8] =
-            unsafe { std::slice::from_raw_parts_mut(underlying_data.cast(), array_buffer_len) };
-          underlying_slice.copy_from_slice(unsafe { std::slice::from_raw_parts(data.cast(), array_buffer_len) });
+          // Copy data before calling finalize, since finalize may free the source data
+          if status == sys::Status::napi_ok && array_buffer_len > 0 {
+            let underlying_slice: &mut [u8] =
+              unsafe { std::slice::from_raw_parts_mut(underlying_data.cast(), array_buffer_len) };
+            underlying_slice.copy_from_slice(unsafe { std::slice::from_raw_parts(data.cast(), array_buffer_len) });
+          }
+          // Always call finalize to clean up caller's resources, even on error
           finalize(*env, hint);
-          status
+          check_status!(status, "Failed to create arraybuffer from data")?;
         } else {
-          status
-        };
-        check_status!(status, "Failed to create arraybuffer from data")?;
+          check_status!(status, "Failed to create arraybuffer from data")?;
+        }
 
         let mut napi_val = ptr::null_mut();
         check_status!(
@@ -1672,14 +1691,17 @@ impl<'env> Uint8ClampedSlice<'env> {
       }
       let mut underlying_data = ptr::null_mut();
       status = unsafe { sys::napi_create_arraybuffer(env.0, len, &mut underlying_data, &mut buf) };
-      let underlying_slice: &mut [u8] =
-        unsafe { std::slice::from_raw_parts_mut(underlying_data.cast(), len) };
-      underlying_slice.copy_from_slice(data.as_slice());
+      check_status!(status, "Failed to create arraybuffer")?;
+      if len > 0 {
+        let underlying_slice: &mut [u8] =
+          unsafe { std::slice::from_raw_parts_mut(underlying_data.cast(), len) };
+        underlying_slice.copy_from_slice(data.as_slice());
+      }
       inner_ptr = underlying_data.cast();
     } else {
+      check_status!(status, "Failed to create arraybuffer")?;
       mem::forget(data);
     }
-    check_status!(status, "Failed to create buffer slice from data")?;
 
     let mut napi_val = ptr::null_mut();
     check_status!(
@@ -1762,21 +1784,24 @@ impl<'env> Uint8ClampedSlice<'env> {
         &mut arraybuffer_value,
       )
     };
-    status = if status == sys::Status::napi_no_external_buffers_allowed {
+    if status == sys::Status::napi_no_external_buffers_allowed {
       let (hint, finalize) = *Box::from_raw(hint_ptr);
       let mut underlying_data = ptr::null_mut();
-      let status = unsafe {
+      status = unsafe {
         sys::napi_create_arraybuffer(env.0, len, &mut underlying_data, &mut arraybuffer_value)
       };
-      let underlying_slice: &mut [u8] =
-        unsafe { std::slice::from_raw_parts_mut(underlying_data.cast(), len) };
-      underlying_slice.copy_from_slice(unsafe { std::slice::from_raw_parts(data, len) });
+      // Copy data before calling finalize, since finalize may free the source data
+      if status == sys::Status::napi_ok && len > 0 {
+        let underlying_slice: &mut [u8] =
+          unsafe { std::slice::from_raw_parts_mut(underlying_data.cast(), len) };
+        underlying_slice.copy_from_slice(unsafe { std::slice::from_raw_parts(data, len) });
+      }
+      // Always call finalize to clean up caller's resources, even on error
       finalize(*env, hint);
-      status
+      check_status!(status, "Failed to create arraybuffer from data")?;
     } else {
-      status
-    };
-    check_status!(status, "Failed to create arraybuffer from data")?;
+      check_status!(status, "Failed to create arraybuffer from data")?;
+    }
 
     let mut napi_val = ptr::null_mut();
     check_status!(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens error handling and memory safety across ArrayBuffer/TypedArray creation and fallback paths.
> 
> - In fallback when external arraybuffers aren’t allowed, now check `status` before copying, only copy when `length > 0`, and always call `finalize`; propagate errors consistently
> - In `&mut TypedArray::to_napi_value`, reclaim leaked hint safely and immediately clear `val` fields before early returns to avoid dangling pointers; copy into newly allocated ArrayBuffer when needed
> - Add missing `check_status!` validations for buffer creation across typed array slices and `Uint8ClampedSlice`, including zero-length guards
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2e1e07be74cd4cd41c87b88c2acd830a5b05007. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved buffer creation logic with enhanced error handling and validation.
  * Added safeguards for zero-length buffer operations to prevent edge-case failures.
  * Strengthened fallback mechanisms and error propagation in buffer creation paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->