### PR TITLE
fix(cli): fail universalize when lipo does not produce output

### DIFF
--- a/cli/src/api/__tests__/universalize.spec.ts
+++ b/cli/src/api/__tests__/universalize.spec.ts
@@ -78,3 +78,51 @@ test('resolves an absolute packageJsonPath instead of joining it with cwd', asyn
     )
   }
 })
+
+test('throws when lipo fails to create a universal binary', async (t) => {
+  if (process.platform !== 'darwin') {
+    t.pass()
+    return
+  }
+
+  const { cwd, packageJsonPath, tmpDir } = t.context
+  const outputDir = join(tmpDir, 'out')
+  const outputPath = join(outputDir, 'universalize-repro.darwin-universal.node')
+
+  await mkdir(outputDir, { recursive: true })
+  await writeFile(
+    packageJsonPath,
+    `${JSON.stringify(
+      {
+        name: 'universalize-repro',
+        napi: {
+          binaryName: 'universalize-repro',
+          targets: ['universal-apple-darwin'],
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  )
+
+  await writeFile(
+    join(outputDir, 'universalize-repro.darwin-x64.node'),
+    'not a mach-o\n',
+  )
+  await writeFile(
+    join(outputDir, 'universalize-repro.darwin-arm64.node'),
+    'not a mach-o\n',
+  )
+
+  const error = await t.throwsAsync(() =>
+    universalizeBinaries({
+      cwd,
+      packageJsonPath,
+      outputDir,
+    }),
+  )
+
+  t.truthy(error)
+  t.regex(error.message, /Failed to create universal binary/)
+  t.false(existsSync(outputPath))
+})

--- a/cli/src/api/universalize.ts
+++ b/cli/src/api/universalize.ts
@@ -12,14 +12,32 @@ import { UniArchsByPlatform } from '../utils/target.js'
 
 const debug = debugFactory('universalize')
 
+function createDarwinUniversalBinary(inputs: string[], output: string) {
+  const result = spawnSync('lipo', ['-create', '-output', output, ...inputs], {
+    stdio: 'inherit',
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+
+  if (result.signal) {
+    throw new Error(
+      `Failed to create universal binary '${output}': lipo terminated with signal ${result.signal}.`,
+    )
+  }
+
+  if (result.status !== 0) {
+    throw new Error(
+      `Failed to create universal binary '${output}': lipo exited with status ${result.status}.`,
+    )
+  }
+}
+
 const universalizers: Partial<
   Record<NodeJS.Platform, (inputs: string[], output: string) => void>
 > = {
-  darwin: (inputs, output) => {
-    spawnSync('lipo', ['-create', '-output', output, ...inputs], {
-      stdio: 'inherit',
-    })
-  },
+  darwin: createDarwinUniversalBinary,
 }
 
 export async function universalizeBinaries(userOptions: UniversalizeOptions) {
@@ -76,6 +94,10 @@ export async function universalizeBinaries(userOptions: UniversalizeOptions) {
   )
 
   universalizers[process.platform]?.(srcFiles, output)
+
+  if (!(await fileExists(output))) {
+    throw new Error(`Universal binary was not created: ${output}`)
+  }
 
   debug(`Produced universal binary: ${output}`)
 }


### PR DESCRIPTION
Fixes: https://github.com/napi-rs/napi-rs/issues/3247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling during universal binary creation on macOS with more explicit and descriptive error messages for failure scenarios
  * Added validation to ensure the output binary file is successfully created

* **Tests**
  * Added test case validating proper error handling when universal binary creation fails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->