### PR TITLE
docs: replace `BufferRef` mention with `BufferSlice`

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values/buffer.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/buffer.rs
@@ -291,7 +291,7 @@ impl DerefMut for BufferSlice<'_> {
 
 /// Zero copy u8 vector shared between rust and napi.
 /// It's designed to be used in `async` context, so it contains overhead to ensure the underlying data is not dropped.
-/// For non-async context, use `BufferRef` instead.
+/// For non-async context, use `BufferSlice` instead.
 ///
 /// Auto reference the raw JavaScript value, and release it when dropped.
 /// So it is safe to use it in `async fn`, the `&[u8]` under the hood will not be dropped until the `drop` called.


### PR DESCRIPTION
There is no `BufferRef` symbol in `napi-rs`. Based on the docstrings, this is likely referring to `BufferSlice`, which seems to be a non-async alternative for `Buffer`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified buffer usage guidance in documentation comments for improved developer reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->