### PR TITLE
Fix(build): on openbsd, work around local thread storage destructor segfault

### DIFF
--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -44,7 +44,10 @@ pub fn setup() {
     _ => {}
   }
 
-  if (target_env == "gnu" && target_os != "windows") || target_os == "freebsd" {
+  if (target_env == "gnu" && target_os != "windows")
+    || target_os == "freebsd"
+    || target_os == "openbsd"
+  {
     // https://sourceware.org/bugzilla/show_bug.cgi?id=21032
     // https://sourceware.org/bugzilla/show_bug.cgi?id=21031
     // https://github.com/rust-lang/rust/issues/134820

--- a/examples/napi/src/lib.rs
+++ b/examples/napi/src/lib.rs
@@ -27,8 +27,6 @@ static ALLOC: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
 #[cfg(not(target_family = "wasm"))]
 #[napi_derive::module_init]
 fn init() {
-  use std::thread::current;
-
   let rt = tokio::runtime::Builder::new_multi_thread()
     .enable_all()
     .on_thread_start(|| {


### PR DESCRIPTION
Same issue as https://github.com/rust-lang/rust/issues/134820

> Program terminated with signal SIGSEGV, Segmentation fault.
> #0  0x000009270a512f90 in ?? ()
> [Current thread is 1 (process 609183)]
> (gdb) bt
> #0  0x000009270a512f90 in ?? ()
> #1  0x0000092651b9a5a2 in _rthread_tls_destructors (thread=0x9264e09ea40) at /usr/src/lib/libc/thread/rthread_tls.c:179
> #2  0x0000092651beeaf6 in _libc_pthread_exit (retval=<optimized out>) at /usr/src/lib/libc/thread/rthread.c:372
> #3  0x00000926781d159a in _rthread_start (v=<optimized out>) at /usr/src/lib/librthread/rthread.c:100
> #4  0x0000092651bc6c6a in __tfork_thread () at /usr/src/lib/libc/arch/amd64/sys/tfork_thread.S:87

While OpenBSD isn't officially supported, this specific crash isn't obvious at all.
It doesn't blow up on most tests and I already have 8 ports (wip) that need the same patch.

I would be really thankful if this change got accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved linker configuration to add OpenBSD support for better compatibility and stability.
* **Chores**
  * Simplified example runtime logging to clean up startup messages in non-wasm examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/napi-rs/napi-rs/pull/3274)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->