### PR TITLE
fix(napi): Convert #[ctor] calls to declarative form to remove all features

### DIFF
--- a/crates/backend/src/codegen/const.rs
+++ b/crates/backend/src/codegen/const.rs
@@ -40,9 +40,11 @@ impl NapiConst {
       #[allow(non_snake_case)]
       #[allow(clippy::all)]
       #[cfg(all(not(test), not(target_family = "wasm")))]
-      #[napi::ctor::ctor(crate_path=::napi::ctor)]
-      fn #register_name() {
-        napi::bindgen_prelude::register_module_export(#js_mod_ident, #js_name_lit, #cb_name);
+      napi::ctor::declarative::ctor! {
+        #[ctor(unsafe)]
+        fn #register_name() {
+          napi::bindgen_prelude::register_module_export(#js_mod_ident, #js_name_lit, #cb_name);
+        }
       }
 
       #[allow(non_snake_case)]

--- a/crates/backend/src/codegen/const.rs
+++ b/crates/backend/src/codegen/const.rs
@@ -37,10 +37,10 @@ impl NapiConst {
       unsafe fn #cb_name(env: napi::sys::napi_env) -> napi::Result<napi::sys::napi_value> {
         <#type_name as napi::bindgen_prelude::ToNapiValue>::to_napi_value(env, #name_ident)
       }
-      #[allow(non_snake_case)]
-      #[allow(clippy::all)]
       #[cfg(all(not(test), not(target_family = "wasm")))]
       napi::ctor::declarative::ctor! {
+        #[allow(non_snake_case)]
+        #[allow(clippy::all)]
         #[ctor(unsafe)]
         fn #register_name() {
           napi::bindgen_prelude::register_module_export(#js_mod_ident, #js_name_lit, #cb_name);

--- a/crates/backend/src/codegen/enum.rs
+++ b/crates/backend/src/codegen/enum.rs
@@ -286,9 +286,11 @@ impl NapiEnum {
       #[allow(non_snake_case)]
       #[allow(clippy::all)]
       #[cfg(all(not(test), not(target_family = "wasm")))]
-      #[napi::ctor::ctor(crate_path=napi::ctor)]
-      fn #register_name() {
-        napi::bindgen_prelude::register_module_export(#js_mod_ident, #js_name_lit, #callback_name);
+      napi::ctor::declarative::ctor! {
+        #[ctor(unsafe)]
+        fn #register_name() {
+          napi::bindgen_prelude::register_module_export(#js_mod_ident, #js_name_lit, #callback_name);
+        }
       }
       #[allow(non_snake_case)]
       #[allow(clippy::all)]

--- a/crates/backend/src/codegen/enum.rs
+++ b/crates/backend/src/codegen/enum.rs
@@ -283,10 +283,10 @@ impl NapiEnum {
 
         Ok(obj_ptr)
       }
-      #[allow(non_snake_case)]
-      #[allow(clippy::all)]
       #[cfg(all(not(test), not(target_family = "wasm")))]
       napi::ctor::declarative::ctor! {
+        #[allow(non_snake_case)]
+        #[allow(clippy::all)]
         #[ctor(unsafe)]
         fn #register_name() {
           napi::bindgen_prelude::register_module_export(#js_mod_ident, #js_name_lit, #callback_name);

--- a/crates/backend/src/codegen/fn.rs
+++ b/crates/backend/src/codegen/fn.rs
@@ -793,11 +793,11 @@ impl NapiFn {
             Ok(exports)
           }
 
-          #[doc(hidden)]
-          #[allow(clippy::all)]
-          #[allow(non_snake_case)]
           #[cfg(all(not(test), not(target_family = "wasm")))]
           napi::ctor::declarative::ctor! {
+            #[doc(hidden)]
+            #[allow(clippy::all)]
+            #[allow(non_snake_case)]
             #[ctor(unsafe)]
             fn #module_register_name() {
               napi::bindgen_prelude::register_module_export_hook(#cb_name);
@@ -818,11 +818,11 @@ impl NapiFn {
         quote! {}
       } else {
         quote! {
-          #[doc(hidden)]
-          #[allow(clippy::all)]
-          #[allow(non_snake_case)]
           #[cfg(all(not(test), not(target_family = "wasm")))]
           napi::ctor::declarative::ctor! {
+            #[doc(hidden)]
+            #[allow(clippy::all)]
+            #[allow(non_snake_case)]
             #[ctor(unsafe)]
             fn #module_register_name() {
               napi::bindgen_prelude::register_module_export(#js_mod_ident, #js_name, #cb_name);

--- a/crates/backend/src/codegen/fn.rs
+++ b/crates/backend/src/codegen/fn.rs
@@ -797,9 +797,11 @@ impl NapiFn {
           #[allow(clippy::all)]
           #[allow(non_snake_case)]
           #[cfg(all(not(test), not(target_family = "wasm")))]
-          #[napi::ctor::ctor(crate_path=::napi::ctor)]
-          fn #module_register_name() {
-            napi::bindgen_prelude::register_module_export_hook(#cb_name);
+          napi::ctor::declarative::ctor! {
+            #[ctor(unsafe)]
+            fn #module_register_name() {
+              napi::bindgen_prelude::register_module_export_hook(#cb_name);
+            }
           }
 
           #[allow(clippy::all)]
@@ -820,9 +822,11 @@ impl NapiFn {
           #[allow(clippy::all)]
           #[allow(non_snake_case)]
           #[cfg(all(not(test), not(target_family = "wasm")))]
-          #[napi::ctor::ctor(crate_path=::napi::ctor)]
-          fn #module_register_name() {
-            napi::bindgen_prelude::register_module_export(#js_mod_ident, #js_name, #cb_name);
+          napi::ctor::declarative::ctor! {
+            #[ctor(unsafe)]
+            fn #module_register_name() {
+              napi::bindgen_prelude::register_module_export(#js_mod_ident, #js_name, #cb_name);
+            }
           }
 
           #[doc(hidden)]

--- a/crates/backend/src/codegen/struct.rs
+++ b/crates/backend/src/codegen/struct.rs
@@ -974,10 +974,10 @@ impl NapiStruct {
     }
     let js_mod_ident = js_mod_to_token_stream(self.js_mod.as_ref());
     quote! {
-      #[allow(non_snake_case)]
-      #[allow(clippy::all)]
       #[cfg(all(not(test), not(target_family = "wasm")))]
       napi::ctor::declarative::ctor! {
+        #[allow(non_snake_case)]
+        #[allow(clippy::all)]
         #[ctor(unsafe)]
         fn #struct_register_name() {
           napi::__private::register_class(std::any::TypeId::of::<#name>(), #js_mod_ident, #js_name, vec![#(#props),*], #implement_iterator);

--- a/crates/backend/src/codegen/struct.rs
+++ b/crates/backend/src/codegen/struct.rs
@@ -977,9 +977,11 @@ impl NapiStruct {
       #[allow(non_snake_case)]
       #[allow(clippy::all)]
       #[cfg(all(not(test), not(target_family = "wasm")))]
-      #[napi::ctor::ctor(crate_path=napi::ctor)]
-      fn #struct_register_name() {
-        napi::__private::register_class(std::any::TypeId::of::<#name>(), #js_mod_ident, #js_name, vec![#(#props),*], #implement_iterator);
+      napi::ctor::declarative::ctor! {
+        #[ctor(unsafe)]
+        fn #struct_register_name() {
+          napi::__private::register_class(std::any::TypeId::of::<#name>(), #js_mod_ident, #js_name, vec![#(#props),*], #implement_iterator);
+        }
       }
 
       #[allow(non_snake_case)]
@@ -1625,9 +1627,11 @@ impl NapiImpl {
         #(#methods)*
 
         #[cfg(all(not(test), not(target_family = "wasm")))]
-        #[napi::ctor::ctor(crate_path=napi::ctor)]
-        fn #register_name() {
-          napi::__private::register_class(std::any::TypeId::of::<#name>(), #js_mod_ident, #js_name, vec![#(#props),*], false);
+        napi::ctor::declarative::ctor! {
+          #[ctor(unsafe)]
+          fn #register_name() {
+            napi::__private::register_class(std::any::TypeId::of::<#name>(), #js_mod_ident, #js_name, vec![#(#props),*], false);
+          }
         }
 
         #[cfg(all(not(test), target_family = "wasm"))]

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -24,7 +24,7 @@ type-def = ["napi-derive-backend/type-def", "ctor"]
 
 [dependencies]
 convert_case = "0.11"
-ctor = { version = "0.10", default-features = false, features = ["std", "proc_macro", "dtor", "no_warn_on_missing_unsafe"], optional = true }
+ctor = { version = "0.10.1", default-features = false, optional = true }
 napi-derive-backend = { version = "5.0.3", path = "../backend" }
 proc-macro2 = "1"
 quote = "1"

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -152,18 +152,21 @@ pub fn module_exports(_attr: TokenStream, input: TokenStream) -> TokenStream {
   };
 
   let register = quote! {
-    #[cfg_attr(not(target_family = "wasm"), napi::ctor::ctor(crate_path=napi::ctor))]
-    fn __napi_explicit_module_register() {
-      unsafe fn register(raw_env: napi::sys::napi_env, raw_exports: napi::sys::napi_value) -> napi::Result<()> {
-        use napi::{Env, JsObject, NapiValue};
+    #[cfg(not(target_family = "wasm"))]
+    napi::ctor::declarative::ctor! {
+      #[ctor(unsafe)]
+      fn __napi_explicit_module_register() {
+        unsafe fn register(raw_env: napi::sys::napi_env, raw_exports: napi::sys::napi_value) -> napi::Result<()> {
+          use napi::{Env, JsObject, NapiValue};
 
-        let env = Env::from_raw(raw_env);
-        let exports = JsObject::from_raw_unchecked(raw_env, raw_exports);
+          let env = Env::from_raw(raw_env);
+          let exports = JsObject::from_raw_unchecked(raw_env, raw_exports);
 
-        #call_expr
+          #call_expr
+        }
+
+        napi::bindgen_prelude::register_module_exports(register)
       }
-
-      napi::bindgen_prelude::register_module_exports(register)
     }
   };
 
@@ -180,8 +183,10 @@ pub fn module_exports(_attr: TokenStream, input: TokenStream) -> TokenStream {
 pub fn module_init(_: TokenStream, input: TokenStream) -> TokenStream {
   let input = parse_macro_input!(input as ItemFn);
   quote! {
-    #[napi::ctor::ctor(crate_path=napi::ctor)]
-    #input
+    napi::ctor::declarative::ctor! {
+      #[ctor(unsafe)]
+      #input
+    }
   }
   .into()
 }

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -74,7 +74,7 @@ tracing = ["dep:tracing"]
 bitflags = "2"
 # Keep ctor's priority support disabled until the Apple/Zig cross-link
 # path stops emitting unresolved `section$end$__DATA$CTOR` references.
-ctor = { version = "0.10.0", default-features = false, features = ["std", "proc_macro", "dtor", "no_warn_on_missing_unsafe"] }
+ctor = { version = "0.10.1", default-features = false }
 nohash-hasher = "0.2.0"
 rustc-hash = "2.1.1"
 

--- a/crates/napi/src/bindgen_runtime/mod.rs
+++ b/crates/napi/src/bindgen_runtime/mod.rs
@@ -2,7 +2,6 @@ use std::ffi::c_void;
 use std::rc::Rc;
 
 pub use callback_info::*;
-pub use ctor::ctor;
 pub use env::*;
 pub use iterator::Generator;
 pub use js_values::*;


### PR DESCRIPTION
The `ctor` crate offer a proc-macro-free, declarative macro style that removes the need for the `proc-macro` feature (and underlying `ctor-proc-macro` crate dep) and makes the `ctor` macro itself more robust to crate import paths. This allows `napi-rs` to import `ctor` with zero features.

The declarative macro is guaranteed to parse any item that is decorated with `#[ctor]` in exactly the same way as if the proc macro was used (https://docs.rs/ctor/latest/ctor/declarative/index.html).

I believe this is correct (tried to run the yarn tests locally), but a CI run should confirm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated module registration/initialization internals for a more consistent and safer startup mechanism; no changes to public APIs or visible runtime behavior.

* **Chores**
  * Bumped an internal dependency to a newer patch version.
  * Removed an internal re-export to simplify module boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->