### PR TITLE
fix(sys): restore napi_create_object_with_properties as compat alias

### DIFF
--- a/crates/sys/src/functions.rs
+++ b/crates/sys/src/functions.rs
@@ -813,6 +813,16 @@ mod experimental {
       ) -> napi_status;
     }
   );
+
+  /// **Deprecated**: use [`node_api_create_object_with_properties`] instead.
+  ///
+  /// Compatibility alias: this binding was originally published under the wrong
+  /// symbol name (`napi_create_object_with_properties` does not exist in Node-API),
+  /// so the old name never resolved at runtime. A `pub use` is used instead of a
+  /// wrapper `fn` to preserve the `extern "C"` item kind under static linking
+  /// (`#[deprecated]` on a re-export is silently ignored by rustc, so the notice
+  /// lives in this doc comment).
+  pub use self::node_api_create_object_with_properties as napi_create_object_with_properties;
 }
 
 #[cfg(feature = "experimental")]


### PR DESCRIPTION
## What

Restores `napi_sys::napi_create_object_with_properties` as a `pub use` re-export of `node_api_create_object_with_properties`, so the rename in #3304 is no longer a breaking change and release-plz (#3306) doesn't need to bump napi-sys to 4.0.0.

## Why a re-export instead of a wrapper fn

Under static linking (`default-features = false`) and wasm, the old item was an `extern "C"` function item that coerces to `unsafe extern "C" fn` pointers. A Rust-ABI wrapper fn would break that coercion (E0308), so it would still be a source break. The `pub use` keeps the exact item kind that 3.2.1 exported under both `generate!` macro modes.

`#[deprecated]` on a `use` declaration is silently ignored by rustc, so the deprecation notice lives in the doc comment instead.

Note: the old name never matched a real Node-API symbol — under `dyn-symbols` it only ever resolved to the panic stub — so the alias also makes any existing callers of the old name work for the first time.

## Verification

- `cargo semver-checks -p napi-sys --baseline-version 3.2.1 --all-features` → 223 checks pass, **no semver update required**
- Consumer crate compiles against the alias in all three modes: `dyn-symbols`, static (`--no-default-features`), and `wasm32-wasip1-threads`, including `unsafe extern "C" fn` pointer coercion in static mode
- `cargo clippy -p napi-sys --all-features` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small public-API compatibility re-export in napi-sys experimental bindings; no runtime logic changes beyond restoring the old symbol name.
> 
> **Overview**
> Restores **`napi_sys::napi_create_object_with_properties`** as a compatibility alias after the binding was renamed to **`node_api_create_object_with_properties`**, so downstream crates keep the old public name without a semver-major bump.
> 
> The alias is a **`pub use` re-export** (not a Rust wrapper function) so static linking and **`unsafe extern "C" fn`** coercion stay the same as in 3.2.1. Deprecation is documented in a comment because **`#[deprecated]` on a `use` is ignored** by the compiler. The old name never matched a real Node-API symbol; with **`dyn-symbols`** it previously only hit a panic stub, so the alias also wires callers to the correct implementation for the first time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d85254d0244dc72c60eec31653f4bf746279d2f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored backward compatibility by adding a deprecated alias for a previously used symbol name, ensuring existing code continues to work while encouraging migration to the corrected naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->