### PR TITLE
fix(napi): preserve external string buffers when Node copies latin1/utf16 data

### DIFF
--- a/crates/napi/src/js_values/string/latin1.rs
+++ b/crates/napi/src/js_values/string/latin1.rs
@@ -44,7 +44,7 @@ impl<'env> JsStringLatin1<'env> {
   /// The `copied` parameter serves as feedback to understand whether the external string
   /// optimization was successful or if V8 fell back to traditional string creation.
   pub fn from_data(env: &'env Env, data: Vec<u8>) -> Result<JsStringLatin1<'env>> {
-    use std::{mem, ptr};
+    use std::{mem::ManuallyDrop, ptr};
 
     use crate::{check_status, Error, Status, Value, ValueType};
 
@@ -55,6 +55,8 @@ impl<'env> JsStringLatin1<'env> {
       ));
     }
 
+    let fallback_buf = data.clone();
+    let mut data = ManuallyDrop::new(data);
     let mut raw_value = ptr::null_mut();
     let mut copied = false;
     let data_ptr = data.as_ptr();
@@ -62,34 +64,29 @@ impl<'env> JsStringLatin1<'env> {
     let cap = data.capacity();
     let finalize_hint = Box::into_raw(Box::new((len, cap)));
 
-    check_status!(
-      unsafe {
-        sys::node_api_create_external_string_latin1(
-          env.0,
-          data_ptr.cast(),
-          len as isize,
-          Some(drop_latin1_string),
-          finalize_hint.cast(),
-          &mut raw_value,
-          &mut copied,
-        )
-      },
-      "Failed to create external string latin1"
-    )?;
-
-    let inner_buf = if copied {
-      // If the data was copied, the finalizer won't be called
-      // We need to clean up the finalize_hint and let the Vec be dropped
-      unsafe {
-        let _ = Box::from_raw(finalize_hint);
-      };
-      data
-    } else {
-      // Only forget the data if it wasn't copied
-      // The finalizer will handle cleanup
-      mem::forget(data);
-      vec![]
+    let status = unsafe {
+      sys::node_api_create_external_string_latin1(
+        env.0,
+        data_ptr.cast(),
+        len as isize,
+        Some(drop_latin1_string),
+        finalize_hint.cast(),
+        &mut raw_value,
+        &mut copied,
+      )
     };
+
+    if status != sys::Status::napi_ok {
+      unsafe {
+        drop(Box::from_raw(finalize_hint));
+        ManuallyDrop::drop(&mut data);
+      }
+    }
+
+    check_status!(status, "Failed to create external string latin1")?;
+
+    let inner_buf = if copied { fallback_buf } else { vec![] };
+    let buf_ptr = if copied { inner_buf.as_ptr() } else { data_ptr };
 
     Ok(Self {
       inner: JsString(
@@ -100,7 +97,7 @@ impl<'env> JsStringLatin1<'env> {
         },
         std::marker::PhantomData,
       ),
-      buf: unsafe { std::slice::from_raw_parts(data_ptr, len) },
+      buf: unsafe { std::slice::from_raw_parts(buf_ptr, len) },
       _inner_buf: inner_buf,
     })
   }
@@ -122,7 +119,7 @@ impl<'env> JsStringLatin1<'env> {
   ///
   /// ### When `copied` is `true`:
   /// - String data is copied to V8's heap
-  /// - Finalizer is called immediately if provided
+  /// - Finalizer is invoked during string creation if provided
   /// - Original buffer can be freed after the call
   /// - Performance benefit of external strings is not achieved
   ///
@@ -149,7 +146,7 @@ impl<'env> JsStringLatin1<'env> {
     finalize_hint: T,
     finalize_callback: F,
   ) -> Result<JsStringLatin1<'env>> {
-    use std::ptr;
+    use std::{ptr, slice};
 
     use crate::{check_status, Error, Status, Value, ValueType};
 
@@ -160,31 +157,33 @@ impl<'env> JsStringLatin1<'env> {
       ));
     }
 
+    let fallback_buf = unsafe { slice::from_raw_parts(data, len) }.to_vec();
     let hint_ptr = Box::into_raw(Box::new((finalize_hint, finalize_callback)));
     let mut raw_value = ptr::null_mut();
     let mut copied = false;
 
-    check_status!(
-      unsafe {
-        sys::node_api_create_external_string_latin1(
-          env.0,
-          data.cast(),
-          len as isize,
-          Some(finalize_with_custom_callback::<T, F>),
-          hint_ptr.cast(),
-          &mut raw_value,
-          &mut copied,
-        )
-      },
-      "Failed to create external string latin1"
-    )?;
+    let status = unsafe {
+      sys::node_api_create_external_string_latin1(
+        env.0,
+        data.cast(),
+        len as isize,
+        Some(finalize_with_custom_callback::<T, F>),
+        hint_ptr.cast(),
+        &mut raw_value,
+        &mut copied,
+      )
+    };
 
-    if copied {
+    if status != sys::Status::napi_ok {
       unsafe {
-        let (hint, finalize) = *Box::from_raw(hint_ptr);
-        finalize(*env, hint);
+        drop(Box::from_raw(hint_ptr));
       }
     }
+
+    check_status!(status, "Failed to create external string latin1")?;
+
+    let inner_buf = if copied { fallback_buf } else { vec![] };
+    let buf_ptr = if copied { inner_buf.as_ptr() } else { data };
 
     Ok(Self {
       inner: JsString(
@@ -195,8 +194,8 @@ impl<'env> JsStringLatin1<'env> {
         },
         std::marker::PhantomData,
       ),
-      buf: unsafe { std::slice::from_raw_parts(data, len) },
-      _inner_buf: vec![],
+      buf: unsafe { std::slice::from_raw_parts(buf_ptr, len) },
+      _inner_buf: inner_buf,
     })
   }
 

--- a/crates/napi/src/js_values/string/latin1.rs
+++ b/crates/napi/src/js_values/string/latin1.rs
@@ -174,7 +174,7 @@ impl<'env> JsStringLatin1<'env> {
       )
     };
 
-    if status != sys::Status::napi_ok {
+    if status != sys::Status::napi_ok && !copied {
       unsafe {
         drop(Box::from_raw(hint_ptr));
       }

--- a/crates/napi/src/js_values/string/latin1.rs
+++ b/crates/napi/src/js_values/string/latin1.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "napi10")]
 use std::ffi::c_void;
+#[cfg(feature = "napi10")]
+use std::sync::Arc;
 
 use crate::{bindgen_prelude::ToNapiValue, sys, JsString, Result};
 
@@ -10,6 +12,8 @@ pub struct JsStringLatin1<'env> {
   pub(crate) inner: JsString<'env>,
   pub(crate) buf: &'env [u8],
   pub(crate) _inner_buf: Vec<u8>,
+  #[cfg(feature = "napi10")]
+  pub(crate) _shared_buf: Option<Arc<Vec<u8>>>,
 }
 
 impl<'env> JsStringLatin1<'env> {
@@ -44,7 +48,7 @@ impl<'env> JsStringLatin1<'env> {
   /// The `copied` parameter serves as feedback to understand whether the external string
   /// optimization was successful or if V8 fell back to traditional string creation.
   pub fn from_data(env: &'env Env, data: Vec<u8>) -> Result<JsStringLatin1<'env>> {
-    use std::{mem::ManuallyDrop, ptr};
+    use std::ptr;
 
     use crate::{check_status, Error, Status, Value, ValueType};
 
@@ -55,14 +59,15 @@ impl<'env> JsStringLatin1<'env> {
       ));
     }
 
-    let fallback_buf = data.clone();
-    let mut data = ManuallyDrop::new(data);
+    let shared_buf = Arc::new(data);
     let mut raw_value = ptr::null_mut();
     let mut copied = false;
-    let data_ptr = data.as_ptr();
-    let len = data.len();
-    let cap = data.capacity();
-    let finalize_hint = Box::into_raw(Box::new((len, cap)));
+    let data_ptr = shared_buf.as_ptr();
+    let len = shared_buf.len();
+    // Keep one strong reference on the Rust side and transfer another to Node.
+    // If V8 copies the string and runs the finalizer immediately, Rust still has
+    // a valid view of the bytes without cloning the full buffer first.
+    let finalize_hint = Arc::into_raw(Arc::clone(&shared_buf));
 
     let status = unsafe {
       sys::node_api_create_external_string_latin1(
@@ -70,7 +75,7 @@ impl<'env> JsStringLatin1<'env> {
         data_ptr.cast(),
         len as isize,
         Some(drop_latin1_string),
-        finalize_hint.cast(),
+        finalize_hint.cast_mut().cast(),
         &mut raw_value,
         &mut copied,
       )
@@ -78,15 +83,11 @@ impl<'env> JsStringLatin1<'env> {
 
     if status != sys::Status::napi_ok {
       unsafe {
-        drop(Box::from_raw(finalize_hint));
-        ManuallyDrop::drop(&mut data);
+        drop(Arc::from_raw(finalize_hint));
       }
     }
 
     check_status!(status, "Failed to create external string latin1")?;
-
-    let inner_buf = if copied { fallback_buf } else { vec![] };
-    let buf_ptr = if copied { inner_buf.as_ptr() } else { data_ptr };
 
     Ok(Self {
       inner: JsString(
@@ -97,8 +98,9 @@ impl<'env> JsStringLatin1<'env> {
         },
         std::marker::PhantomData,
       ),
-      buf: unsafe { std::slice::from_raw_parts(buf_ptr, len) },
-      _inner_buf: inner_buf,
+      buf: unsafe { std::slice::from_raw_parts(data_ptr, len) },
+      _inner_buf: vec![],
+      _shared_buf: Some(shared_buf),
     })
   }
 
@@ -196,6 +198,7 @@ impl<'env> JsStringLatin1<'env> {
       ),
       buf: unsafe { std::slice::from_raw_parts(buf_ptr, len) },
       _inner_buf: inner_buf,
+      _shared_buf: None,
     })
   }
 
@@ -241,6 +244,7 @@ impl<'env> JsStringLatin1<'env> {
       ),
       buf: string.as_bytes(),
       _inner_buf: vec![],
+      _shared_buf: None,
     })
   }
 
@@ -287,15 +291,13 @@ impl ToNapiValue for JsStringLatin1<'_> {
 #[cfg(feature = "napi10")]
 extern "C" fn drop_latin1_string(
   _: sys::node_api_basic_env,
-  finalize_data: *mut c_void,
+  _: *mut c_void,
   finalize_hint: *mut c_void,
 ) {
-  let (size, capacity): (usize, usize) = unsafe { *Box::from_raw(finalize_hint.cast()) };
-  if size == 0 || finalize_data.is_null() {
+  if finalize_hint.is_null() {
     return;
   }
-  let data: Vec<u8> = unsafe { Vec::from_raw_parts(finalize_data.cast(), size, capacity) };
-  drop(data);
+  drop(unsafe { Arc::from_raw(finalize_hint.cast::<Vec<u8>>()) });
 }
 
 #[cfg(feature = "napi10")]

--- a/crates/napi/src/js_values/string/mod.rs
+++ b/crates/napi/src/js_values/string/mod.rs
@@ -136,6 +136,8 @@ impl<'env> JsString<'env> {
       inner: self,
       buf: unsafe { std::slice::from_raw_parts(buf_ptr.cast(), len) },
       _inner_buf: result,
+      #[cfg(feature = "napi10")]
+      _shared_buf: None,
     })
   }
 
@@ -160,6 +162,8 @@ impl<'env> JsString<'env> {
       inner: self,
       buf: unsafe { std::slice::from_raw_parts(buf_ptr.cast(), written_char_count) },
       _inner_buf: unsafe { Vec::from_raw_parts(buf_ptr.cast(), written_char_count, len) },
+      #[cfg(feature = "napi10")]
+      _shared_buf: None,
     })
   }
 }

--- a/crates/napi/src/js_values/string/utf16.rs
+++ b/crates/napi/src/js_values/string/utf16.rs
@@ -2,6 +2,8 @@ use std::convert::TryFrom;
 #[cfg(feature = "napi10")]
 use std::ffi::c_void;
 use std::ops::Deref;
+#[cfg(feature = "napi10")]
+use std::sync::Arc;
 
 use crate::{bindgen_runtime::ToNapiValue, sys, Error, JsString, Result, Status};
 
@@ -12,6 +14,8 @@ pub struct JsStringUtf16<'env> {
   pub(crate) inner: JsString<'env>,
   pub(crate) buf: &'env [u16],
   pub(crate) _inner_buf: Vec<u16>,
+  #[cfg(feature = "napi10")]
+  pub(crate) _shared_buf: Option<Arc<Vec<u16>>>,
 }
 
 impl<'env> JsStringUtf16<'env> {
@@ -46,7 +50,6 @@ impl<'env> JsStringUtf16<'env> {
   /// The `copied` parameter serves as feedback to understand whether the external string
   /// optimization was successful or if V8 fell back to traditional string creation.
   pub fn from_data(env: &'env Env, data: Vec<u16>) -> Result<JsStringUtf16<'env>> {
-    use std::mem::ManuallyDrop;
     use std::ptr;
 
     use crate::{check_status, Value, ValueType};
@@ -58,14 +61,15 @@ impl<'env> JsStringUtf16<'env> {
       ));
     }
 
-    let fallback_buf = data.clone();
-    let mut data = ManuallyDrop::new(data);
+    let shared_buf = Arc::new(data);
     let mut raw_value = ptr::null_mut();
     let mut copied = false;
-    let data_ptr = data.as_ptr();
-    let len = data.len();
-    let cap = data.capacity();
-    let finalize_hint = Box::into_raw(Box::new((len, cap)));
+    let data_ptr = shared_buf.as_ptr();
+    let len = shared_buf.len();
+    // Keep one strong reference on the Rust side and transfer another to Node.
+    // If V8 copies the string and runs the finalizer immediately, Rust still has
+    // a valid view of the bytes without cloning the full buffer first.
+    let finalize_hint = Arc::into_raw(Arc::clone(&shared_buf));
 
     let status = unsafe {
       sys::node_api_create_external_string_utf16(
@@ -73,7 +77,7 @@ impl<'env> JsStringUtf16<'env> {
         data_ptr,
         len as isize,
         Some(drop_utf16_string),
-        finalize_hint.cast(),
+        finalize_hint.cast_mut().cast(),
         &mut raw_value,
         &mut copied,
       )
@@ -81,15 +85,11 @@ impl<'env> JsStringUtf16<'env> {
 
     if status != sys::Status::napi_ok {
       unsafe {
-        drop(Box::from_raw(finalize_hint));
-        ManuallyDrop::drop(&mut data);
+        drop(Arc::from_raw(finalize_hint));
       }
     }
 
     check_status!(status, "Failed to create external string utf16")?;
-
-    let inner_buf = if copied { fallback_buf } else { vec![] };
-    let buf_ptr = if copied { inner_buf.as_ptr() } else { data_ptr };
 
     Ok(Self {
       inner: JsString(
@@ -100,8 +100,9 @@ impl<'env> JsStringUtf16<'env> {
         },
         std::marker::PhantomData,
       ),
-      buf: unsafe { std::slice::from_raw_parts(buf_ptr, len) },
-      _inner_buf: inner_buf,
+      buf: unsafe { std::slice::from_raw_parts(data_ptr, len) },
+      _inner_buf: vec![],
+      _shared_buf: Some(shared_buf),
     })
   }
 
@@ -197,6 +198,7 @@ impl<'env> JsStringUtf16<'env> {
       ),
       buf: unsafe { std::slice::from_raw_parts(buf_ptr, len) },
       _inner_buf: inner_buf,
+      _shared_buf: None,
     })
   }
 
@@ -242,6 +244,7 @@ impl<'env> JsStringUtf16<'env> {
       ),
       buf: data,
       _inner_buf: vec![],
+      _shared_buf: None,
     })
   }
 
@@ -307,15 +310,13 @@ impl ToNapiValue for JsStringUtf16<'_> {
 #[cfg(feature = "napi10")]
 extern "C" fn drop_utf16_string(
   _: sys::node_api_basic_env,
-  finalize_data: *mut c_void,
+  _: *mut c_void,
   finalize_hint: *mut c_void,
 ) {
-  let (size, capacity): (usize, usize) = unsafe { *Box::from_raw(finalize_hint.cast()) };
-  if size == 0 || finalize_data.is_null() {
+  if finalize_hint.is_null() {
     return;
   }
-  let data: Vec<u16> = unsafe { Vec::from_raw_parts(finalize_data.cast(), size, capacity) };
-  drop(data);
+  drop(unsafe { Arc::from_raw(finalize_hint.cast::<Vec<u16>>()) });
 }
 
 #[cfg(feature = "napi10")]

--- a/crates/napi/src/js_values/string/utf16.rs
+++ b/crates/napi/src/js_values/string/utf16.rs
@@ -177,10 +177,8 @@ impl<'env> JsStringUtf16<'env> {
       )
     };
 
-    if status != sys::Status::napi_ok {
-      unsafe {
-        drop(Box::from_raw(hint_ptr));
-      }
+    if status != sys::Status::napi_ok && !copied {
+      finalize_with_custom_callback::<T, F>(env.0.cast(), ptr::null_mut(), hint_ptr.cast());
     }
 
     check_status!(status, "Failed to create external string utf16")?;

--- a/crates/napi/src/js_values/string/utf16.rs
+++ b/crates/napi/src/js_values/string/utf16.rs
@@ -46,7 +46,7 @@ impl<'env> JsStringUtf16<'env> {
   /// The `copied` parameter serves as feedback to understand whether the external string
   /// optimization was successful or if V8 fell back to traditional string creation.
   pub fn from_data(env: &'env Env, data: Vec<u16>) -> Result<JsStringUtf16<'env>> {
-    use std::mem;
+    use std::mem::ManuallyDrop;
     use std::ptr;
 
     use crate::{check_status, Value, ValueType};
@@ -58,6 +58,8 @@ impl<'env> JsStringUtf16<'env> {
       ));
     }
 
+    let fallback_buf = data.clone();
+    let mut data = ManuallyDrop::new(data);
     let mut raw_value = ptr::null_mut();
     let mut copied = false;
     let data_ptr = data.as_ptr();
@@ -65,34 +67,29 @@ impl<'env> JsStringUtf16<'env> {
     let cap = data.capacity();
     let finalize_hint = Box::into_raw(Box::new((len, cap)));
 
-    check_status!(
-      unsafe {
-        sys::node_api_create_external_string_utf16(
-          env.0,
-          data_ptr,
-          len as isize,
-          Some(drop_utf16_string),
-          finalize_hint.cast(),
-          &mut raw_value,
-          &mut copied,
-        )
-      },
-      "Failed to create external string utf16"
-    )?;
-
-    let inner_buf = if copied {
-      // If the data was copied, the finalizer won't be called
-      // We need to clean up the finalize_hint and let the Vec be dropped
-      unsafe {
-        let _ = Box::from_raw(finalize_hint);
-      };
-      data
-    } else {
-      // Only forget the data if it wasn't copied
-      // The finalizer will handle cleanup
-      mem::forget(data);
-      vec![]
+    let status = unsafe {
+      sys::node_api_create_external_string_utf16(
+        env.0,
+        data_ptr,
+        len as isize,
+        Some(drop_utf16_string),
+        finalize_hint.cast(),
+        &mut raw_value,
+        &mut copied,
+      )
     };
+
+    if status != sys::Status::napi_ok {
+      unsafe {
+        drop(Box::from_raw(finalize_hint));
+        ManuallyDrop::drop(&mut data);
+      }
+    }
+
+    check_status!(status, "Failed to create external string utf16")?;
+
+    let inner_buf = if copied { fallback_buf } else { vec![] };
+    let buf_ptr = if copied { inner_buf.as_ptr() } else { data_ptr };
 
     Ok(Self {
       inner: JsString(
@@ -103,7 +100,7 @@ impl<'env> JsStringUtf16<'env> {
         },
         std::marker::PhantomData,
       ),
-      buf: unsafe { std::slice::from_raw_parts(data_ptr.cast(), len) },
+      buf: unsafe { std::slice::from_raw_parts(buf_ptr, len) },
       _inner_buf: inner_buf,
     })
   }
@@ -125,7 +122,7 @@ impl<'env> JsStringUtf16<'env> {
   ///
   /// ### When `copied` is `true`:
   /// - String data is copied to V8's heap
-  /// - Finalizer is called immediately if provided
+  /// - Finalizer is invoked during string creation if provided
   /// - Original buffer can be freed after the call
   /// - Performance benefit of external strings is not achieved
   ///
@@ -152,7 +149,7 @@ impl<'env> JsStringUtf16<'env> {
     finalize_hint: T,
     finalize_callback: F,
   ) -> Result<JsStringUtf16<'env>> {
-    use std::ptr;
+    use std::{ptr, slice};
 
     use crate::{check_status, Value, ValueType};
 
@@ -163,31 +160,33 @@ impl<'env> JsStringUtf16<'env> {
       ));
     }
 
+    let fallback_buf = unsafe { slice::from_raw_parts(data, len) }.to_vec();
     let hint_ptr = Box::into_raw(Box::new((finalize_hint, finalize_callback)));
     let mut raw_value = ptr::null_mut();
     let mut copied = false;
 
-    check_status!(
-      unsafe {
-        sys::node_api_create_external_string_utf16(
-          env.0,
-          data,
-          len as isize,
-          Some(finalize_with_custom_callback::<T, F>),
-          hint_ptr.cast(),
-          &mut raw_value,
-          &mut copied,
-        )
-      },
-      "Failed to create external string utf16"
-    )?;
+    let status = unsafe {
+      sys::node_api_create_external_string_utf16(
+        env.0,
+        data,
+        len as isize,
+        Some(finalize_with_custom_callback::<T, F>),
+        hint_ptr.cast(),
+        &mut raw_value,
+        &mut copied,
+      )
+    };
 
-    if copied {
+    if status != sys::Status::napi_ok {
       unsafe {
-        let (hint, finalize) = *Box::from_raw(hint_ptr);
-        finalize(*env, hint);
+        drop(Box::from_raw(hint_ptr));
       }
     }
+
+    check_status!(status, "Failed to create external string utf16")?;
+
+    let inner_buf = if copied { fallback_buf } else { vec![] };
+    let buf_ptr = if copied { inner_buf.as_ptr() } else { data };
 
     Ok(Self {
       inner: JsString(
@@ -198,8 +197,8 @@ impl<'env> JsStringUtf16<'env> {
         },
         std::marker::PhantomData,
       ),
-      buf: unsafe { std::slice::from_raw_parts(data, len) },
-      _inner_buf: vec![],
+      buf: unsafe { std::slice::from_raw_parts(buf_ptr, len) },
+      _inner_buf: inner_buf,
     })
   }
 


### PR DESCRIPTION
Fixes the intermittent failures in "Test node wasi target"
https://github.com/napi-rs/napi-rs/actions/workflows/test-release.yaml

CI was successful on fork
https://github.com/trivikr/napi-rs/pull/5#issuecomment-4285224359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory and ownership handling for external string creation to prevent leaks and ensure buffers are retained or released correctly on success or failure.
  * More robust error handling around external string registration, avoiding premature drops when strings are copied vs referenced.

* **Documentation**
  * Clarified wording about when the custom finalizer is invoked during string creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->