### PR TITLE
Fix experimental node_api_create_object_with_properties

### DIFF
--- a/crates/napi/src/bindgen_runtime/mod.rs
+++ b/crates/napi/src/bindgen_runtime/mod.rs
@@ -117,7 +117,7 @@ pub unsafe extern "C" fn drop_buffer_slice(
 
 /// Create an object with properties
 ///
-/// When the `experimental` feature is enabled, uses `napi_create_object_with_properties`
+/// When the `experimental` feature is enabled, uses `node_api_create_object_with_properties`
 /// which creates the object with all properties in a single optimized call.
 /// Otherwise falls back to `napi_create_object` + `napi_define_properties`.
 #[doc(hidden)]
@@ -158,7 +158,7 @@ pub unsafe fn create_object_with_properties(
 
       let mut result_obj = std::ptr::null_mut();
       check_status!(
-        sys::napi_create_object_with_properties(
+        sys::node_api_create_object_with_properties(
           env,
           std::ptr::null_mut(), // prototype_or_null
           names.as_ptr(),

--- a/crates/sys/src/functions.rs
+++ b/crates/sys/src/functions.rs
@@ -803,7 +803,7 @@ mod experimental {
         finalize_hint: *mut c_void,
       ) -> napi_status;
 
-      fn napi_create_object_with_properties(
+      fn node_api_create_object_with_properties(
         env: napi_env,
         prototype_or_null: napi_value,
         property_names: *const napi_value,


### PR DESCRIPTION
Binding name was incorrect. `napi_create_object_with_properties` vs `node_api_create_object_with_properties`. It seems that for experimental features, the namespace is `node_api` instead of `napi`.

See https://nodejs.org/api/n-api.html#node_api_create_object_with_properties

See https://github.com/napi-rs/napi-rs/issues/2985, https://github.com/napi-rs/napi-rs/pull/2990
