### PR TITLE
fix(cli): fail build when --pipe post-process command exits non-zero

### DIFF
--- a/cli/e2e/cli.spec.ts
+++ b/cli/e2e/cli.spec.ts
@@ -76,6 +76,28 @@ test('should be able to build a project', async (t) => {
   t.truthy(existsSync(join(context, 'index.node')))
 })
 
+test('should exit non-zero when pipe command fails', async (t) => {
+  const { context } = t.context
+  await writeCargoToml(context)
+  await writePackageJson(context, {})
+  await writeFile(join(context, 'postprocess-fail.cjs'), 'process.exit(1)\n')
+
+  const bin = join(context, 'node_modules', '.bin')
+  const { code, stderr } = await execResult(
+    `${bin}/napi build --pipe "node ./postprocess-fail.cjs"`,
+    {
+      cwd: context,
+      env: {
+        ...process.env,
+        FORCE_COLOR: '0',
+      },
+    },
+  )
+
+  t.not(code, 0)
+  t.regex(stderr, /Failed to pipe output file/)
+})
+
 test('should throw error when duplicate targets are provided', async (t) => {
   const { context } = t.context
   await writeCargoToml(context)
@@ -127,6 +149,29 @@ async function execAsync(command: string, options: ExecOptions = {}) {
       resolve()
     })
   })
+}
+
+async function execResult(command: string, options: ExecOptions = {}) {
+  return new Promise<{ code: number | null; stdout: string; stderr: string }>(
+    (resolve) => {
+      let stdout = ''
+      let stderr = ''
+      const cp = exec(command, options)
+      cp.stdout?.on('data', (chunk) => {
+        stdout += chunk.toString()
+      })
+      cp.stderr?.on('data', (chunk) => {
+        stderr += chunk.toString()
+      })
+      cp.on('close', (code) => {
+        resolve({
+          code,
+          stdout,
+          stderr,
+        })
+      })
+    },
+  )
 }
 
 async function writeCargoToml(projectDir: string, cargoToml: string = '') {

--- a/cli/e2e/cli.spec.ts
+++ b/cli/e2e/cli.spec.ts
@@ -94,7 +94,7 @@ test('should exit non-zero when pipe command fails', async (t) => {
     },
   )
 
-  t.not(code, 0)
+  t.true(Number.isInteger(code) && code !== 0)
   t.regex(stderr, /Failed to pipe output file/)
 })
 

--- a/cli/src/commands/build.ts
+++ b/cli/src/commands/build.ts
@@ -35,6 +35,7 @@ export class BuildCommand extends BaseBuildCommand {
         } catch (e) {
           debug.error(`Failed to pipe output file ${output.path} to command`)
           debug.error(e)
+          throw e
         }
       }
     }


### PR DESCRIPTION
`napi build --pipe` currently logs post-processing failures but still exits successfully.

This PR fixes that behavior so failed pipe commands cause the overall build to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The `napi build --pipe` flow now correctly stops and reports a failure when a piped postprocess script exits with an error, instead of continuing silently.

* **Tests**
  * Added end-to-end test coverage that verifies non-zero exit behavior and appropriate stderr output when a piped postprocess script fails.
  * Added a local test helper to capture command exit codes and streamed output for assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->