### PR TITLE
fix(cli): parallelize type definition generation deterministically

### DIFF
--- a/cli/src/api/__tests__/build.spec.ts
+++ b/cli/src/api/__tests__/build.spec.ts
@@ -184,6 +184,31 @@ napi-build = { path = "${napiBuildPath}" }
   t.regex(jsContent, /module\.exports\.sum = nativeBinding\.sum/)
 })
 
+test('generateTypeDef preserves deterministic file order', async (t) => {
+  const { projectDir, typeDefDir } = t.context
+
+  await mkdir(join(typeDefDir, 'nested'), { recursive: true })
+  await writeFile(
+    join(typeDefDir, 'b.type'),
+    '{"kind":"fn","name":"zeta","def":"function zeta(): void"}\n',
+  )
+  await writeFile(
+    join(typeDefDir, 'a.type'),
+    '{"kind":"fn","name":"alpha","def":"function alpha(): void"}\n',
+  )
+
+  const { exports, dts } = await generateTypeDef({
+    typeDefDir,
+    cwd: projectDir,
+  })
+
+  t.deepEqual(exports, ['alpha', 'zeta'])
+  t.true(
+    dts.indexOf('function alpha(): void') <
+      dts.indexOf('function zeta(): void'),
+  )
+})
+
 test('should throw on emnapi version mismatch in wasm build', async (t) => {
   const { projectDir } = t.context
   const crateName = 'wasm_version_check'

--- a/cli/src/api/build.ts
+++ b/cli/src/api/build.ts
@@ -1093,19 +1093,21 @@ export async function generateTypeDef(
     return { exports: [], dts: '' }
   }
 
-  for (const file of files) {
-    if (!file.isFile()) {
-      continue
-    }
+  const typeDefFiles = files
+    .filter((file) => file.isFile())
+    .sort((a, b) => a.name.localeCompare(b.name))
 
-    const { dts: fileDts, exports: fileExports } = await processTypeDef(
-      join(options.typeDefDir, file.name),
-      options.constEnum ?? true,
-    )
+  const processedTypeDefs = await Promise.all(
+    typeDefFiles.map((file) =>
+      processTypeDef(
+        join(options.typeDefDir, file.name),
+        options.constEnum ?? true,
+      ),
+    ),
+  )
 
-    dts += fileDts
-    exports.push(...fileExports)
-  }
+  dts = processedTypeDefs.map(({ dts }) => dts).join('')
+  exports = processedTypeDefs.flatMap(({ exports }) => exports)
 
   if (dts.indexOf('ExternalObject<') > -1) {
     header += `


### PR DESCRIPTION
Fixes: https://github.com/napi-rs/napi-rs/issues/3202

This PR speeds up `.d.ts` generation by processing intermediate type definition files in parallel instead of serially.

`generateTypeDef` previously awaited `processTypeDef` one file at a time. This change switches that work to `Promise.all`, while explicitly sorting filenames first so the final `.d.ts` output and exported identifier order remain deterministic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized type-definition file processing performance by implementing concurrent execution while preserving deterministic ordering and ensuring consistent output generation.

* **Tests**
  * Added test case to verify type-definition files are processed in deterministic order, guaranteeing predictable and consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->