### PR TITLE
fix(cli): remove stale browser metadata in non-WASI new projects

### DIFF
--- a/cli/src/api/__tests__/new.spec.ts
+++ b/cli/src/api/__tests__/new.spec.ts
@@ -56,6 +56,9 @@ test('create a new project with default options', async (t) => {
   t.is(pkgJson.napi.binaryName, 'default-project')
   t.is(pkgJson.license, 'MIT')
   t.truthy(pkgJson.engines.node)
+  t.false('browser' in pkgJson)
+  t.false(pkgJson.files.includes('browser.js'))
+  t.falsy(existsSync(join(projectPath, 'browser.js')))
   t.falsy(existsSync(join(projectPath, 'default-project.wasi-browser.js')))
   t.falsy(existsSync(join(projectPath, 'wasi-worker-browser.mjs')))
   t.falsy(existsSync(join(projectPath, 'wasi-worker.mjs')))
@@ -166,6 +169,9 @@ test('create a new project with custom path, name, and targets', async (t) => {
   t.is(pkgJson.napi.binaryName, 'full-project')
   t.is(pkgJson.license, 'Apache-2.0')
   t.true(pkgJson.engines.node.includes('>= 14.0.0'))
+  t.is(pkgJson.browser, 'browser.js')
+  t.true(pkgJson.files.includes('browser.js'))
+  t.true(existsSync(join(projectPath, 'browser.js')))
 
   // Check that CI workflow only includes the specified targets
   const ciYaml = await readFile(

--- a/cli/src/api/new.ts
+++ b/cli/src/api/new.ts
@@ -369,11 +369,9 @@ function processOptions(options: RawNewOptions) {
     const out = execSync(`rustup target list`, {
       encoding: 'utf8',
     })
-    if (out.includes('wasm32-wasip1-threads')) {
+    if (out.includes(WASI_TARGET)) {
       options.targets = options.targets.map((target) =>
-        target === 'wasm32-wasi-preview1-threads'
-          ? 'wasm32-wasip1-threads'
-          : target,
+        target === 'wasm32-wasi-preview1-threads' ? WASI_TARGET : target,
       )
     }
   }
@@ -413,7 +411,7 @@ export async function newProject(userOptions: RawNewOptions) {
       await copyDirectory(
         templatePath,
         options.path,
-        options.targets.includes('wasm32-wasip1-threads'),
+        options.targets.includes(WASI_TARGET),
       )
 
       // Rename project using the rename API

--- a/cli/src/api/new.ts
+++ b/cli/src/api/new.ts
@@ -35,6 +35,8 @@ const TEMPLATE_REPOS = {
   pnpm: 'https://github.com/napi-rs/package-template-pnpm',
 } as const
 
+const WASI_TARGET = 'wasm32-wasip1-threads'
+
 async function checkGitCommand(): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
     const cp = exec('git --version')
@@ -127,7 +129,7 @@ async function copyDirectory(
           entry.name.endsWith('.wasi.cjs') ||
           entry.name.endsWith('wasi-worker-browser.mjs') ||
           entry.name.endsWith('wasi-worker.mjs') ||
-          entry.name.endsWith('browser.js'))
+          entry.name === 'browser.js')
       ) {
         continue
       }
@@ -142,12 +144,28 @@ async function filterTargetsInPackageJson(
 ): Promise<void> {
   const content = await fs.readFile(filePath, 'utf-8')
   const packageJson = JSON.parse(content)
+  const includeWasiBindings = enabledTargets.includes(WASI_TARGET)
 
   // Filter napi.targets
   if (packageJson.napi?.targets) {
     packageJson.napi.targets = packageJson.napi.targets.filter(
       (target: string) => enabledTargets.includes(target),
     )
+  }
+
+  if (!includeWasiBindings) {
+    if (
+      packageJson.browser === 'browser.js' ||
+      packageJson.browser === './browser.js'
+    ) {
+      delete packageJson.browser
+    }
+
+    if (Array.isArray(packageJson.files)) {
+      packageJson.files = packageJson.files.filter(
+        (file: unknown) => file !== 'browser.js' && file !== './browser.js',
+      )
+    }
   }
 
   await fs.writeFile(filePath, JSON.stringify(packageJson, null, 2) + '\n')
@@ -275,7 +293,7 @@ async function filterTargetsInGithubActions(
     }
   }
 
-  if (!enabledTargets.includes('wasm32-wasip1-threads')) {
+  if (!enabledTargets.includes(WASI_TARGET)) {
     jobsToRemove.push('test-wasi')
   }
 


### PR DESCRIPTION
Fixes: https://github.com/napi-rs/napi-rs/issues/3226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added assertions verifying the presence or absence of the browser artifact and related package manifest entries under default and custom project options.

* **Bug Fixes**
  * Improved logic for excluding the browser artifact and corresponding package manifest entries when WASI targets are not enabled.
  * Ensured consistent target normalization and CI workflow behavior for WASI-targeted builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->