### PR TITLE
fix(cli): keep macOS test job for aarch64-apple-darwin

### DIFF
--- a/cli/src/api/__tests__/new.spec.ts
+++ b/cli/src/api/__tests__/new.spec.ts
@@ -237,6 +237,33 @@ test('non Windows and macOS targets should remove test-macOS-windows-binding job
   t.falsy(yamlObject.jobs.publish.needs.includes('test-macOS-windows-binding'))
 })
 
+test('aarch64-apple-darwin should keep test-macOS-windows-binding job', async (t) => {
+  const projectPath = join(t.context.tmpDir, 'apple-silicon-only')
+  const targets = ['aarch64-apple-darwin']
+
+  await newProject({
+    path: projectPath,
+    targets,
+    enableDefaultTargets: false,
+  })
+
+  t.true(existsSync(projectPath))
+
+  const ciYaml = await readFile(
+    join(projectPath, '.github', 'workflows', 'CI.yml'),
+    'utf-8',
+  )
+  const yamlObject = yamlLoad(ciYaml) as any
+  t.truthy(yamlObject.jobs['test-macOS-windows-binding'])
+  t.deepEqual(
+    yamlObject.jobs['test-macOS-windows-binding'].strategy.matrix.settings.map(
+      (setting: any) => setting.target,
+    ),
+    ['aarch64-apple-darwin'],
+  )
+  t.truthy(yamlObject.jobs.publish.needs.includes('test-macOS-windows-binding'))
+})
+
 test('should remove test-linux-binding job if no Linux targets are enabled', async (t) => {
   const projectPath = join(t.context.tmpDir, 'no-linux')
   const targets = ['x86_64-apple-darwin', 'aarch64-apple-darwin']

--- a/cli/src/api/new.ts
+++ b/cli/src/api/new.ts
@@ -15,6 +15,7 @@ import {
   debugFactory,
   DEFAULT_TARGETS,
   mkdirAsync,
+  parseTriple,
   readdirAsync,
   statAsync,
   type SupportedPackageManager,
@@ -158,13 +159,6 @@ async function filterTargetsInGithubActions(
   const content = await fs.readFile(filePath, 'utf-8')
   const yaml = yamlLoad(content) as any
 
-  const macOSAndWindowsTargets = new Set([
-    'x86_64-pc-windows-msvc',
-    'x86_64-pc-windows-gnu',
-    'aarch64-pc-windows-msvc',
-    'x86_64-apple-darwin',
-  ])
-
   const linuxTargets = new Set([
     'x86_64-unknown-linux-gnu',
     'x86_64-unknown-linux-musl',
@@ -184,6 +178,10 @@ async function filterTargetsInGithubActions(
   const hasLinuxTargets = enabledTargets.some((target) =>
     linuxTargets.has(target),
   )
+  const hasMacOSOrWindowsTargets = enabledTargets.some((target) => {
+    const platform = parseTriple(target).platform
+    return platform === 'darwin' || platform === 'win32'
+  })
 
   // Filter the matrix configurations in the build job
   if (yaml?.jobs?.build?.strategy?.matrix?.settings) {
@@ -198,7 +196,7 @@ async function filterTargetsInGithubActions(
 
   const jobsToRemove: string[] = []
 
-  if (enabledTargets.every((target) => !macOSAndWindowsTargets.has(target))) {
+  if (!hasMacOSOrWindowsTargets) {
     jobsToRemove.push('test-macOS-windows-binding')
   } else {
     // Filter the matrix configurations in the test-macOS-windows-binding job


### PR DESCRIPTION
Fixes: https://github.com/napi-rs/napi-rs/issues/3215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced macOS and Windows target detection in GitHub Actions workflow generation for improved accuracy across different target configurations.

* **Tests**
  * Added test coverage for single-platform target scenarios in the CLI project creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->