### PR TITLE
fix(napi): skip debug buffer tracking on wasm targets

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/arraybuffer.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/arraybuffer.rs
@@ -148,7 +148,7 @@ impl<'env> ArrayBuffer<'env> {
     let mut buf = ptr::null_mut();
     let mut data = data.into();
     let mut inner_ptr = data.as_mut_ptr();
-    #[cfg(all(debug_assertions, not(windows)))]
+    #[cfg(all(debug_assertions, not(windows), not(target_family = "wasm")))]
     {
       let is_existed = super::BUFFER_DATA.with(|buffer_data| {
         let buffer = buffer_data.lock().expect("Unlock buffer data failed");
@@ -229,7 +229,7 @@ impl<'env> ArrayBuffer<'env> {
         "Borrowed data should not be null".to_owned(),
       ));
     }
-    #[cfg(all(debug_assertions, not(windows)))]
+    #[cfg(all(debug_assertions, not(windows), not(target_family = "wasm")))]
     {
       let is_existed = super::BUFFER_DATA.with(|buffer_data| {
         let buffer = buffer_data.lock().expect("Unlock buffer data failed");
@@ -916,7 +916,7 @@ macro_rules! impl_from_slice {
         let mut buf = ptr::null_mut();
         let mut data = data.into();
         let mut inner_ptr = data.as_mut_ptr();
-        #[cfg(all(debug_assertions, not(windows)))]
+        #[cfg(all(debug_assertions, not(windows), not(target_family = "wasm")))]
         {
           let is_existed = super::BUFFER_DATA.with(|buffer_data| {
             let buffer = buffer_data.lock().expect("Unlock buffer data failed");
@@ -1021,7 +1021,7 @@ macro_rules! impl_from_slice {
             "Borrowed data should not be null".to_owned(),
           ));
         }
-        #[cfg(all(debug_assertions, not(windows)))]
+        #[cfg(all(debug_assertions, not(windows), not(target_family = "wasm")))]
         {
           let is_existed = super::BUFFER_DATA.with(|buffer_data| {
             let buffer = buffer_data.lock().expect("Unlock buffer data failed");
@@ -1635,7 +1635,7 @@ impl<'env> Uint8ClampedSlice<'env> {
     let mut buf = ptr::null_mut();
     let mut data: Vec<u8> = data.into();
     let mut inner_ptr = data.as_mut_ptr();
-    #[cfg(all(debug_assertions, not(windows)))]
+    #[cfg(all(debug_assertions, not(windows), not(target_family = "wasm")))]
     {
       let is_existed = super::BUFFER_DATA.with(|buffer_data| {
         let buffer = buffer_data.lock().expect("Unlock buffer data failed");
@@ -1732,7 +1732,7 @@ impl<'env> Uint8ClampedSlice<'env> {
         "Borrowed data should not be null".to_owned(),
       ));
     }
-    #[cfg(all(debug_assertions, not(windows)))]
+    #[cfg(all(debug_assertions, not(windows), not(target_family = "wasm")))]
     {
       let is_existed = super::BUFFER_DATA.with(|buffer_data| {
         let buffer = buffer_data.lock().expect("Unlock buffer data failed");

--- a/crates/napi/src/bindgen_runtime/js_values/buffer.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/buffer.rs
@@ -14,7 +14,7 @@ use crate::{
   bindgen_prelude::*, check_status, env::EMPTY_VEC, sys, JsValue, Result, Value, ValueType,
 };
 
-#[cfg(all(debug_assertions, not(windows)))]
+#[cfg(all(debug_assertions, not(windows), not(target_family = "wasm")))]
 thread_local! {
   pub (crate) static BUFFER_DATA: Mutex<HashSet<*mut u8>> = Default::default();
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts debug-only buffer tracking to exclude WebAssembly targets.
> 
> - Adds `not(target_family = "wasm")` to `#[cfg(all(debug_assertions, not(windows)))]` guards
> - Applies to `BUFFER_DATA` thread_local in `buffer.rs` and duplicate-pointer checks in `arraybuffer.rs` (including typed array slices and `Uint8ClampedSlice`)
> - Prevents wasm builds from using debug TLS-based pointer checks/panics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac6a276aacabb997ab9a7bb3f5fca5f02b0be1a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined platform-specific debug behavior to disable certain debug-only buffer checks on WebAssembly builds while preserving them on other platforms; public APIs remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->