### PR TITLE
fix(cli): use target cwd for pre-publish git log lookup

### DIFF
--- a/cli/src/api/pre-publish.ts
+++ b/cli/src/api/pre-publish.ts
@@ -85,6 +85,7 @@ export async function prePublish(userOptions: PrePublishOptions) {
 
   function getRepoInfo(packageName: string, version: string) {
     const headCommit = execSync('git log -1 --pretty=%B', {
+      cwd: options.cwd,
       encoding: 'utf-8',
     }).trim()
 


### PR DESCRIPTION
Fixes: https://github.com/napi-rs/napi-rs/issues/3227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pre-publish command to correctly read commit information from the specified working directory instead of the default process directory when invoked with a custom path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->