### PR TITLE
fix(wasm-runtime): preserve Buffer return values in fs-proxy

### DIFF
--- a/wasm-runtime/fs-proxy.js
+++ b/wasm-runtime/fs-proxy.js
@@ -6,6 +6,7 @@
 const getType = (value) => {
   if (value === undefined) return 0
   if (value === null) return 1
+  if (isBuffer(value)) return 10
   const t = typeof value
   if (t === 'boolean') return 2
   if (t === 'number') return 3
@@ -13,6 +14,18 @@ const getType = (value) => {
   if (t === 'object') return 6
   if (t === 'bigint') return 9
   return -1
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is Uint8Array}
+ */
+const isBuffer = (value) => {
+  const BufferCtor = globalThis.Buffer
+  if (typeof BufferCtor?.isBuffer === 'function') {
+    return BufferCtor.isBuffer(value)
+  }
+  return value instanceof Uint8Array && value.constructor?.name === 'Buffer'
 }
 
 const RESPONSE_HEADER_SIZE = 16
@@ -55,6 +68,8 @@ const encodeValue = (memfs, value, type) => {
       const view = new TextEncoder().encode(value)
       return view
     }
+    case 10:
+      return new Uint8Array(value)
     case 6: {
       function storeConstructor(obj, memfs, processed = new WeakSet()) {
         if (!obj || typeof obj !== 'object') {
@@ -126,6 +141,13 @@ const decodeValue = (memfs, payload, type) => {
   if (type === 3)
     return new Float64Array(payload.buffer, payload.byteOffset, 1)[0]
   if (type === 4) return new TextDecoder().decode(payload.slice())
+  if (type === 10) {
+    const BufferCtor = globalThis.Buffer
+    if (typeof BufferCtor?.from === 'function') {
+      return BufferCtor.from(payload)
+    }
+    return payload.slice()
+  }
   if (type === 6) {
     const obj = JSON.parse(
       new TextDecoder().decode(payload.slice()),
@@ -205,7 +227,7 @@ export const createOnMessage = (fs) =>
     if (e.data.__fs__) {
       /**
        * 0..4                    status(int32_t):        21(waiting) 0(success) 1(error)
-       * 5..8                    type(napi_valuetype):   0(undefined) 1(null) 2(boolean) 3(number) 4(string) 6(jsonstring) 9(bigint) -1(unsupported)
+       * 5..8                    type(napi_valuetype):   0(undefined) 1(null) 2(boolean) 3(number) 4(string) 6(jsonstring) 9(bigint) 10(buffer) -1(unsupported)
        * 9..16                   payload_size(uint32_t)  <= 10240
        * 16..16 + payload_size   payload_content
        */

--- a/wasm-runtime/fs-proxy.test.js
+++ b/wasm-runtime/fs-proxy.test.js
@@ -49,6 +49,9 @@ await test(`fs-proxy between main and worker (${isMainThread ? 'main' : 'worker'
         parentPort.postMessage(data)
       },
     })
+    const buffer = fs.readFileSync('/test.txt')
+    assert.ok(Buffer.isBuffer(buffer))
+    assert.ok(buffer.equals(Buffer.from('test')))
     assert.strictEqual(fs.readFileSync('/test.txt', 'utf8'), 'test')
     assert.strictEqual(fs.readFileSync('/test.json', 'utf8'), '{"a":"b"}')
     assert.throws(() => fs.readFileSync('/notexist', 'utf8'), /ENOENT/)


### PR DESCRIPTION
Fixes: https://github.com/napi-rs/napi-rs/issues/3249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for binary buffer values with automatic detection, serialization, and deserialization in file operations. Binary file data is now properly handled and transmitted.

* **Tests**
  * Added validation tests for buffer handling in file read operations to ensure proper return values and data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->