### PR TITLE
chore: tokio_unstable is required for async wasi codes

### DIFF
--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -762,12 +762,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Test node wasi target
     timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        settings:
-          - RUSTFLAGS: '--cfg tokio_unstable'
-          - RUSTFLAGS: ''
     steps:
       - uses: actions/checkout@v6
       - name: Setup node
@@ -784,15 +778,15 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable --mode=skip-build
       - name: Check
-        if: ${{ matrix.settings.RUSTFLAGS == '--cfg tokio_unstable' }}
         run: cargo check -p napi --all-features --target wasm32-wasip1-threads
         env:
-          RUSTFLAGS: ${{ matrix.settings.RUSTFLAGS }}
+          RUSTFLAGS: '--cfg tokio_unstable'
       - name: Build
         run: |
           yarn build
-          export RUSTFLAGS="${{ matrix.settings.RUSTFLAGS }}"
           yarn workspace @examples/napi build --target wasm32-wasip1-threads --profile wasi
+        env:
+          RUSTFLAGS: '--cfg tokio_unstable'
       - name: Test
         run: yarn workspace @examples/napi test -s
         env:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Simplifies the `test-node-wasi` GitHub Actions job and standardizes build flags.
> 
> - Removes the RUSTFLAGS matrix and unconditionally sets `RUSTFLAGS='--cfg tokio_unstable'` for `cargo check` and the `@examples/napi` WASI build
> - Adds explicit `env` blocks for the Build step; other steps and jobs remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24da1eb6160c771cfe75bad5d2c8142e6ccc5be9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined CI/CD build and test pipeline configuration by simplifying matrix-based settings and standardizing build environment variables. These changes optimize the testing workflow without affecting end-user functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->