### PR TITLE
fix(cli): respect --cross-compile when host matches target

### DIFF
--- a/cli/src/api/build.ts
+++ b/cli/src/api/build.ts
@@ -381,35 +381,11 @@ class Builder {
           set = true
         }
       } else {
-        if (
-          this.target.platform === 'linux' &&
-          process.platform === 'linux' &&
-          this.target.arch === process.arch &&
-          (function (abi: string | null) {
-            const glibcVersionRuntime =
-              // @ts-expect-error
-              process.report?.getReport()?.header?.glibcVersionRuntime
-            const libc = glibcVersionRuntime ? 'gnu' : 'musl'
-            return abi === libc
-          })(this.target.abi)
-        ) {
-          debug.warn(
-            'You are trying to cross compile to linux target on linux platform which is unnecessary.',
-          )
-        } else if (
-          this.target.platform === 'darwin' &&
-          process.platform === 'darwin'
-        ) {
-          debug.warn(
-            'You are trying to cross compile to darwin target on darwin platform which is unnecessary.',
-          )
-        } else {
-          // use cargo-zigbuild to cross compile to other platforms
-          debug('Use %i', 'cargo-zigbuild')
-          tryInstallCargoBinary('cargo-zigbuild', 'zigbuild')
-          this.args.push('zigbuild')
-          set = true
-        }
+        // use cargo-zigbuild to cross compile to other platforms
+        debug('Use %i', 'cargo-zigbuild')
+        tryInstallCargoBinary('cargo-zigbuild', 'zigbuild')
+        this.args.push('zigbuild')
+        set = true
       }
     }
 


### PR DESCRIPTION
When `--cross-compile` / `-x` is passed, `cargo-zigbuild` should run regardless of whether the host platform matches the target. This allows pinning a lower glibc version via zig's linker on native builds.

This was fixed in v2 by #1432 (fixing #1430) but the fix was not carried over to the v3 CLI rewrite in #1492. The v3 code skips `cargo-zigbuild` when host platform/arch/abi matches the target, logging a warning but silently falling through to `cargo build`, which links against the host glibc.

Without this fix, projects building `x86_64-unknown-linux-gnu` on `ubuntu-latest` (glibc 2.39) produce binaries incompatible with glibc < 2.35 systems like Amazon Linux 2023 (glibc 2.34) and Vercel's build container.

changes:
- `cli/src/api/build.ts`: remove the platform-match conditions in the `else` branch of `pickBinary()` that skip `cargo-zigbuild` when host equals target on linux or darwin. when `--cross-compile` is explicitly passed for a non-windows target, always use `cargo-zigbuild`.

relates to #1430

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized cross-platform compilation for non-Windows targets for more consistent builds.
* **Bug Fixes**
  * Removed spurious cross-compile warnings so build output is clearer and less noisy.
* **Chores**
  * Switched non-Windows cross-compiles to use a Zig-based build tool to ensure consistent toolchain behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->