### PR TITLE
docs(napi): clarify unsafe function invariants

### DIFF
--- a/crates/napi/src/bindgen_runtime/js_values.rs
+++ b/crates/napi/src/bindgen_runtime/js_values.rs
@@ -66,9 +66,10 @@ pub trait TypeName {
 }
 
 pub trait ToNapiValue: Sized {
-  /// # Safety
+  /// This function called to convert rust values to napi values
   ///
-  /// this function called to convert rust values to napi values
+  /// # Safety
+  /// The caller must guarantee that the `env` is a valid napi env pointer and the returned `napi_value` is a valid js value pointer.
   unsafe fn to_napi_value(env: sys::napi_env, val: Self) -> Result<sys::napi_value>;
 
   fn into_unknown(self, env: &Env) -> Result<Unknown<'_>> {
@@ -97,9 +98,14 @@ impl<'env, T: JsValue<'env>> ToNapiValue for T {
 }
 
 pub trait FromNapiValue: Sized {
+  /// This function called to convert napi values to native rust values
+  ///
   /// # Safety
   ///
-  /// this function called to convert napi values to native rust values
+  /// The caller must ensure that:
+  /// - The `env` is a valid napi env pointer
+  /// - The `napi_val` is a valid js value pointer
+  /// - The `napi_val` is a valid type that can be converted into `Self` using [ValidateNapiValue::validate]
   unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> Result<Self>;
 
   fn from_unknown(value: Unknown) -> Result<Self> {
@@ -108,16 +114,26 @@ pub trait FromNapiValue: Sized {
 }
 
 pub trait FromNapiRef {
+  /// This function called to convert napi values to native rust values
+  ///
   /// # Safety
   ///
-  /// this function called to convert napi values to native rust values
+  /// The caller must ensure that:
+  /// - The `env` is a valid napi env pointer
+  /// - The `napi_val` is a valid js value pointer
+  /// - The `napi_val` is a valid type that can be converted into `Self` using [ValidateNapiValue::validate]
   unsafe fn from_napi_ref(env: sys::napi_env, napi_val: sys::napi_value) -> Result<&'static Self>;
 }
 
 pub trait FromNapiMutRef {
+  /// This function called to convert napi values to native rust values
+  ///
   /// # Safety
   ///
-  /// this function called to convert napi values to native rust values
+  /// The caller must ensure that:
+  /// - The `env` is a valid napi env pointer
+  /// - The `napi_val` is a valid js value pointer
+  /// - The `napi_val` is a valid type that can be converted into `Self` using [ValidateNapiValue::validate]
   unsafe fn from_napi_mut_ref(
     env: sys::napi_env,
     napi_val: sys::napi_value,
@@ -137,12 +153,17 @@ impl<T: FromNapiMutRef + 'static> FromNapiValue for &mut T {
 }
 
 pub trait ValidateNapiValue: TypeName {
-  /// # Safety
+  /// This function called to validate whether napi value passed to rust is valid type.
   ///
-  /// this function called to validate whether napi value passed to rust is valid type
   /// The reason why this function return `napi_value` is that if a `Promise<T>` passed in
   /// we need to return `Promise.reject(T)`, not the `T`.
   /// So we need to create `Promise.reject(T)` in this function.
+  ///
+  /// # Safety
+  ///
+  /// The caller must ensure that:
+  /// - The `env` is a valid napi env pointer
+  /// - The `napi_val` is a valid js value pointer
   unsafe fn validate(env: sys::napi_env, napi_val: sys::napi_value) -> Result<sys::napi_value> {
     let value_type = Self::value_type();
 

--- a/crates/napi/src/bindgen_runtime/js_values/arraybuffer.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/arraybuffer.rs
@@ -1037,7 +1037,7 @@ macro_rules! impl_from_slice {
       #[doc = "## Safety"]
       #[doc = ""]
       #[doc = "The caller must ensure that:"]
-      #[doc = "- The data pointer is valid for the lifetime of the buffer and points to a memory region of at least `len` bytes"]
+      #[doc = "- The data pointer is valid for the lifetime of the buffer and points to a memory region of at least `len` elements"]
       #[doc = "- The finalize callback properly cleans up the data"]
       #[doc = ""]
       #[doc = "### Notes"]

--- a/crates/napi/src/bindgen_runtime/js_values/arraybuffer.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/arraybuffer.rs
@@ -213,13 +213,16 @@ impl<'env> ArrayBuffer<'env> {
     })
   }
 
-  /// ## Safety
-  ///
   /// Mostly the same with `from_data`
   ///
   /// Provided `finalize_callback` will be called when `[u8]` got dropped.
-  ///
   /// You can pass in `noop_finalize` if you have nothing to do in finalize phase.
+  ///
+  /// ## Safety
+  ///
+  /// The caller must ensure that:
+  /// - The data pointer is valid for the lifetime of the buffer and points to a memory region of at least `len` bytes
+  /// - The finalize callback properly cleans up the data
   ///
   /// ### Notes
   ///
@@ -1024,15 +1027,18 @@ macro_rules! impl_from_slice {
         })
       }
 
-      #[doc = "## Safety"]
-      #[doc = ""]
       #[doc = "Mostly the same with `from_data`"]
       #[doc = ""]
       #[doc = "Provided `finalize_callback` will be called when `"]
       #[doc = stringify!($slice_type)]
       #[doc = "` got dropped."]
-      #[doc = ""]
       #[doc = "You can pass in `noop_finalize` if you have nothing to do in finalize phase."]
+      #[doc = ""]
+      #[doc = "## Safety"]
+      #[doc = ""]
+      #[doc = "The caller must ensure that:"]
+      #[doc = "- The data pointer is valid for the lifetime of the buffer and points to a memory region of at least `len` bytes"]
+      #[doc = "- The finalize callback properly cleans up the data"]
       #[doc = ""]
       #[doc = "### Notes"]
       #[doc = ""]
@@ -1741,20 +1747,21 @@ impl<'env> Uint8ClampedSlice<'env> {
     })
   }
 
-  /// ## Safety
-  ///
   /// Mostly the same with `from_data`
   ///
   /// Provided `finalize_callback` will be called when `Uint8ClampedSlice` got dropped.
-  ///
   /// You can pass in `noop_finalize` if you have nothing to do in finalize phase.
+  ///
+  /// ## Safety
+  ///
+  /// The caller must ensure that:
+  /// - The data pointer is valid for the lifetime of the buffer and points to a memory region of at least `len` bytes
+  /// - The finalize callback properly cleans up the data
   ///
   /// ### Notes
   ///
   /// JavaScript may mutate the data passed in to this buffer when writing the buffer.
-  ///
   /// However, some JavaScript runtimes do not support external buffers (notably electron!)
-  ///
   /// in which case modifications may be lost.
   ///
   /// If you need to support these runtimes, you should create a buffer by other means and then

--- a/crates/napi/src/bindgen_runtime/js_values/buffer.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/buffer.rs
@@ -91,13 +91,16 @@ impl<'env> BufferSlice<'env> {
     })
   }
 
-  /// ## Safety
-  ///
   /// Mostly the same with `from_data`
   ///
   /// Provided `finalize_callback` will be called when `BufferSlice` got dropped.
-  ///
   /// You can pass in `noop_finalize` if you have nothing to do in finalize phase.
+  ///
+  /// ## Safety
+  ///
+  /// The caller must ensure that:
+  /// - The data pointer is valid for the lifetime of the buffer and points to a memory region of at least `len` bytes
+  /// - The finalize callback properly cleans up the data
   ///
   /// ### Notes
   ///

--- a/crates/napi/src/env.rs
+++ b/crates/napi/src/env.rs
@@ -190,7 +190,9 @@ impl Env {
   ///
   /// # Safety
   ///
-  /// Create JsString from known valid utf-8 string
+  /// The caller must guarantee that the `data_ptr` is a valid pointer to either:
+  /// - a valid utf-8 string with length of `len`
+  /// - a valid utf-8 string terminated by a null character when [crate::bindgen_runtime::NAPI_AUTO_LENGTH] is passed to `len`
   pub unsafe fn create_string_from_c_char<'env>(
     &self,
     data_ptr: *const c_char,

--- a/crates/napi/src/js_values/string/latin1.rs
+++ b/crates/napi/src/js_values/string/latin1.rs
@@ -111,7 +111,7 @@ impl<'env> JsStringLatin1<'env> {
   /// ## Safety
   ///
   /// The caller must ensure that:
-  /// - The data pointer is valid for the lifetime of the string
+  /// - The data pointer is valid for the lifetime of the string and points to a memory region of at least `len` bytes
   /// - The finalize callback properly cleans up the data
   ///
   /// ## Behavior

--- a/crates/napi/src/js_values/string/utf16.rs
+++ b/crates/napi/src/js_values/string/utf16.rs
@@ -114,7 +114,7 @@ impl<'env> JsStringUtf16<'env> {
   /// ## Safety
   ///
   /// The caller must ensure that:
-  /// - The data pointer is valid for the lifetime of the string and points to a memory region of at least `len` bytes
+  /// - The data pointer is valid for the lifetime of the string and points to at least `len` UTF-16 code units of storage
   /// - The finalize callback properly cleans up the data
   ///
   /// ## Behavior

--- a/crates/napi/src/js_values/string/utf16.rs
+++ b/crates/napi/src/js_values/string/utf16.rs
@@ -114,7 +114,7 @@ impl<'env> JsStringUtf16<'env> {
   /// ## Safety
   ///
   /// The caller must ensure that:
-  /// - The data pointer is valid for the lifetime of the string
+  /// - The data pointer is valid for the lifetime of the string and points to a memory region of at least `len` bytes
   /// - The finalize callback properly cleans up the data
   ///
   /// ## Behavior

--- a/crates/napi/src/js_values/unknown.rs
+++ b/crates/napi/src/js_values/unknown.rs
@@ -55,11 +55,12 @@ impl Unknown<'_> {
     type_of!(self.0.env, self.0.value)
   }
 
+  /// This function should be called after `JsUnknown::get_type`
+  /// and the `V` must be match with the return value of `get_type`
+  ///
   /// # Safety
   ///
-  /// This function should be called after `JsUnknown::get_type`
-  ///
-  /// And the `V` must be match with the return value of `get_type`
+  /// The caller must ensure that `Self` can be converted into `V`
   pub unsafe fn cast<V>(&self) -> Result<V>
   where
     V: FromNapiValue,
@@ -67,9 +68,13 @@ impl Unknown<'_> {
     unsafe { V::from_napi_value(self.0.env, self.0.value) }
   }
 
+  /// Unknown doesn't have a type
+  ///
   /// # Safety
   ///
-  /// Unknown doesn't have a type
+  /// The caller must ensure that:
+  /// - The `env` is a valid napi env pointer
+  /// - The `napi_val` is a valid js value pointer
   pub unsafe fn from_raw_unchecked(env: sys::napi_env, value: sys::napi_value) -> Self {
     Unknown(
       Value {


### PR DESCRIPTION
Clarified unsafe function invariants in the safety comments. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified and expanded safety docs for unsafe N-API conversions, validations, and external-data constructors. Updated requirements for environment and value pointer validity, memory lifetime and length guarantees, and finalize callbacks across string, buffer/array-buffer, and generic value APIs to make caller preconditions and safety contracts explicit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->