### PR TITLE
fix(cli): preserve existing optionalDependencies in pre-publish

### DIFF
--- a/cli/src/utils/__tests__/misc.spec.ts
+++ b/cli/src/utils/__tests__/misc.spec.ts
@@ -1,0 +1,56 @@
+import { existsSync } from 'node:fs'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import ava, { type TestFn } from 'ava'
+
+import { updatePackageJson } from '../misc.js'
+
+const test = ava as TestFn<{
+  tmpDir: string
+}>
+
+test.beforeEach(async (t) => {
+  t.context = {
+    tmpDir: await mkdtemp(join(tmpdir(), 'napi-rs-misc-spec-')),
+  }
+})
+
+test.afterEach.always(async (t) => {
+  if (existsSync(t.context.tmpDir)) {
+    await rm(t.context.tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('updatePackageJson merges nested objects instead of overwriting them', async (t) => {
+  const packageJsonPath = join(t.context.tmpDir, 'package.json')
+
+  await writeFile(
+    packageJsonPath,
+    JSON.stringify(
+      {
+        name: 'fixture',
+        version: '1.0.0',
+        optionalDependencies: {
+          fsevents: '^2.3.3',
+        },
+      },
+      null,
+      2,
+    ),
+  )
+
+  await updatePackageJson(packageJsonPath, {
+    optionalDependencies: {
+      '@napi-rs/fixture-darwin-arm64': '1.0.1',
+    },
+  })
+
+  const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'))
+
+  t.deepEqual(packageJson.optionalDependencies, {
+    fsevents: '^2.3.3',
+    '@napi-rs/fixture-darwin-arm64': '1.0.1',
+  })
+})

--- a/cli/src/utils/misc.ts
+++ b/cli/src/utils/misc.ts
@@ -43,6 +43,27 @@ export function pick<O, K extends keyof O>(o: O, ...keys: K[]): Pick<O, K> {
   }, {} as O)
 }
 
+function isPlainObject(value: unknown): value is Record<string, any> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function mergePackageJson(
+  old: Record<string, any>,
+  partial: Record<string, any>,
+): Record<string, any> {
+  const merged = { ...old }
+
+  for (const [key, value] of Object.entries(partial)) {
+    if (isPlainObject(merged[key]) && isPlainObject(value)) {
+      merged[key] = mergePackageJson(merged[key], value)
+    } else {
+      merged[key] = value
+    }
+  }
+
+  return merged
+}
+
 export async function updatePackageJson(
   path: string,
   partial: Record<string, any>,
@@ -53,7 +74,10 @@ export async function updatePackageJson(
     return
   }
   const old = JSON.parse(await readFileAsync(path, 'utf8'))
-  await writeFileAsync(path, JSON.stringify({ ...old, ...partial }, null, 2))
+  await writeFileAsync(
+    path,
+    JSON.stringify(mergePackageJson(old, partial), null, 2),
+  )
 }
 
 export const CLI_VERSION = pkgJson.version


### PR DESCRIPTION
Fixes: https://github.com/napi-rs/napi-rs/issues/3206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of nested dependencies in `package.json` updates—existing entries are now preserved and merged with new ones instead of being overwritten.

* **Tests**
  * Added comprehensive test coverage for dependency merge behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->