### PR TITLE
fix(cli): persist repository when renaming project

### DIFF
--- a/cli/src/api/__tests__/rename.spec.ts
+++ b/cli/src/api/__tests__/rename.spec.ts
@@ -176,5 +176,6 @@ test('repository updates package.json when provided', async (t) => {
   )
 
   t.is(packageJson.name, 'renamed')
-  t.is(packageJson.repository, 'https://example.com/new.git')
+  t.is(packageJson.repository.url, 'https://example.com/new.git')
+  t.is(packageJson.repository.type, 'git')
 })

--- a/cli/src/api/__tests__/rename.spec.ts
+++ b/cli/src/api/__tests__/rename.spec.ts
@@ -146,3 +146,35 @@ test('omitting binaryName preserves separated napi config fields', async (t) => 
   t.false(existsSync(join(projectPath, 'undefined.wasi-browser.js')))
   t.false(existsSync(join(projectPath, 'undefined.wasi.cjs')))
 })
+
+test('repository updates package.json when provided', async (t) => {
+  const projectPath = join(t.context.tmpDir, 'repository-rename')
+
+  await createFixtureProject(projectPath, {
+    packageJson: {
+      name: 'original',
+      repository: {
+        type: 'git',
+        url: 'https://example.com/old.git',
+      },
+      napi: {
+        binaryName: 'foo',
+        packageName: '@scope/original',
+      },
+    },
+    cargoPackageName: 'foo',
+  })
+
+  await renameProject({
+    cwd: projectPath,
+    name: 'renamed',
+    repository: 'https://example.com/new.git',
+  })
+
+  const packageJson = JSON.parse(
+    await readFile(join(projectPath, 'package.json'), 'utf8'),
+  )
+
+  t.is(packageJson.name, 'renamed')
+  t.is(packageJson.repository, 'https://example.com/new.git')
+})

--- a/cli/src/api/rename.ts
+++ b/cli/src/api/rename.ts
@@ -26,13 +26,7 @@ export async function renameProject(userOptions: RenameOptions) {
       packageJsonData,
       omitBy(
         // @ts-expect-error missing fields: author and license
-        pick(options, [
-          'name',
-          'description',
-          'author',
-          'license',
-          'repository',
-        ]),
+        pick(options, ['name', 'description', 'author', 'license']),
         isNil,
       ),
     ),
@@ -46,6 +40,18 @@ export async function renameProject(userOptions: RenameOptions) {
       ),
     },
   )
+
+  if (options.repository) {
+    if (
+      packageJsonData.repository &&
+      typeof packageJsonData.repository === 'object' &&
+      !Array.isArray(packageJsonData.repository)
+    ) {
+      packageJsonData.repository.url = options.repository
+    } else {
+      packageJsonData.repository = options.repository
+    }
+  }
 
   if (options.configPath) {
     const configPath = resolve(options.cwd, options.configPath)

--- a/cli/src/api/rename.ts
+++ b/cli/src/api/rename.ts
@@ -26,7 +26,13 @@ export async function renameProject(userOptions: RenameOptions) {
       packageJsonData,
       omitBy(
         // @ts-expect-error missing fields: author and license
-        pick(options, ['name', 'description', 'author', 'license']),
+        pick(options, [
+          'name',
+          'description',
+          'author',
+          'license',
+          'repository',
+        ]),
         isNil,
       ),
     ),


### PR DESCRIPTION
Fixes https://github.com/napi-rs/napi-rs/issues/3219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rename operation now optionally updates the repository URL in package.json so you can change project name and repository reference together.

* **Tests**
  * Added test coverage to verify repository field updates during project rename operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->