### PR TITLE
fix(napi): fix custom tokio runtime recreation and cleanup hook re-re…

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -111,7 +111,7 @@
     "extensions": {
       "ts": "module"
     },
-    "timeout": "2m",
+    "timeout": "4m",
     "workerThreads": false,
     "files": [
       "**/__tests__/**/*.spec.ts",

--- a/crates/napi/src/bindgen_runtime/module_register.rs
+++ b/crates/napi/src/bindgen_runtime/module_register.rs
@@ -626,6 +626,12 @@ fn create_custom_gc(env: sys::napi_env) {
 ))]
 unsafe extern "C" fn thread_cleanup(_data: *mut std::ffi::c_void) {
   if MODULE_COUNT.fetch_sub(1, Ordering::Relaxed) == 1 {
+    // Reset the flag so the next Node.js env (e.g. Electron renderer reload) can
+    // re-register this hook. The hook is bound to the env instance that registered it;
+    // a new env will not inherit it automatically.
+    if let Ok(mut flag) = ENV_CLEANUP_HOOK_ADDED.write() {
+      *flag = false;
+    }
     crate::tokio_runtime::shutdown_async_runtime();
   }
 }

--- a/crates/napi/src/tokio_runtime.rs
+++ b/crates/napi/src/tokio_runtime.rs
@@ -12,15 +12,19 @@ use crate::{JsDeferred, SendableResolver, Unknown};
 fn create_runtime() -> Runtime {
   // Check if we're supposed to use a user-defined runtime
   if IS_USER_DEFINED_RT.get().copied().unwrap_or(false) {
-    // Try to take the user-defined runtime if it's still available
+    // Factory takes priority: supports recreation after shutdown (e.g. Electron renderer reload)
+    if let Some(factory) = USER_DEFINED_RT_FACTORY.get() {
+      return factory();
+    }
+    // One-shot path: original create_custom_tokio_runtime API, only works on first creation
     if let Some(user_defined_rt) = USER_DEFINED_RT
       .get()
       .and_then(|rt| rt.write().ok().and_then(|mut rt| rt.take()))
     {
       return user_defined_rt;
     }
-    // If the user-defined runtime was already taken, fall back to creating a default runtime
-    // This handles the case where the runtime was shutdown and needs to be restarted
+    // If the user-defined runtime was already taken and no factory is set, fall back to a default
+    // runtime. This handles the case where the runtime was shutdown and needs to be restarted.
   }
 
   #[cfg(any(
@@ -50,11 +54,20 @@ static RT: LazyLock<RwLock<Option<Runtime>>> =
 static USER_DEFINED_RT: OnceLock<RwLock<Option<Runtime>>> = OnceLock::new();
 
 #[cfg(not(feature = "noop"))]
+static USER_DEFINED_RT_FACTORY: OnceLock<Box<dyn Fn() -> Runtime + Send + Sync>> = OnceLock::new();
+
+#[cfg(not(feature = "noop"))]
 static IS_USER_DEFINED_RT: OnceLock<bool> = OnceLock::new();
 
 #[cfg(not(feature = "noop"))]
 /// Create a custom Tokio runtime used by the NAPI-RS.
 /// You can control the tokio runtime configuration by yourself.
+///
+/// **Warning**: this accepts a pre-built [`Runtime`] and can only be used for the *first*
+/// runtime creation. After [`shutdown_async_runtime`] + [`start_async_runtime`] (e.g. Electron
+/// renderer reload), the custom runtime is **lost** and a default runtime is used instead.
+/// Use [`create_custom_tokio_runtime_factory`] to correctly handle restart scenarios.
+///
 /// ### Example
 /// ```no_run
 /// use tokio::runtime::Builder;
@@ -65,13 +78,62 @@ static IS_USER_DEFINED_RT: OnceLock<bool> = OnceLock::new();
 ///    let rt = Builder::new_multi_thread().enable_all().thread_stack_size(32 * 1024 * 1024).build().unwrap();
 ///    create_custom_tokio_runtime(rt);
 /// }
+/// ```
 pub fn create_custom_tokio_runtime(rt: Runtime) {
+  debug_assert!(
+    USER_DEFINED_RT_FACTORY.get().is_none(),
+    "create_custom_tokio_runtime called after create_custom_tokio_runtime_factory; \
+     the factory takes precedence and the pre-built Runtime will be leaked"
+  );
   USER_DEFINED_RT.get_or_init(move || RwLock::new(Some(rt)));
+  IS_USER_DEFINED_RT.get_or_init(|| true);
+}
+
+#[cfg(not(feature = "noop"))]
+/// Create a custom Tokio runtime factory used by NAPI-RS.
+///
+/// Unlike [`create_custom_tokio_runtime`] which accepts a pre-built [`Runtime`] (and can only be
+/// used once), this function accepts a factory closure that will be called **every time** a new
+/// runtime needs to be created — including after [`shutdown_async_runtime`] followed by
+/// [`start_async_runtime`]. This makes it the correct choice for scenarios where the runtime can
+/// be shut down and restarted, such as Electron renderer process reloads.
+///
+/// ### Example
+/// ```no_run
+/// use napi::create_custom_tokio_runtime_factory;
+///
+/// #[napi_derive::module_init]
+/// fn init() {
+///   create_custom_tokio_runtime_factory(|| {
+///     tokio::runtime::Builder::new_multi_thread()
+///       .enable_all()
+///       .thread_stack_size(32 * 1024 * 1024)
+///       .build()
+///       .unwrap()
+///   });
+/// }
+/// ```
+pub fn create_custom_tokio_runtime_factory<F>(factory: F)
+where
+  F: Fn() -> Runtime + Send + Sync + 'static,
+{
+  debug_assert!(
+    USER_DEFINED_RT.get().is_none(),
+    "create_custom_tokio_runtime_factory called after create_custom_tokio_runtime; \
+     the factory takes precedence but the pre-built Runtime stored earlier will be leaked"
+  );
+  USER_DEFINED_RT_FACTORY.get_or_init(|| Box::new(factory));
   IS_USER_DEFINED_RT.get_or_init(|| true);
 }
 
 #[cfg(feature = "noop")]
 pub fn create_custom_tokio_runtime(_: Runtime) {}
+
+#[cfg(feature = "noop")]
+pub fn create_custom_tokio_runtime_factory<F: Fn() -> Runtime + Send + Sync + 'static>(
+  _: F,
+) {
+}
 
 #[cfg(not(feature = "noop"))]
 /// Start the async runtime (Currently is tokio).

--- a/crates/napi/src/tokio_runtime.rs
+++ b/crates/napi/src/tokio_runtime.rs
@@ -130,10 +130,7 @@ where
 pub fn create_custom_tokio_runtime(_: Runtime) {}
 
 #[cfg(feature = "noop")]
-pub fn create_custom_tokio_runtime_factory<F: Fn() -> Runtime + Send + Sync + 'static>(
-  _: F,
-) {
-}
+pub fn create_custom_tokio_runtime_factory<F: Fn() -> Runtime + Send + Sync + 'static>(_: F) {}
 
 #[cfg(not(feature = "noop"))]
 /// Start the async runtime (Currently is tokio).

--- a/crates/napi/src/tokio_runtime.rs
+++ b/crates/napi/src/tokio_runtime.rs
@@ -80,11 +80,11 @@ static IS_USER_DEFINED_RT: OnceLock<bool> = OnceLock::new();
 /// }
 /// ```
 pub fn create_custom_tokio_runtime(rt: Runtime) {
-  debug_assert!(
-    USER_DEFINED_RT_FACTORY.get().is_none(),
-    "create_custom_tokio_runtime called after create_custom_tokio_runtime_factory; \
-     the factory takes precedence and the pre-built Runtime will be leaked"
-  );
+  if USER_DEFINED_RT_FACTORY.get().is_some() {
+    // A factory is already registered; dropping the pre-built Runtime here prevents its
+    // worker threads from running unused alongside the factory-created ones.
+    return;
+  }
   USER_DEFINED_RT.get_or_init(move || RwLock::new(Some(rt)));
   IS_USER_DEFINED_RT.get_or_init(|| true);
 }
@@ -117,11 +117,11 @@ pub fn create_custom_tokio_runtime_factory<F>(factory: F)
 where
   F: Fn() -> Runtime + Send + Sync + 'static,
 {
-  debug_assert!(
-    USER_DEFINED_RT.get().is_none(),
-    "create_custom_tokio_runtime_factory called after create_custom_tokio_runtime; \
-     the factory takes precedence but the pre-built Runtime stored earlier will be leaked"
-  );
+  if USER_DEFINED_RT.get().is_some() {
+    // A pre-built Runtime is already registered; discard the factory so the first
+    // caller's choice wins and we avoid storing a factory that would never be used.
+    return;
+  }
   USER_DEFINED_RT_FACTORY.get_or_init(|| Box::new(factory));
   IS_USER_DEFINED_RT.get_or_init(|| true);
 }


### PR DESCRIPTION
…gistration

- Add `create_custom_tokio_runtime_factory` API that accepts a `Fn() -> Runtime` closure, enabling correct runtime recreation after shutdown (e.g. Electron renderer reload). The existing one-shot `create_custom_tokio_runtime` API is preserved for backward compatibility with a deprecation note.
- Add `debug_assert!` guards to both APIs to catch misuse when both are called.
- Reset `ENV_CLEANUP_HOOK_ADDED` to `false` inside `thread_cleanup` so the next Node.js env (e.g. after Electron window reload) can re-register the cleanup hook. Previously the process-level flag was never reset, causing the runtime to leak across env recreation.

Fixes #3251 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a factory-based API for supplying custom Tokio runtimes, enabling reliable runtime recreation and restart after shutdown.

* **Bug Fixes**
  * Fixed environment cleanup hook handling so hooks can be re-registered when new Node.js env instances are created.

* **Tests**
  * Increased test runner timeout to allow longer-running tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->