### PR TITLE
fix(cli): compatible with latest wasi-sdk toolchain

### DIFF
--- a/cli/src/api/build.ts
+++ b/cli/src/api/build.ts
@@ -542,7 +542,7 @@ class Builder {
       require.resolve('emnapi'),
       '..',
       'lib',
-      'wasm32-wasi-threads',
+      'wasm32-wasip1-threads',
     )
     this.envs.EMNAPI_LINK_DIR = emnapi
     const emnapiVersion = require('emnapi/package.json').version
@@ -593,15 +593,15 @@ class Builder {
       )
       this.setEnvIfNotExists(
         'TARGET_CFLAGS',
-        `--target=wasm32-wasi-threads --sysroot=${WASI_SDK_PATH}/share/wasi-sysroot -pthread -mllvm -wasm-enable-sjlj`,
+        `--target=wasm32-wasip1-threads --sysroot=${WASI_SDK_PATH}/share/wasi-sysroot -pthread -mllvm -wasm-enable-sjlj`,
       )
       this.setEnvIfNotExists(
         'TARGET_CXXFLAGS',
-        `--target=wasm32-wasi-threads --sysroot=${WASI_SDK_PATH}/share/wasi-sysroot -pthread -mllvm -wasm-enable-sjlj`,
+        `--target=wasm32-wasip1-threads --sysroot=${WASI_SDK_PATH}/share/wasi-sysroot -pthread -mllvm -wasm-enable-sjlj`,
       )
       this.setEnvIfNotExists(
         `TARGET_LDFLAGS`,
-        `-fuse-ld=${WASI_SDK_PATH}/bin/wasm-ld --target=wasm32-wasi-threads`,
+        `-fuse-ld=${WASI_SDK_PATH}/bin/wasm-ld --target=wasm32-wasip1-threads`,
       )
     }
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches WASI cross-compilation environment setup; misconfiguration could break `.wasm` builds for users on older wasi-sdk/emnapi layouts.
> 
> **Overview**
> Updates the CLI’s WASI build environment to use the newer `wasm32-wasip1-threads` target naming.
> 
> This switches the `emnapi` link directory and the default `TARGET_CFLAGS`/`TARGET_CXXFLAGS`/`TARGET_LDFLAGS` `--target` values from `wasm32-wasi-threads` to `wasm32-wasip1-threads` to align with the latest `wasi-sdk` toolchain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aab0d0fe926c0bdd51208b67d4acaf8741ac4f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated WebAssembly build toolchain configuration with the latest WASI target specification, enhancing compatibility and standards alignment for native module builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->