### PR TITLE
fix(cli): NAPI_RS_FORCE_WASI only activates on 'true' or 'error'

### DIFF
--- a/cli/src/api/templates/js-binding.ts
+++ b/cli/src/api/templates/js-binding.ts
@@ -227,23 +227,33 @@ function requireNative() {
 
 nativeBinding = requireNative()
 
-if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
+// NAPI_RS_FORCE_WASI is a tri-state flag:
+//   unset / any other value → native binding preferred, WASI is only a fallback
+//   'true'                   → force WASI fallback even if native loaded
+//   'error'                  → force WASI and throw if no WASI binding is found
+// Treating any non-empty string as truthy (the historical behavior) meant
+// NAPI_RS_FORCE_WASI=false, NAPI_RS_FORCE_WASI=0, etc. inadvertently triggered
+// the WASI path, causing ENOENT for packages shipped without a .wasi.cjs file.
+const forceWasi =
+  process.env.NAPI_RS_FORCE_WASI === 'true' || process.env.NAPI_RS_FORCE_WASI === 'error'
+
+if (!nativeBinding || forceWasi) {
   let wasiBinding = null
   let wasiBindingError = null
   try {
     wasiBinding = require('./${localName}.wasi.cjs')
     nativeBinding = wasiBinding
   } catch (err) {
-    if (process.env.NAPI_RS_FORCE_WASI) {
+    if (forceWasi) {
       wasiBindingError = err
     }
   }
-  if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
+  if (!nativeBinding || forceWasi) {
     try {
       wasiBinding = require('${pkgName}-wasm32-wasi')
       nativeBinding = wasiBinding
     } catch (err) {
-      if (process.env.NAPI_RS_FORCE_WASI) {
+      if (forceWasi) {
         if (!wasiBindingError) {
           wasiBindingError = err
         } else {


### PR DESCRIPTION
## Why

The generated `native.js` template treats `process.env.NAPI_RS_FORCE_WASI` as a plain truthy check. In JavaScript every non-empty string is truthy, so setting `NAPI_RS_FORCE_WASI=false` (intending to opt *out*) inadvertently triggers the WASI fallback — the same path that tries to `require('./<pkg>.wasi.cjs')` and fails with `ENOENT` for packages that don't ship a WASI binding.

Surfaced downstream in [lancedb/lancedb#3267](https://github.com/lancedb/lancedb/issues/3267):

```
ENOENT: no such file or directory, open '.../@lancedb/lancedb/dist/lancedb.wasi.cjs'
```

The existing `=== 'error'` branch at line 256 already shows the right pattern — this PR applies it consistently at the other four sites.

## What

Extracts a single `forceWasi` boolean at the top of the generated script:

```javascript
const forceWasi =
  process.env.NAPI_RS_FORCE_WASI === 'true' || process.env.NAPI_RS_FORCE_WASI === 'error'
```

and uses it at all four call sites that previously did the truthy-string check. The `=== 'error'` branch at the bottom is preserved unchanged — it already handled its value correctly.

## Behavior table

| `NAPI_RS_FORCE_WASI` | Before | After |
|---|---|---|
| unset | native preferred; WASI only if native fails | same |
| `'true'` | forced WASI | forced WASI (unchanged) |
| `'error'` | forced WASI; throw if none | forced WASI; throw if none (unchanged) |
| `'false'` | **forced WASI (bug)** | native preferred |
| `'0'` | **forced WASI (bug)** | native preferred |
| anything else | **forced WASI (bug)** | native preferred |

## Scope

- Template change only (`cli/src/api/templates/js-binding.ts`).
- Downstream packages pick up the fix on their next `napi build`.
- No existing users who set `NAPI_RS_FORCE_WASI` to `'true'` or `'error'` are affected.
- No behavior change when the var is unset.

## Related

- Closes a downstream symptom reported at lancedb/lancedb#3267
- Complements PR #2919 which introduced the `'error'` tri-state value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved WASI fallback loading logic to require explicit environment variable values (`'true'` or `'error'`) instead of treating any non-empty string as truthy, resulting in more predictable behavior and clearer error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->