### PR TITLE
fix(cli): include napi9 in interactive new prompt

### DIFF
--- a/cli/src/commands/__tests__/new.spec.ts
+++ b/cli/src/commands/__tests__/new.spec.ts
@@ -1,0 +1,13 @@
+import test from 'ava'
+
+import { getNapiVersionChoices } from '../new.js'
+import { SUPPORTED_NAPI_VERSIONS } from '../../utils/version.js'
+
+test('napi version prompt choices track supported versions', (t) => {
+  const choices = getNapiVersionChoices()
+
+  t.deepEqual(
+    choices.map((choice) => choice.value),
+    SUPPORTED_NAPI_VERSIONS,
+  )
+})

--- a/cli/src/commands/new.ts
+++ b/cli/src/commands/new.ts
@@ -89,7 +89,7 @@ export class NewCommand extends BaseNewCommand {
       pageSize: 10,
       choices: getNapiVersionChoices(),
       // choice index
-      default: SUPPORTED_NAPI_VERSIONS.indexOf(Number(this.minNodeApiVersion)),
+      default: this.minNodeApiVersion - 1,
     })
   }
 

--- a/cli/src/commands/new.ts
+++ b/cli/src/commands/new.ts
@@ -11,9 +11,19 @@ import {
   DEFAULT_TARGETS,
   type TargetTriple,
 } from '../utils/index.js'
-import { napiEngineRequirement } from '../utils/version.js'
+import {
+  napiEngineRequirement,
+  SUPPORTED_NAPI_VERSIONS,
+} from '../utils/version.js'
 
 const debug = debugFactory('new')
+
+export function getNapiVersionChoices() {
+  return SUPPORTED_NAPI_VERSIONS.map((version) => ({
+    name: `napi${version} (${napiEngineRequirement(version)})`,
+    value: version,
+  }))
+}
 
 export class NewCommand extends BaseNewCommand {
   interactive = Option.Boolean('--interactive,-i', true, {
@@ -77,12 +87,9 @@ export class NewCommand extends BaseNewCommand {
       message: 'Minimum node-api version (with node version requirement)',
       loop: false,
       pageSize: 10,
-      choices: Array.from({ length: 8 }, (_, i) => ({
-        name: `napi${i + 1} (${napiEngineRequirement(i + 1)})`,
-        value: i + 1,
-      })),
+      choices: getNapiVersionChoices(),
       // choice index
-      default: this.minNodeApiVersion - 1,
+      default: SUPPORTED_NAPI_VERSIONS.indexOf(Number(this.minNodeApiVersion)),
     })
   }
 

--- a/cli/src/utils/__tests__/version.spec.ts
+++ b/cli/src/utils/__tests__/version.spec.ts
@@ -1,13 +1,7 @@
 import test from 'ava'
 
-import { napiEngineRequirement, NapiVersion } from '../version.js'
+import { napiEngineRequirement, SUPPORTED_NAPI_VERSIONS } from '../version.js'
 
 test('should generate correct napi engine requirement', (t) => {
-  t.snapshot(
-    (
-      Object.values(NapiVersion).filter(
-        (v) => typeof v === 'number',
-      ) as NapiVersion[]
-    ).map(napiEngineRequirement),
-  )
+  t.snapshot(SUPPORTED_NAPI_VERSIONS.map(napiEngineRequirement))
 })

--- a/cli/src/utils/version.ts
+++ b/cli/src/utils/version.ts
@@ -25,6 +25,10 @@ const NAPI_VERSION_MATRIX = new Map<NapiVersion, string>([
   [NapiVersion.Napi9, '18.17.0 | 20.3.0 | 21.1.0'],
 ])
 
+export const SUPPORTED_NAPI_VERSIONS = Object.values(NapiVersion).filter(
+  (v): v is NapiVersion => typeof v === 'number',
+)
+
 interface NodeVersion {
   major: number
   minor: number


### PR DESCRIPTION
Fixes: https://github.com/napi-rs/napi-rs/issues/3234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * N-API version selection in the CLI now sources a dynamic supported-versions list so prompt options always match supported releases.

* **Tests**
  * Added test coverage for generation of N-API version choices and updated existing tests to validate behavior against the new supported-versions list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->