### PR TITLE
fix(napi): zero-copy external strings, fix WASI double-free

### DIFF
--- a/crates/napi/src/js_values/string/latin1.rs
+++ b/crates/napi/src/js_values/string/latin1.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "napi10")]
+#[cfg(all(feature = "napi10", not(target_family = "wasm")))]
 use std::ffi::c_void;
 
 use crate::{bindgen_prelude::ToNapiValue, sys, JsString, Result};
@@ -8,13 +8,26 @@ use crate::Env;
 
 pub struct JsStringLatin1<'env> {
   pub(crate) inner: JsString<'env>,
+  /// Backing bytes view.
+  ///
+  /// For wrappers produced by [`Self::from_data`] / [`Self::from_external`]:
+  /// - On `wasm32-*` (WASI / emnapi) the external-string APIs always copy
+  ///   into the JS heap, so the wrapper retains its own owning copy of the
+  ///   bytes in `_inner_buf` and `buf` slices that copy — always valid.
+  /// - On native, when V8 keeps the external buffer (`copied = false`),
+  ///   `buf` slices the original bytes for free; when V8 chooses to copy
+  ///   (`copied = true` — short strings or sandbox mode), the finalizer
+  ///   already freed the source buffer before this function returned, so
+  ///   `buf` is `&[]`. Recover the bytes via [`JsString::into_latin1`] on
+  ///   [`Self::into_value`] in that rare native case.
   pub(crate) buf: &'env [u8],
   pub(crate) _inner_buf: Vec<u8>,
 }
 
 impl<'env> JsStringLatin1<'env> {
   #[cfg(feature = "napi10")]
-  /// Try to create a new JavaScript latin1 string from a Rust `Vec<u8>` without copying the data
+  /// Try to create a new JavaScript latin1 string from a Rust `Vec<u8>` without copying the data.
+  ///
   /// ## Behavior
   ///
   /// The `copied` parameter in the underlying `node_api_create_external_string_latin1` call
@@ -23,8 +36,7 @@ impl<'env> JsStringLatin1<'env> {
   ///
   /// ### When `copied` is `true`:
   /// - String data is copied to V8's heap
-  /// - Finalizer is called immediately if provided
-  /// - Original buffer can be freed after the call
+  /// - Finalizer is called synchronously to release the source buffer
   /// - Performance benefit of external strings is not achieved
   ///
   /// ### When `copied` is `false`:
@@ -38,13 +50,24 @@ impl<'env> JsStringLatin1<'env> {
   /// - V8 heap is under memory pressure
   /// - V8 is running with pointer compression or sandbox features
   /// - Invalid Latin-1 encoding that requires sanitization
-  /// - Platform doesn't support external strings
+  /// - Platform doesn't support external strings (e.g. `wasm32-*` / emnapi)
   /// - Memory alignment issues with the provided buffer
   ///
-  /// The `copied` parameter serves as feedback to understand whether the external string
-  /// optimization was successful or if V8 fell back to traditional string creation.
+  /// ## Platform notes
+  ///
+  /// On `wasm32-*` (WASI / emnapi) the external-string API always falls back
+  /// to `napi_create_string_latin1`, which copies into the JS heap. To avoid
+  /// the double work and the use-after-free that would otherwise come with
+  /// the synchronous finalizer, this function uses `napi_create_string_latin1`
+  /// directly on WASM and keeps the source `Vec` alive in the wrapper so
+  /// `as_slice()` / `len()` / `is_empty()` keep returning the original bytes.
+  ///
+  /// On native, when V8 chooses to copy (`copied = true`), the source buffer
+  /// has been freed by the finalizer before this returns. `as_slice()` then
+  /// returns `&[]`; recover the bytes via [`JsString::into_latin1`] on
+  /// [`Self::into_value`] if needed.
   pub fn from_data(env: &'env Env, data: Vec<u8>) -> Result<JsStringLatin1<'env>> {
-    use std::{mem, ptr};
+    use std::ptr;
 
     use crate::{check_status, Error, Status, Value, ValueType};
 
@@ -55,15 +78,52 @@ impl<'env> JsStringLatin1<'env> {
       ));
     }
 
-    let mut raw_value = ptr::null_mut();
-    let mut copied = false;
-    let data_ptr = data.as_ptr();
-    let len = data.len();
-    let cap = data.capacity();
-    let finalize_hint = Box::into_raw(Box::new((len, cap)));
+    #[cfg(target_family = "wasm")]
+    {
+      // emnapi always copies into the JS heap, so skip the external-string
+      // API entirely and just call the regular one. Then keep the source Vec
+      // alive in `_inner_buf` so `buf` stays valid for the wrapper's
+      // accessors.
+      let mut raw_value = ptr::null_mut();
+      let data_ptr = data.as_ptr();
+      let len = data.len();
+      check_status!(
+        unsafe {
+          sys::napi_create_string_latin1(env.0, data_ptr.cast(), len as isize, &mut raw_value)
+        },
+        "Failed to create latin1 string"
+      )?;
+      Ok(Self {
+        inner: JsString(
+          Value {
+            env: env.0,
+            value: raw_value,
+            value_type: ValueType::String,
+          },
+          std::marker::PhantomData,
+        ),
+        buf: unsafe { std::slice::from_raw_parts(data_ptr, len) },
+        _inner_buf: data,
+      })
+    }
 
-    check_status!(
-      unsafe {
+    #[cfg(not(target_family = "wasm"))]
+    {
+      use std::mem::ManuallyDrop;
+
+      // Transfer ownership of the Vec to V8 via the finalizer; Rust must not
+      // drop it. The finalizer reconstructs the Vec from (ptr, len, cap) and
+      // drops it — synchronously when V8 copies, or on GC when V8 keeps the
+      // external reference.
+      let mut data = ManuallyDrop::new(data);
+      let data_ptr = data.as_ptr();
+      let len = data.len();
+      let cap = data.capacity();
+      let finalize_hint = Box::into_raw(Box::new((len, cap)));
+      let mut raw_value = ptr::null_mut();
+      let mut copied = false;
+
+      let status = unsafe {
         sys::node_api_create_external_string_latin1(
           env.0,
           data_ptr.cast(),
@@ -73,36 +133,40 @@ impl<'env> JsStringLatin1<'env> {
           &mut raw_value,
           &mut copied,
         )
-      },
-      "Failed to create external string latin1"
-    )?;
-
-    let inner_buf = if copied {
-      // If the data was copied, the finalizer won't be called
-      // We need to clean up the finalize_hint and let the Vec be dropped
-      unsafe {
-        let _ = Box::from_raw(finalize_hint);
       };
-      data
-    } else {
-      // Only forget the data if it wasn't copied
-      // The finalizer will handle cleanup
-      mem::forget(data);
-      vec![]
-    };
 
-    Ok(Self {
-      inner: JsString(
-        Value {
-          env: env.0,
-          value: raw_value,
-          value_type: ValueType::String,
-        },
-        std::marker::PhantomData,
-      ),
-      buf: unsafe { std::slice::from_raw_parts(data_ptr, len) },
-      _inner_buf: inner_buf,
-    })
+      // On error V8 never invokes the finalizer; release both the hint Box
+      // and the Vec ourselves. On success the finalizer owns them.
+      if status != sys::Status::napi_ok {
+        unsafe {
+          drop(Box::from_raw(finalize_hint));
+          ManuallyDrop::drop(&mut data);
+        }
+      }
+      check_status!(status, "Failed to create external string latin1")?;
+
+      // If V8 copied the bytes, the finalizer already freed our buffer
+      // synchronously and exposing a slice into it would be use-after-free.
+      // Report an empty view in that case.
+      let buf: &'env [u8] = if copied {
+        &[]
+      } else {
+        unsafe { std::slice::from_raw_parts(data_ptr, len) }
+      };
+
+      Ok(Self {
+        inner: JsString(
+          Value {
+            env: env.0,
+            value: raw_value,
+            value_type: ValueType::String,
+          },
+          std::marker::PhantomData,
+        ),
+        buf,
+        _inner_buf: vec![],
+      })
+    }
   }
 
   #[cfg(feature = "napi10")]
@@ -114,6 +178,25 @@ impl<'env> JsStringLatin1<'env> {
   /// - The data pointer is valid for the lifetime of the string and points to a memory region of at least `len` bytes
   /// - The finalize callback properly cleans up the data
   ///
+  /// ## `finalize_callback` invocation contract
+  ///
+  /// `finalize_callback` is invoked **exactly once** for any call that
+  /// reaches the N-API layer:
+  /// - On success, V8 invokes it (synchronously when `copied = true`, on GC
+  ///   when `copied = false`) on native; on WASM this function invokes it
+  ///   inline after the N-API call.
+  /// - On N-API failure (e.g. OOM, status != `napi_ok`), this function
+  ///   invokes it inline before returning the error so the caller's buffer
+  ///   is released.
+  ///
+  /// It is **not** invoked when this function returns `InvalidArg` from its
+  /// own pre-validation (null `data` or `len > isize::MAX`). Those are
+  /// caller bugs: we cannot safely reach the buffer at `data + len`, and
+  /// many real callbacks (e.g. `Vec::from_raw_parts(ptr, len, len)`) would
+  /// trigger UB if invoked with the bogus arguments. Validate inputs and
+  /// retain ownership of the source buffer until this returns `Ok` if you
+  /// rely on the callback as your only cleanup path.
+  ///
   /// ## Behavior
   ///
   /// The `copied` parameter in the underlying `node_api_create_external_string_latin1` call
@@ -122,7 +205,7 @@ impl<'env> JsStringLatin1<'env> {
   ///
   /// ### When `copied` is `true`:
   /// - String data is copied to V8's heap
-  /// - Finalizer is called immediately if provided
+  /// - Finalizer is invoked during string creation if provided
   /// - Original buffer can be freed after the call
   /// - Performance benefit of external strings is not achieved
   ///
@@ -132,16 +215,20 @@ impl<'env> JsStringLatin1<'env> {
   /// - Finalizer called when string is garbage collected
   /// - Memory usage and copying overhead is reduced
   ///
-  /// ## Common scenarios where `copied` is `true`:
-  /// - String is too short (typically < 10-15 characters)
-  /// - V8 heap is under memory pressure
-  /// - V8 is running with pointer compression or sandbox features
-  /// - Invalid Latin-1 encoding that requires sanitization
-  /// - Platform doesn't support external strings
-  /// - Memory alignment issues with the provided buffer
+  /// ## Platform notes
   ///
-  /// The `copied` parameter serves as feedback to understand whether the external string
-  /// optimization was successful or if V8 fell back to traditional string creation.
+  /// On `wasm32-*` (WASI / emnapi) the external-string API always copies and
+  /// runs the finalizer synchronously, so this function makes its own copy
+  /// of the bytes into the wrapper before invoking the caller's finalize
+  /// callback. The caller's buffer ownership semantics are unchanged
+  /// (finalize_callback is called exactly once); on WASM, `as_slice()` etc.
+  /// observe the copy stored inside the wrapper.
+  ///
+  /// On native, when V8 chooses to copy (`copied = true`), the caller's
+  /// finalize callback has already run synchronously by the time this
+  /// returns, so the source bytes may be freed; `as_slice()` returns `&[]`
+  /// in that case. When V8 keeps the buffer external (`copied = false`),
+  /// `as_slice()` borrows the caller-provided bytes for free.
   pub unsafe fn from_external<T: 'env, F: FnOnce(Env, T) + 'env>(
     env: &'env Env,
     data: *const u8,
@@ -153,19 +240,68 @@ impl<'env> JsStringLatin1<'env> {
 
     use crate::{check_status, Error, Status, Value, ValueType};
 
+    // Validation failures below are caller bugs: we cannot safely interact
+    // with the buffer at `data + len`, and we have no contractually safe way
+    // to invoke the caller's `finalize_callback`. The callback is dropped
+    // without being invoked in these cases; the caller is responsible for
+    // their own cleanup before passing invalid arguments.
     if data.is_null() {
       return Err(Error::new(
         Status::InvalidArg,
         "Data pointer should not be null".to_owned(),
       ));
     }
+    if len > isize::MAX as usize {
+      return Err(Error::new(
+        Status::InvalidArg,
+        "Data length exceeds isize::MAX".to_owned(),
+      ));
+    }
 
-    let hint_ptr = Box::into_raw(Box::new((finalize_hint, finalize_callback)));
-    let mut raw_value = ptr::null_mut();
-    let mut copied = false;
+    #[cfg(target_family = "wasm")]
+    {
+      // emnapi always copies, so use the plain create_string entry point and
+      // copy the caller's bytes into our own buffer (so `buf` stays valid
+      // after the caller's finalize_callback releases the source). The
+      // caller's callback runs exactly once, here, regardless of whether
+      // create succeeds — on WASM the engine never delegates finalization.
+      let buffer = if len == 0 {
+        Vec::new()
+      } else {
+        unsafe { std::slice::from_raw_parts(data, len) }.to_vec()
+      };
+      let buf_ptr = buffer.as_ptr();
+      let buf_len = buffer.len();
+      let mut raw_value = ptr::null_mut();
+      let status = unsafe {
+        sys::napi_create_string_latin1(env.0, buf_ptr.cast(), buf_len as isize, &mut raw_value)
+      };
 
-    check_status!(
-      unsafe {
+      finalize_callback(*env, finalize_hint);
+
+      check_status!(status, "Failed to create latin1 string")?;
+
+      Ok(Self {
+        inner: JsString(
+          Value {
+            env: env.0,
+            value: raw_value,
+            value_type: ValueType::String,
+          },
+          std::marker::PhantomData,
+        ),
+        buf: unsafe { std::slice::from_raw_parts(buf_ptr, buf_len) },
+        _inner_buf: buffer,
+      })
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    {
+      let hint_ptr = Box::into_raw(Box::new((finalize_hint, finalize_callback)));
+      let mut raw_value = ptr::null_mut();
+      let mut copied = false;
+
+      let status = unsafe {
         sys::node_api_create_external_string_latin1(
           env.0,
           data.cast(),
@@ -175,29 +311,42 @@ impl<'env> JsStringLatin1<'env> {
           &mut raw_value,
           &mut copied,
         )
-      },
-      "Failed to create external string latin1"
-    )?;
+      };
 
-    if copied {
-      unsafe {
-        let (hint, finalize) = *Box::from_raw(hint_ptr);
-        finalize(*env, hint);
+      // V8 only invokes `finalize_with_custom_callback` on success. On
+      // failure we still own the hint Box; reconstruct and invoke the
+      // caller's callback to release their buffer, otherwise it leaks.
+      // On success (copied = true or false), V8 owns the hint and will
+      // invoke the callback itself — we must not call it again here.
+      if status != sys::Status::napi_ok {
+        let (hint, callback) = *unsafe { Box::from_raw(hint_ptr) };
+        callback(*env, hint);
       }
-    }
+      check_status!(status, "Failed to create external string latin1")?;
 
-    Ok(Self {
-      inner: JsString(
-        Value {
-          env: env.0,
-          value: raw_value,
-          value_type: ValueType::String,
-        },
-        std::marker::PhantomData,
-      ),
-      buf: unsafe { std::slice::from_raw_parts(data, len) },
-      _inner_buf: vec![],
-    })
+      // If V8 copied the bytes, the caller's `finalize_callback` already
+      // ran synchronously and the buffer at `data` may be freed. Exposing
+      // a slice into it would be use-after-free, so report an empty view
+      // in that case.
+      let buf: &'env [u8] = if copied {
+        &[]
+      } else {
+        unsafe { std::slice::from_raw_parts(data, len) }
+      };
+
+      Ok(Self {
+        inner: JsString(
+          Value {
+            env: env.0,
+            value: raw_value,
+            value_type: ValueType::String,
+          },
+          std::marker::PhantomData,
+        ),
+        buf,
+        _inner_buf: vec![],
+      })
+    }
   }
 
   #[cfg(feature = "napi10")]
@@ -285,21 +434,24 @@ impl ToNapiValue for JsStringLatin1<'_> {
   }
 }
 
-#[cfg(feature = "napi10")]
+#[cfg(all(feature = "napi10", not(target_family = "wasm")))]
 extern "C" fn drop_latin1_string(
   _: sys::node_api_basic_env,
   finalize_data: *mut c_void,
   finalize_hint: *mut c_void,
 ) {
+  // Pair with `Box::into_raw` in `from_data`. Reconstructs both the hint Box
+  // and the original Vec from its (ptr, len, cap) to release them. Called
+  // synchronously by V8 when the string was copied, or on GC when the
+  // string was kept external.
   let (size, capacity): (usize, usize) = unsafe { *Box::from_raw(finalize_hint.cast()) };
   if size == 0 || finalize_data.is_null() {
     return;
   }
-  let data: Vec<u8> = unsafe { Vec::from_raw_parts(finalize_data.cast(), size, capacity) };
-  drop(data);
+  drop(unsafe { Vec::from_raw_parts(finalize_data.cast::<u8>(), size, capacity) });
 }
 
-#[cfg(feature = "napi10")]
+#[cfg(all(feature = "napi10", not(target_family = "wasm")))]
 extern "C" fn finalize_with_custom_callback<T, F: FnOnce(Env, T)>(
   env: sys::node_api_basic_env,
   _finalize_data: *mut c_void,

--- a/crates/napi/src/js_values/string/utf16.rs
+++ b/crates/napi/src/js_values/string/utf16.rs
@@ -1,5 +1,5 @@
 use std::convert::TryFrom;
-#[cfg(feature = "napi10")]
+#[cfg(all(feature = "napi10", not(target_family = "wasm")))]
 use std::ffi::c_void;
 use std::ops::Deref;
 
@@ -10,13 +10,26 @@ use crate::Env;
 
 pub struct JsStringUtf16<'env> {
   pub(crate) inner: JsString<'env>,
+  /// Backing code-unit view.
+  ///
+  /// For wrappers produced by [`Self::from_data`] / [`Self::from_external`]:
+  /// - On `wasm32-*` (WASI / emnapi) the external-string APIs always copy
+  ///   into the JS heap, so the wrapper retains its own owning copy of the
+  ///   units in `_inner_buf` and `buf` slices that copy — always valid.
+  /// - On native, when V8 keeps the external buffer (`copied = false`),
+  ///   `buf` slices the original units for free; when V8 chooses to copy
+  ///   (`copied = true` — short strings or sandbox mode), the finalizer
+  ///   already freed the source buffer before this function returned, so
+  ///   `buf` is `&[]`. Recover the units via [`JsString::into_utf16`] on
+  ///   [`Self::into_value`] in that rare native case.
   pub(crate) buf: &'env [u16],
   pub(crate) _inner_buf: Vec<u16>,
 }
 
 impl<'env> JsStringUtf16<'env> {
   #[cfg(feature = "napi10")]
-  /// Try to create a new JavaScript utf16 string from a Rust `Vec<u16>` without copying the data
+  /// Try to create a new JavaScript utf16 string from a Rust `Vec<u16>` without copying the data.
+  ///
   /// ## Behavior
   ///
   /// The `copied` parameter in the underlying `node_api_create_external_string_utf16` call
@@ -25,8 +38,7 @@ impl<'env> JsStringUtf16<'env> {
   ///
   /// ### When `copied` is `true`:
   /// - String data is copied to V8's heap
-  /// - Finalizer is called immediately if provided
-  /// - Original buffer can be freed after the call
+  /// - Finalizer is called synchronously to release the source buffer
   /// - Performance benefit of external strings is not achieved
   ///
   /// ### When `copied` is `false`:
@@ -40,13 +52,23 @@ impl<'env> JsStringUtf16<'env> {
   /// - V8 heap is under memory pressure
   /// - V8 is running with pointer compression or sandbox features
   /// - Invalid UTF-16 encoding that requires sanitization
-  /// - Platform doesn't support external strings
+  /// - Platform doesn't support external strings (e.g. `wasm32-*` / emnapi)
   /// - Memory alignment issues with the provided buffer
   ///
-  /// The `copied` parameter serves as feedback to understand whether the external string
-  /// optimization was successful or if V8 fell back to traditional string creation.
+  /// ## Platform notes
+  ///
+  /// On `wasm32-*` (WASI / emnapi) the external-string API always falls back
+  /// to `napi_create_string_utf16`, which copies into the JS heap. To avoid
+  /// the double work and the use-after-free that would otherwise come with
+  /// the synchronous finalizer, this function uses `napi_create_string_utf16`
+  /// directly on WASM and keeps the source `Vec` alive in the wrapper so
+  /// `as_slice()` / `len()` / `is_empty()` keep returning the original units.
+  ///
+  /// On native, when V8 chooses to copy (`copied = true`), the source buffer
+  /// has been freed by the finalizer before this returns. `as_slice()` then
+  /// returns `&[]`; recover the units via [`JsString::into_utf16`] on
+  /// [`Self::into_value`] if needed.
   pub fn from_data(env: &'env Env, data: Vec<u16>) -> Result<JsStringUtf16<'env>> {
-    use std::mem;
     use std::ptr;
 
     use crate::{check_status, Value, ValueType};
@@ -58,15 +80,50 @@ impl<'env> JsStringUtf16<'env> {
       ));
     }
 
-    let mut raw_value = ptr::null_mut();
-    let mut copied = false;
-    let data_ptr = data.as_ptr();
-    let len = data.len();
-    let cap = data.capacity();
-    let finalize_hint = Box::into_raw(Box::new((len, cap)));
+    #[cfg(target_family = "wasm")]
+    {
+      // emnapi always copies into the JS heap, so skip the external-string
+      // API entirely and just call the regular one. Then keep the source Vec
+      // alive in `_inner_buf` so `buf` stays valid for the wrapper's
+      // accessors.
+      let mut raw_value = ptr::null_mut();
+      let data_ptr = data.as_ptr();
+      let len = data.len();
+      check_status!(
+        unsafe { sys::napi_create_string_utf16(env.0, data_ptr, len as isize, &mut raw_value) },
+        "Failed to create utf16 string"
+      )?;
+      Ok(Self {
+        inner: JsString(
+          Value {
+            env: env.0,
+            value: raw_value,
+            value_type: ValueType::String,
+          },
+          std::marker::PhantomData,
+        ),
+        buf: unsafe { std::slice::from_raw_parts(data_ptr, len) },
+        _inner_buf: data,
+      })
+    }
 
-    check_status!(
-      unsafe {
+    #[cfg(not(target_family = "wasm"))]
+    {
+      use std::mem::ManuallyDrop;
+
+      // Transfer ownership of the Vec to V8 via the finalizer; Rust must not
+      // drop it. The finalizer reconstructs the Vec from (ptr, len, cap) and
+      // drops it — synchronously when V8 copies, or on GC when V8 keeps the
+      // external reference.
+      let mut data = ManuallyDrop::new(data);
+      let data_ptr = data.as_ptr();
+      let len = data.len();
+      let cap = data.capacity();
+      let finalize_hint = Box::into_raw(Box::new((len, cap)));
+      let mut raw_value = ptr::null_mut();
+      let mut copied = false;
+
+      let status = unsafe {
         sys::node_api_create_external_string_utf16(
           env.0,
           data_ptr,
@@ -76,36 +133,40 @@ impl<'env> JsStringUtf16<'env> {
           &mut raw_value,
           &mut copied,
         )
-      },
-      "Failed to create external string utf16"
-    )?;
-
-    let inner_buf = if copied {
-      // If the data was copied, the finalizer won't be called
-      // We need to clean up the finalize_hint and let the Vec be dropped
-      unsafe {
-        let _ = Box::from_raw(finalize_hint);
       };
-      data
-    } else {
-      // Only forget the data if it wasn't copied
-      // The finalizer will handle cleanup
-      mem::forget(data);
-      vec![]
-    };
 
-    Ok(Self {
-      inner: JsString(
-        Value {
-          env: env.0,
-          value: raw_value,
-          value_type: ValueType::String,
-        },
-        std::marker::PhantomData,
-      ),
-      buf: unsafe { std::slice::from_raw_parts(data_ptr.cast(), len) },
-      _inner_buf: inner_buf,
-    })
+      // On error V8 never invokes the finalizer; release both the hint Box
+      // and the Vec ourselves. On success the finalizer owns them.
+      if status != sys::Status::napi_ok {
+        unsafe {
+          drop(Box::from_raw(finalize_hint));
+          ManuallyDrop::drop(&mut data);
+        }
+      }
+      check_status!(status, "Failed to create external string utf16")?;
+
+      // If V8 copied the units, the finalizer already freed our buffer
+      // synchronously and exposing a slice into it would be use-after-free.
+      // Report an empty view in that case.
+      let buf: &'env [u16] = if copied {
+        &[]
+      } else {
+        unsafe { std::slice::from_raw_parts(data_ptr, len) }
+      };
+
+      Ok(Self {
+        inner: JsString(
+          Value {
+            env: env.0,
+            value: raw_value,
+            value_type: ValueType::String,
+          },
+          std::marker::PhantomData,
+        ),
+        buf,
+        _inner_buf: vec![],
+      })
+    }
   }
 
   #[cfg(feature = "napi10")]
@@ -117,6 +178,25 @@ impl<'env> JsStringUtf16<'env> {
   /// - The data pointer is valid for the lifetime of the string and points to at least `len` UTF-16 code units of storage
   /// - The finalize callback properly cleans up the data
   ///
+  /// ## `finalize_callback` invocation contract
+  ///
+  /// `finalize_callback` is invoked **exactly once** for any call that
+  /// reaches the N-API layer:
+  /// - On success, V8 invokes it (synchronously when `copied = true`, on GC
+  ///   when `copied = false`) on native; on WASM this function invokes it
+  ///   inline after the N-API call.
+  /// - On N-API failure (e.g. OOM, status != `napi_ok`), this function
+  ///   invokes it inline before returning the error so the caller's buffer
+  ///   is released.
+  ///
+  /// It is **not** invoked when this function returns `InvalidArg` from its
+  /// own pre-validation (null `data` or `len > isize::MAX / size_of::<u16>()`).
+  /// Those are caller bugs: we cannot safely reach the buffer at `data + len`,
+  /// and many real callbacks (e.g. `Vec::from_raw_parts(ptr, len, len)`)
+  /// would trigger UB if invoked with the bogus arguments. Validate inputs
+  /// and retain ownership of the source buffer until this returns `Ok` if
+  /// you rely on the callback as your only cleanup path.
+  ///
   /// ## Behavior
   ///
   /// The `copied` parameter in the underlying `node_api_create_external_string_utf16` call
@@ -125,7 +205,7 @@ impl<'env> JsStringUtf16<'env> {
   ///
   /// ### When `copied` is `true`:
   /// - String data is copied to V8's heap
-  /// - Finalizer is called immediately if provided
+  /// - Finalizer is invoked during string creation if provided
   /// - Original buffer can be freed after the call
   /// - Performance benefit of external strings is not achieved
   ///
@@ -135,16 +215,20 @@ impl<'env> JsStringUtf16<'env> {
   /// - Finalizer called when string is garbage collected
   /// - Memory usage and copying overhead is reduced
   ///
-  /// ## Common scenarios where `copied` is `true`:
-  /// - String is too short (typically < 10-15 characters)
-  /// - V8 heap is under memory pressure
-  /// - V8 is running with pointer compression or sandbox features
-  /// - Invalid UTF-16 encoding that requires sanitization
-  /// - Platform doesn't support external strings
-  /// - Memory alignment issues with the provided buffer
+  /// ## Platform notes
   ///
-  /// The `copied` parameter serves as feedback to understand whether the external string
-  /// optimization was successful or if V8 fell back to traditional string creation.
+  /// On `wasm32-*` (WASI / emnapi) the external-string API always copies and
+  /// runs the finalizer synchronously, so this function makes its own copy
+  /// of the units into the wrapper before invoking the caller's finalize
+  /// callback. The caller's buffer ownership semantics are unchanged
+  /// (finalize_callback is called exactly once); on WASM, `as_slice()` etc.
+  /// observe the copy stored inside the wrapper.
+  ///
+  /// On native, when V8 chooses to copy (`copied = true`), the caller's
+  /// finalize callback has already run synchronously by the time this
+  /// returns, so the source units may be freed; `as_slice()` returns `&[]`
+  /// in that case. When V8 keeps the buffer external (`copied = false`),
+  /// `as_slice()` borrows the caller-provided units for free.
   pub unsafe fn from_external<T: 'env, F: FnOnce(Env, T) + 'env>(
     env: &'env Env,
     data: *const u16,
@@ -152,23 +236,72 @@ impl<'env> JsStringUtf16<'env> {
     finalize_hint: T,
     finalize_callback: F,
   ) -> Result<JsStringUtf16<'env>> {
+    use std::mem::size_of;
     use std::ptr;
 
     use crate::{check_status, Value, ValueType};
 
+    // Validation failures below are caller bugs: we cannot safely interact
+    // with the buffer at `data + len`, and we have no contractually safe way
+    // to invoke the caller's `finalize_callback`. The callback is dropped
+    // without being invoked in these cases; the caller is responsible for
+    // their own cleanup before passing invalid arguments.
     if data.is_null() {
       return Err(Error::new(
         Status::InvalidArg,
         "Data pointer should not be null".to_owned(),
       ));
     }
+    if len > isize::MAX as usize / size_of::<u16>() {
+      return Err(Error::new(
+        Status::InvalidArg,
+        "Data length exceeds isize::MAX / sizeof(u16)".to_owned(),
+      ));
+    }
 
-    let hint_ptr = Box::into_raw(Box::new((finalize_hint, finalize_callback)));
-    let mut raw_value = ptr::null_mut();
-    let mut copied = false;
+    #[cfg(target_family = "wasm")]
+    {
+      // emnapi always copies, so use the plain create_string entry point and
+      // copy the caller's units into our own buffer (so `buf` stays valid
+      // after the caller's finalize_callback releases the source). The
+      // caller's callback runs exactly once, here, regardless of whether
+      // create succeeds — on WASM the engine never delegates finalization.
+      let buffer = if len == 0 {
+        Vec::new()
+      } else {
+        unsafe { std::slice::from_raw_parts(data, len) }.to_vec()
+      };
+      let buf_ptr = buffer.as_ptr();
+      let buf_len = buffer.len();
+      let mut raw_value = ptr::null_mut();
+      let status =
+        unsafe { sys::napi_create_string_utf16(env.0, buf_ptr, buf_len as isize, &mut raw_value) };
 
-    check_status!(
-      unsafe {
+      finalize_callback(*env, finalize_hint);
+
+      check_status!(status, "Failed to create utf16 string")?;
+
+      Ok(Self {
+        inner: JsString(
+          Value {
+            env: env.0,
+            value: raw_value,
+            value_type: ValueType::String,
+          },
+          std::marker::PhantomData,
+        ),
+        buf: unsafe { std::slice::from_raw_parts(buf_ptr, buf_len) },
+        _inner_buf: buffer,
+      })
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    {
+      let hint_ptr = Box::into_raw(Box::new((finalize_hint, finalize_callback)));
+      let mut raw_value = ptr::null_mut();
+      let mut copied = false;
+
+      let status = unsafe {
         sys::node_api_create_external_string_utf16(
           env.0,
           data,
@@ -178,29 +311,42 @@ impl<'env> JsStringUtf16<'env> {
           &mut raw_value,
           &mut copied,
         )
-      },
-      "Failed to create external string utf16"
-    )?;
+      };
 
-    if copied {
-      unsafe {
-        let (hint, finalize) = *Box::from_raw(hint_ptr);
-        finalize(*env, hint);
+      // V8 only invokes `finalize_with_custom_callback` on success. On
+      // failure we still own the hint Box; reconstruct and invoke the
+      // caller's callback to release their buffer, otherwise it leaks.
+      // On success (copied = true or false), V8 owns the hint and will
+      // invoke the callback itself — we must not call it again here.
+      if status != sys::Status::napi_ok {
+        let (hint, callback) = *unsafe { Box::from_raw(hint_ptr) };
+        callback(*env, hint);
       }
-    }
+      check_status!(status, "Failed to create external string utf16")?;
 
-    Ok(Self {
-      inner: JsString(
-        Value {
-          env: env.0,
-          value: raw_value,
-          value_type: ValueType::String,
-        },
-        std::marker::PhantomData,
-      ),
-      buf: unsafe { std::slice::from_raw_parts(data, len) },
-      _inner_buf: vec![],
-    })
+      // If V8 copied the units, the caller's `finalize_callback` already
+      // ran synchronously and the buffer at `data` may be freed. Exposing
+      // a slice into it would be use-after-free, so report an empty view
+      // in that case.
+      let buf: &'env [u16] = if copied {
+        &[]
+      } else {
+        unsafe { std::slice::from_raw_parts(data, len) }
+      };
+
+      Ok(Self {
+        inner: JsString(
+          Value {
+            env: env.0,
+            value: raw_value,
+            value_type: ValueType::String,
+          },
+          std::marker::PhantomData,
+        ),
+        buf,
+        _inner_buf: vec![],
+      })
+    }
   }
 
   #[cfg(feature = "napi10")]
@@ -307,7 +453,7 @@ impl ToNapiValue for JsStringUtf16<'_> {
   }
 }
 
-#[cfg(feature = "napi10")]
+#[cfg(all(feature = "napi10", not(target_family = "wasm")))]
 extern "C" fn drop_utf16_string(
   _: sys::node_api_basic_env,
   finalize_data: *mut c_void,
@@ -321,7 +467,7 @@ extern "C" fn drop_utf16_string(
   drop(data);
 }
 
-#[cfg(feature = "napi10")]
+#[cfg(all(feature = "napi10", not(target_family = "wasm")))]
 extern "C" fn finalize_with_custom_callback<T, F: FnOnce(Env, T)>(
   env: sys::node_api_basic_env,
   _finalize_data: *mut c_void,

--- a/examples/napi/__tests__/values.spec.ts
+++ b/examples/napi/__tests__/values.spec.ts
@@ -376,12 +376,21 @@ test('JsStringLatin1::from_external tests', (t) => {
   // Test with custom finalize hint
   t.is(createExternalLatin1CustomFinalize(), 'Custom finalize test')
 
-  // Test Latin1 methods
+  // Test Latin1 methods. The wrapper's Rust-side accessors mirror `buf`:
+  // - On WASM (WASI/emnapi) and on native when V8 keeps the string external,
+  //   `buf` slices the real bytes and the wrapper reports the full length.
+  // - On native when V8 chooses to copy (sandbox mode and/or some short
+  //   strings), the finalizer ran synchronously and `buf` is `&[]`; the
+  //   wrapper then reports length 0 / isEmpty true / asSlice []. Recover
+  //   the bytes via `JsString::into_latin1` on `.into_value()` if needed.
   const methodsTest = testLatin1Methods('Test string')
-  t.is(methodsTest.length, 11)
-  t.is(methodsTest.isEmpty, false)
-  if (!process.env.WASI_TEST) {
+  if (methodsTest.length === 11) {
+    t.is(methodsTest.isEmpty, false)
     t.deepEqual(methodsTest.asSlice, Array.from(Buffer.from('Test string')))
+  } else {
+    t.is(methodsTest.length, 0)
+    t.is(methodsTest.isEmpty, true)
+    t.deepEqual(methodsTest.asSlice, [])
   }
 
   // Test with empty input


### PR DESCRIPTION
## Summary
- Fix double-free / UAF in `JsStringLatin1::from_external` and `JsStringUtf16::from_external` on WASI / V8-sandbox where emnapi/V8 returns `copied=true` and invokes the finalizer synchronously (PR #2898 regression).
- Preserve zero-copy by default on native: `from_external` keeps using `node_api_create_external_string_*` and the buffer is borrowed from V8's external pointer when `copied=false`.
- WASM path uses a self-referential struct that keeps the source `Vec` alive in `_inner_buf` and slices from it, so accessors always observe the original bytes.
- `from_external` now invokes the user's `finalize_callback` exactly once on the success path (V8 on native, inline on WASM) and on N-API failure (`status != napi_ok`). Validation-failure paths (null `data`, `len > isize::MAX`) deliberately drop the callback without invoking it — they indicate caller bugs.
- Same fix applied symmetrically to latin1 and utf16.

## Test plan
- [x] `cargo check` (native + wasm32-wasip1)
- [x] All native tests pass (217/217 in `@examples/napi`)
- [x] WASI string tests pass 5x stress
- [x] `testLatin1Methods` accepts both native (length=11) and WASM/sandbox (length=0, empty) accessor results

Fixes flaky WASI CI introduced by #2898.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes N-API string ownership, finalizer timing, and slice lifetime across native and WASI; incorrect behavior would cause UAF, double-free, or buffer leaks.
> 
> **Overview**
> Fixes **memory-safety bugs** in N-API 10 external Latin-1 and UTF-16 string wrappers (`JsStringLatin1` / `JsStringUtf16`) introduced when V8/emnapi reports `copied=true` and runs finalizers synchronously (WASI, sandbox, some short strings).
> 
> **WASM (`wasm32-*`):** `from_data` and `from_external` no longer use `node_api_create_external_string_*`. They create strings with `napi_create_string_*`, keep an owning copy in `_inner_buf`, and run custom finalization inline so accessors stay valid without double-free or use-after-free.
> 
> **Native:** `from_data` transfers the `Vec` via `ManuallyDrop` and the V8 finalizer; on N-API error it drops the hint and `Vec` itself. When `copied=true`, `as_slice()` / `len()` return empty views instead of slicing freed memory (bytes recoverable via `into_latin1` / `into_utf16` on the inner `JsString`). `from_external` documents when `finalize_callback` runs (once on success/failure paths that reach N-API; not on null/oversized `len`), invokes the callback on N-API failure, and avoids double-invoking when V8 already finalized on the copy path.
> 
> Drop/finalize C callbacks are compiled only on non-WASM. Example tests accept either full wrapper length (zero-copy path) or empty accessor results when V8 copied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba9f2e0e3f3d1bbd7a464a7fb779faba7c7e39f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved string memory management and finalization to ensure correct behavior across WebAssembly and native platforms.
  * Fixed potential memory leaks and use-after-free issues in string lifecycle handling.
  * Enhanced platform-specific string resource cleanup and buffer management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/napi-rs/napi-rs/pull/3308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->