### PR TITLE
ci: use cargo-zigbuild to build freebsd target

### DIFF
--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -686,6 +686,45 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+      - name: Install ziglang
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+      - uses: jaxxstorm/action-install-gh-release@v1
+        with:
+          repo: rust-cross/cargo-zigbuild
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'yarn'
+
+      - name: Install
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: x86_64-unknown-freebsd
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: stable-cargo-cache-build-freebsd
+
+      - name: 'Install dependencies'
+        run: |
+          yarn config set supportedArchitectures.cpu --json '["current", "x64", "arm64", "wasm32"]'
+          yarn config set supportedArchitectures.os --json '["current", "freebsd"]'
+          yarn install --mode=skip-build --immutable
+      - name: Build
+        run: |
+          yarn workspace @examples/napi build --target x86_64-unknown-freebsd -x
+          yarn tsc -p examples/napi/tsconfig.json
+          rm -rf examples/napi/__tests__
+          mv examples/napi/dist/__tests__ examples/napi/
       - name: Test
         id: build
         uses: cross-platform-actions/action@v0.32.0
@@ -697,7 +736,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           operating_system: freebsd
-          version: '14.3'
+          version: '15.0'
           memory: 12G
           cpu_count: 3
           environment_variables: 'DEBUG RUSTUP_IO_THREADS GITHUB_TOKEN'
@@ -707,11 +746,6 @@ jobs:
             sudo pkg install -y -f curl node libnghttp2 npm
             sudo npm install -g corepack
             sudo corepack enable
-            curl https://sh.rustup.rs -sSf --output rustup.sh
-            sh rustup.sh -y --default-toolchain stable
-            source "$HOME/.cargo/env"
-            echo "~~~~ rustc --version ~~~~"
-            rustc --version
             echo "~~~~ node -v ~~~~"
             node -v
             echo "~~~~ yarn --version ~~~~"
@@ -721,14 +755,7 @@ jobs:
             whoami
             env
             freebsd-version
-            yarn config set supportedArchitectures.cpu --json '["current", "wasm32"]'
             export NODE_OPTIONS="--max-old-space-size=8192"
-            export CARGO_PROFILE_DEV_OPT_LEVEL="1"
-            yarn install --immutable --mode=skip-build
-            yarn workspace @examples/napi build
-            yarn tsc -p examples/napi/tsconfig.json
-            rm -rf examples/napi/__tests__
-            mv examples/napi/dist/__tests__ examples/napi/
             yarn workspace @examples/napi test-js -s
 
   test-node-wasi:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Overhauls the FreeBSD CI job to cross-build and test more reliably.
> 
> - Adds `zig` and `cargo-zigbuild`, configures Yarn arch/OS, and caches Cargo for faster builds
> - Cross-builds `@examples/napi` for `x86_64-unknown-freebsd` on Ubuntu, compiles TS, and prepares test fixtures
> - Runs tests on FreeBSD via `cross-platform-actions` upgraded from `14.3` to `15.0`
> - Removes in-VM Rust installation and previous on-VM build steps in favor of prebuilt artifacts
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23da25bd6eb99c67b84fccc8b7ebdb1970ce65bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Overhauled CI workflow for FreeBSD: added a comprehensive setup and build/test sequence and consolidated test artifacts handling.
  * Added release publishing steps to the workflow and replaced the previous lean FreeBSD test path, removing several legacy setup checks and per-target build steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->