### PR TITLE
fix(napi): wasi debug compile error

### DIFF
--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -753,6 +753,11 @@ jobs:
           targets: wasm32-wasip1-threads
       - name: Install dependencies
         run: yarn install --immutable --mode=skip-build
+      - name: Check
+        if: ${{ matrix.settings.RUSTFLAGS == '--cfg tokio_unstable' }}
+        run: cargo check -p napi --all-features --target wasm32-wasip1-threads
+        env:
+          RUSTFLAGS: ${{ matrix.settings.RUSTFLAGS }}
       - name: Build
         run: |
           yarn build

--- a/crates/napi/src/bindgen_runtime/js_values/buffer.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/buffer.rs
@@ -1,11 +1,11 @@
-#[cfg(all(debug_assertions, not(windows)))]
+#[cfg(all(debug_assertions, not(windows), not(target_family = "wasm")))]
 use std::collections::HashSet;
 use std::ffi::c_void;
 use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::ptr::{self, NonNull};
 use std::slice;
-#[cfg(all(debug_assertions, not(windows)))]
+#[cfg(all(debug_assertions, not(windows), not(target_family = "wasm")))]
 use std::sync::Mutex;
 
 #[cfg(all(feature = "napi4", not(feature = "noop")))]
@@ -39,7 +39,7 @@ impl<'env> BufferSlice<'env> {
     let mut buf = ptr::null_mut();
     let mut data = data.into();
     let inner_ptr = data.as_mut_ptr();
-    #[cfg(all(debug_assertions, not(windows)))]
+    #[cfg(all(debug_assertions, not(windows), not(target_family = "wasm")))]
     {
       let is_existed = BUFFER_DATA.with(|buffer_data| {
         let buffer = buffer_data.lock().expect("Unlock buffer data failed");
@@ -121,7 +121,7 @@ impl<'env> BufferSlice<'env> {
         "Borrowed data should not be null".to_owned(),
       ));
     }
-    #[cfg(all(debug_assertions, not(windows)))]
+    #[cfg(all(debug_assertions, not(windows), not(target_family = "wasm")))]
     {
       let is_existed = BUFFER_DATA.with(|buffer_data| {
         let buffer = buffer_data.lock().expect("Unlock buffer data failed");
@@ -370,7 +370,7 @@ impl Default for Buffer {
 impl From<Vec<u8>> for Buffer {
   fn from(mut data: Vec<u8>) -> Self {
     let inner_ptr = data.as_mut_ptr();
-    #[cfg(all(debug_assertions, not(windows)))]
+    #[cfg(all(debug_assertions, not(windows), not(target_family = "wasm")))]
     {
       let is_existed = BUFFER_DATA.with(|buffer_data| {
         let buffer = buffer_data.lock().expect("Unlock buffer data failed");

--- a/crates/napi/src/bindgen_runtime/mod.rs
+++ b/crates/napi/src/bindgen_runtime/mod.rs
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn drop_buffer(
   #[allow(unused)] finalize_data: *mut c_void,
   finalize_hint: *mut c_void,
 ) {
-  #[cfg(all(debug_assertions, not(windows)))]
+  #[cfg(all(debug_assertions, not(windows), not(target_family = "wasm")))]
   {
     js_values::BUFFER_DATA.with(|buffer_data| {
       let mut buffer = buffer_data.lock().expect("Unlock Buffer data failed");
@@ -101,7 +101,7 @@ pub unsafe extern "C" fn drop_buffer_slice(
   finalize_hint: *mut c_void,
 ) {
   let (len, cap): (usize, usize) = *unsafe { Box::from_raw(finalize_hint.cast()) };
-  #[cfg(all(debug_assertions, not(windows)))]
+  #[cfg(all(debug_assertions, not(windows), not(target_family = "wasm")))]
   {
     js_values::BUFFER_DATA.with(|buffer_data| {
       let mut buffer = buffer_data.lock().expect("Unlock Buffer data failed");

--- a/crates/napi/src/env.rs
+++ b/crates/napi/src/env.rs
@@ -1114,7 +1114,7 @@ impl Env {
       })?;
     }
 
-    #[cfg(target_family = "wasm")]
+    #[cfg(all(target_family = "wasm", not(feature = "noop")))]
     {
       check_status!(unsafe {
         crate::napi_add_env_cleanup_hook(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Addresses WASI debug build issues and strengthens WASI CI.
> 
> - Excludes `wasm` from debug-only buffer tracking and GC cleanup paths (`js_values/buffer.rs`, `bindgen_runtime/mod.rs`) via `#[cfg(all(debug_assertions, not(windows), not(target_family = "wasm")))]`
> - Tightens WASM cleanup hook gating to `#[cfg(all(target_family = "wasm", not(feature = "noop")))]` in `env.rs`
> - CI: Adds conditional `cargo check -p napi --all-features --target wasm32-wasip1-threads` when `RUSTFLAGS == '--cfg tokio_unstable'` in `test-node-wasi`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffc8cb9934df9e8faa213337674204a4cecacf0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added build validation step for WebAssembly target with all features enabled.
  * Optimized WebAssembly builds by excluding debug-only assertions and code tracking, reducing binary size and overhead.
  * Refined WebAssembly feature flag handling for better configuration control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->