### PR TITLE
fix(napi): unify Reference finalize callbacks on Arc (Rc/Arc type confusion)

### DIFF
--- a/crates/napi/src/bindgen_runtime/callback_info.rs
+++ b/crates/napi/src/bindgen_runtime/callback_info.rs
@@ -1,7 +1,7 @@
 use std::cell::Cell;
 use std::ffi::c_void;
 use std::ptr;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::{bindgen_prelude::*, check_status, iterator::ScopedGenerator};
 
@@ -102,7 +102,12 @@ impl<const N: usize> CallbackInfo<N> {
     }
     let mut object_ref = ptr::null_mut();
     let initial_finalize: Box<dyn FnOnce()> = Box::new(|| {});
-    let finalize_callbacks_ptr = Rc::into_raw(Rc::new(Cell::new(Box::into_raw(initial_finalize))));
+    // `Reference` needs atomic ref-counting for its `unsafe impl Sync`, so the finalize
+    // callbacks slot is an `Arc`. The inner `Cell` is only ever accessed on the JS thread
+    // (see `Reference`), so the non-`Send`/`Sync` interior is sound here.
+    #[allow(clippy::arc_with_non_send_sync)]
+    let finalize_callbacks_ptr =
+      Arc::into_raw(Arc::new(Cell::new(Box::into_raw(initial_finalize))));
     unsafe {
       check_status!(
         sys::napi_wrap(
@@ -225,7 +230,11 @@ impl<const N: usize> CallbackInfo<N> {
     check_status!(status, "Failed to create instance of class `{}`", js_name)?;
     let obj = Box::new(obj);
     let initial_finalize: Box<dyn FnOnce()> = Box::new(|| {});
-    let finalize_callbacks_ptr = Rc::into_raw(Rc::new(Cell::new(Box::into_raw(initial_finalize))));
+    // See `_construct`: `Arc` is required for `Reference`'s `Sync` impl; the `Cell` is
+    // only touched on the JS thread.
+    #[allow(clippy::arc_with_non_send_sync)]
+    let finalize_callbacks_ptr =
+      Arc::into_raw(Arc::new(Cell::new(Box::into_raw(initial_finalize))));
     let mut object_ref = ptr::null_mut();
     let mut value_ref = Box::into_raw(obj);
 

--- a/crates/napi/src/bindgen_runtime/js_values/class.rs
+++ b/crates/napi/src/bindgen_runtime/js_values/class.rs
@@ -262,7 +262,10 @@ pub unsafe fn new_instance<T: 'static + ObjectFinalize>(
   crate::__private::___CALL_FROM_FACTORY.with(|inner| inner.set(false));
   let mut object_ref = std::ptr::null_mut();
   let initial_finalize: Box<dyn FnOnce()> = Box::new(|| {});
-  let finalize_callbacks_ptr = std::rc::Rc::into_raw(std::rc::Rc::new(std::cell::Cell::new(
+  // `Arc` (not `Rc`) is required so it matches `Reference`'s `Arc<Cell<..>>` field and its
+  // `Sync` impl; the `Cell` is only accessed on the JS thread.
+  #[allow(clippy::arc_with_non_send_sync)]
+  let finalize_callbacks_ptr = std::sync::Arc::into_raw(std::sync::Arc::new(std::cell::Cell::new(
     Box::into_raw(initial_finalize),
   )));
   check_status!(

--- a/crates/napi/src/bindgen_runtime/mod.rs
+++ b/crates/napi/src/bindgen_runtime/mod.rs
@@ -1,5 +1,5 @@
 use std::ffi::c_void;
-use std::rc::Rc;
+use std::sync::Arc;
 
 pub use callback_info::*;
 pub use env::*;
@@ -46,16 +46,16 @@ pub(crate) unsafe extern "C" fn raw_finalize_unchecked<T: ObjectFinalize>(
   if let Some((_, ref_val, finalize_callbacks_ptr)) =
     REFERENCE_MAP.with(|cell| cell.borrow_mut(|reference_map| reference_map.remove(&finalize_data)))
   {
-    let finalize_callbacks_rc = unsafe { Rc::from_raw(finalize_callbacks_ptr) };
+    let finalize_callbacks_rc = unsafe { Arc::from_raw(finalize_callbacks_ptr) };
 
     #[cfg(all(debug_assertions, not(target_family = "wasm")))]
     {
-      let rc_strong_count = Rc::strong_count(&finalize_callbacks_rc);
-      // If `Rc` strong count is 2, it means the finalize of referenced `Object` is called before the `fn drop` of the `Reference`
+      let rc_strong_count = Arc::strong_count(&finalize_callbacks_rc);
+      // If `Arc` strong count is 2, it means the finalize of referenced `Object` is called before the `fn drop` of the `Reference`
       // It always happened on exiting process
       // In general, the `fn drop` would happen first
       if rc_strong_count != 1 && rc_strong_count != 2 {
-        eprintln!("Rc strong count is: {rc_strong_count}, it should be 1 or 2");
+        eprintln!("Arc strong count is: {rc_strong_count}, it should be 1 or 2");
       }
     }
     let finalize = unsafe { Box::from_raw(finalize_callbacks_rc.get()) };


### PR DESCRIPTION
## Summary

`Reference<T>`'s `finalize_callbacks` slot was created as `Rc` but consumed as both `Rc` and `Arc`, which is undefined behavior. This PR completes the `Rc → Arc` migration started in #2668 so the same heap allocation is created, reconstructed, and dropped as a single type.

## Root cause

#2668 ("use Arc in Reference because it is Send") changed the struct field to `Arc<Cell<..>>` and added `unsafe impl<T: Sync> Sync for Reference<T>`, but left the **allocation sites and the GC finalizer on `Rc`**. The same `*const Cell<*mut dyn FnOnce()>` allocation was therefore used as two different smart-pointer types:

| Site | Before | After |
| --- | --- | --- |
| `callback_info.rs::_construct` | `Rc::into_raw` | `Arc::into_raw` |
| `callback_info.rs::_factory` | `Rc::into_raw` | `Arc::into_raw` |
| `class.rs` (`into_reference`) | `Rc::into_raw` | `Arc::into_raw` |
| `mod.rs::raw_finalize_unchecked` | `Rc::from_raw` / `Rc::strong_count` | `Arc::from_raw` / `Arc::strong_count` |
| `value_ref.rs` (`add_ref`, `from_value_ptr`, field) | `Arc` (since #2668) | `Arc` |

Consequences of the mismatch:
- `RcBox<T>` vs `ArcInner<T>` layout is an unstable std implementation detail — relying on them coinciding is unsound.
- Mixed atomic (`Arc`) / non-atomic (`Rc`) access to the same refcount.
- The `Arc` drop path deallocates assuming `ArcInner` for memory allocated as `RcBox`.

Reported impact: process abort (DoS) under repeated `Reference<T>` conversions + GC, with potential native memory corruption.

## Why `Arc` (not revert to `Rc`)

`Reference`'s `unsafe impl Sync` is only sound with atomic refcounting, so `Rc` is not an option. `Arc` is the type the rest of `Reference`/`WeakReference` already uses; this PR just makes creation and finalization consistent with it. The `#[allow(clippy::arc_with_non_send_sync)]` on the three `Arc::new` sites mirrors the existing precedent in `threadsafe_function.rs` — the inner `Cell` is only ever mutated on the JS thread via `Env`, as documented on `Reference`.

## Verification

- `cargo clippy -p napi` — clean
- Full `@examples/napi` suite — **217 passed, 1 skipped** (incl. `async-generator-gc`, `issue-3119-repro`)
- `cargo test -p napi --lib` — passed
- 500k-iteration GC stress repro (`--expose-gc`) — passed

## Credit

Reported by **Thanasis Trispiotis**, who identified the `Rc::into_raw` → `Arc::from_raw` mismatch and reproduced the abort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Fixes memory-unsafe refcount/type confusion in native addon GC/finalization paths; incorrect handling could abort processes or corrupt memory, though the change aligns creation and teardown to a single type.
> 
> **Overview**
> Fixes **undefined behavior** in N-API class/`Reference` teardown by using **`Arc` consistently** for the shared finalize-callbacks slot instead of allocating with **`Rc`** and later reinterpreting the pointer as **`Arc`**.
> 
> **`callback_info.rs`** (`_construct`, `_factory`) and **`class.rs`** (`into_reference` / `new_instance`) now create the slot with `Arc::into_raw(Arc::new(Cell::new(...)))`, with comments and `clippy::arc_with_non_send_sync` allowances documenting that the inner `Cell` is only used on the JS thread. **`mod.rs`** `raw_finalize_unchecked` now recovers it with `Arc::from_raw` and updates debug refcount checks/messages from `Rc` to `Arc`.
> 
> This completes the migration started when `Reference` moved to `Arc` for `Sync`; behavior is unchanged except avoiding mixed refcount layouts and potential abort/memory corruption under GC + `Reference` use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3462f36fb7ca4754f3183ec4f017ae9431ba293. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced thread-safety handling in native callback finalization mechanisms for improved reliability in concurrent operation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->