### PR TITLE
fix(deps): disable ctor priority feature

### DIFF
--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -24,7 +24,7 @@ type-def = ["napi-derive-backend/type-def", "ctor"]
 
 [dependencies]
 convert_case = "0.11"
-ctor = { version = "0.9", optional = true }
+ctor = { version = "0.9", default-features = false, features = ["std", "proc_macro", "dtor", "no_warn_on_missing_unsafe"], optional = true }
 napi-derive-backend = { version = "5.0.2", path = "../backend" }
 proc-macro2 = "1"
 quote = "1"

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -72,7 +72,9 @@ tracing = ["dep:tracing"]
 
 [dependencies]
 bitflags = "2"
-ctor = "0.9.0"
+# Keep ctor's priority support disabled until the Apple/Zig cross-link
+# path stops emitting unresolved `section$end$__DATA$CTOR` references.
+ctor = { version = "0.9.0", default-features = false, features = ["std", "proc_macro", "dtor", "no_warn_on_missing_unsafe"] }
 nohash-hasher = "0.2.0"
 rustc-hash = "2.1.1"
 


### PR DESCRIPTION
## Summary
- opt `ctor` into its non-`priority` default features explicitly in `crates/napi`
- do the same in `crates/macro` so the workspace stays consistent on `ctor 0.9`
- avoid the Apple/Zig cross-link path that ends up with unresolved `section$end$__DATA$CTOR` references at runtime

## Why
`napi-rs` only uses plain `#[ctor]` registration today, not `#[ctor(priority = ...)]`. After the `ctor 0.9` upgrade, the default feature set enables `priority`, which takes a different Apple implementation path. That path is what shows up in the failing `aarch64-apple-darwin` Zig job.

This keeps the `ctor 0.9` upgrade, but restores the pre-`priority` behavior by explicitly enabling the other default features and leaving `priority` off.

## Expected impact
- fixes `ERR_DLOPEN_FAILED` with `symbol not found in flat namespace 'section$end$__DATA$CTOR'`
- no intended runtime behavior change for existing napi-rs module registration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency configuration change that only alters how `ctor` is built (feature set) to avoid Apple/Zig linker/runtime symbol issues; behavior should be unchanged unless code relied on `ctor` priority support.
> 
> **Overview**
> Forces the `ctor` dependency to build with `default-features = false` and an explicit feature list in both `crates/napi` and `crates/macro`, intentionally leaving off `priority` support.
> 
> This keeps the workspace consistent on `ctor 0.9` while avoiding the Apple/Zig cross-link path that can emit unresolved `section$end$__DATA$CTOR` references at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5015f4371e88cc88916ebaa0f9c6caa7aa0b1f05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build configuration for dependency features.

---

**Note:** This release contains internal maintenance updates with no end-user-visible changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->