### PR TITLE
chore(cli): add --version command

### DIFF
--- a/cli/src/commands/cli-version.ts
+++ b/cli/src/commands/cli-version.ts
@@ -1,0 +1,15 @@
+import { Command } from 'clipanion'
+
+import { CLI_VERSION } from '../utils/misc.js'
+
+/**
+ * A command that prints the version of the CLI.
+ *
+ * Paths: `-v`, `--version`
+ */
+export class CliVersionCommand extends Command<any> {
+  static paths = [[`-v`], [`--version`]]
+  async execute() {
+    await this.context.stdout.write(`${CLI_VERSION}\n`)
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -10,6 +10,7 @@ import { universalizeBinaries } from './api/universalize.js'
 import { version } from './api/version.js'
 import { ArtifactsCommand } from './commands/artifacts.js'
 import { BuildCommand } from './commands/build.js'
+import { CliVersionCommand } from './commands/cli-version.js'
 import { CreateNpmDirsCommand } from './commands/create-npm-dirs.js'
 import { HelpCommand } from './commands/help.js'
 import { NewCommand } from './commands/new.js'
@@ -33,6 +34,7 @@ cli.register(RenameCommand)
 cli.register(PrePublishCommand)
 cli.register(VersionCommand)
 cli.register(HelpCommand)
+cli.register(CliVersionCommand)
 
 /**
  *


### PR DESCRIPTION
- Close https://github.com/napi-rs/napi-rs/issues/3070

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new version command and wires it into the CLI.
> 
> - Introduces `CliVersionCommand` that writes `CLI_VERSION` to stdout (paths: `-v`, `--version`)
> - Registers the command in `cli/src/index.ts` so flags are recognized across the CLI
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f390a69cd2af6b0fa2f6b1cce7282106c234bec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `-v` and `--version` CLI flags to display the installed CLI version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->