### PR TITLE
fix(cli): apply enableTypeDef when generating new projects

### DIFF
--- a/cli/src/api/__tests__/new.spec.ts
+++ b/cli/src/api/__tests__/new.spec.ts
@@ -417,7 +417,7 @@ test('create project without type-def', async (t) => {
   const cargoTomlData = parseToml(cargoToml) as any
   t.is(cargoTomlData.dependencies['napi-derive']['default-features'], false)
   t.false(
-    cargoTomlData.dependencies['napi-derive'].features.includes('typedef'),
+    cargoTomlData.dependencies['napi-derive'].features.includes('type-def'),
   )
 })
 

--- a/cli/src/api/__tests__/new.spec.ts
+++ b/cli/src/api/__tests__/new.spec.ts
@@ -416,7 +416,9 @@ test('create project without type-def', async (t) => {
   const cargoToml = await readFile(join(projectPath, 'Cargo.toml'), 'utf-8')
   const cargoTomlData = parseToml(cargoToml) as any
   t.is(cargoTomlData.dependencies['napi-derive']['default-features'], false)
-  t.deepEqual(cargoTomlData.dependencies['napi-derive'].features, ['strict'])
+  t.false(
+    cargoTomlData.dependencies['napi-derive'].features.includes('typedef'),
+  )
 })
 
 test('create a new project with pnpm package manager', async (t) => {

--- a/cli/src/api/__tests__/new.spec.ts
+++ b/cli/src/api/__tests__/new.spec.ts
@@ -415,11 +415,8 @@ test('create project without type-def', async (t) => {
 
   const cargoToml = await readFile(join(projectPath, 'Cargo.toml'), 'utf-8')
   const cargoTomlData = parseToml(cargoToml) as any
-  t.deepEqual(cargoTomlData.dependencies['napi-derive'], {
-    version: '3.0.0',
-    'default-features': false,
-    features: ['strict'],
-  })
+  t.is(cargoTomlData.dependencies['napi-derive']['default-features'], false)
+  t.deepEqual(cargoTomlData.dependencies['napi-derive'].features, ['strict'])
 })
 
 test('create a new project with pnpm package manager', async (t) => {

--- a/cli/src/api/__tests__/new.spec.ts
+++ b/cli/src/api/__tests__/new.spec.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
+import { parse as parseToml } from '@std/toml'
 import ava, { type TestFn } from 'ava'
 import { load as yamlLoad } from 'js-yaml'
 
@@ -401,6 +402,24 @@ test('create project without GitHub Actions', async (t) => {
   t.true(existsSync(projectPath))
   t.true(existsSync(join(projectPath, 'package.json')))
   t.false(existsSync(join(projectPath, '.github')))
+})
+
+test('create project without type-def', async (t) => {
+  const projectPath = join(t.context.tmpDir, 'no-type-def')
+
+  await newProject({
+    path: projectPath,
+    enableDefaultTargets: true,
+    enableTypeDef: false,
+  })
+
+  const cargoToml = await readFile(join(projectPath, 'Cargo.toml'), 'utf-8')
+  const cargoTomlData = parseToml(cargoToml) as any
+  t.deepEqual(cargoTomlData.dependencies['napi-derive'], {
+    version: '3.0.0',
+    'default-features': false,
+    features: ['strict'],
+  })
 })
 
 test('create a new project with pnpm package manager', async (t) => {

--- a/cli/src/api/new.ts
+++ b/cli/src/api/new.ts
@@ -4,6 +4,7 @@ import { homedir } from 'node:os'
 import path from 'node:path'
 import { promises as fs } from 'node:fs'
 
+import { parse as parseToml, stringify as stringifyToml } from '@std/toml'
 import { load as yamlLoad, dump as yamlDump } from 'js-yaml'
 
 import {
@@ -150,6 +151,45 @@ async function filterTargetsInPackageJson(
   }
 
   await fs.writeFile(filePath, JSON.stringify(packageJson, null, 2) + '\n')
+}
+
+async function updateCargoTomlTypeDef(
+  filePath: string,
+  enableTypeDef: boolean,
+): Promise<void> {
+  if (enableTypeDef) {
+    return
+  }
+
+  const content = await fs.readFile(filePath, 'utf-8')
+  const cargoToml = parseToml(content) as Record<string, any>
+  const dependencies = cargoToml.dependencies
+
+  if (!dependencies || !dependencies['napi-derive']) {
+    return
+  }
+
+  const napiDeriveDependency = dependencies['napi-derive']
+  const dependencyConfig =
+    typeof napiDeriveDependency === 'string'
+      ? { version: napiDeriveDependency }
+      : { ...napiDeriveDependency }
+
+  const existingFeatures = Array.isArray(dependencyConfig.features)
+    ? dependencyConfig.features.filter(
+        (feature: unknown): feature is string => typeof feature === 'string',
+      )
+    : []
+
+  dependencyConfig['default-features'] = false
+  dependencyConfig.features = [
+    'strict',
+    ...existingFeatures.filter((feature) => feature !== 'strict'),
+  ].filter((feature) => feature !== 'type-def')
+
+  dependencies['napi-derive'] = dependencyConfig
+
+  await fs.writeFile(filePath, stringifyToml(cargoToml))
 }
 
 async function filterTargetsInGithubActions(
@@ -364,6 +404,11 @@ export async function newProject(userOptions: RawNewOptions) {
         name: options.name,
         binaryName: getBinaryName(options.name),
       })
+
+      const cargoTomlPath = path.join(options.path, 'Cargo.toml')
+      if (existsSync(cargoTomlPath)) {
+        await updateCargoTomlTypeDef(cargoTomlPath, options.enableTypeDef)
+      }
 
       // Filter targets in package.json
       const packageJsonPath = path.join(options.path, 'package.json')


### PR DESCRIPTION
Fixes: https://github.com/napi-rs/napi-rs/issues/3211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to create projects with type definitions disabled; project build config and dependency feature flags are automatically adjusted when this option is used.

* **Tests**
  * Added test coverage verifying project creation with type definitions disabled and confirming the resulting build configuration and dependency feature changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->