### PR TITLE
chore(deps): group emnapi updates and bump to 1.11.1

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,7 +14,8 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"]
     },
     {
-      "matchPackageNames": ["emnapi", "@emnapi/"],
+      "matchPackageNames": ["emnapi"],
+      "matchPackagePrefixes": ["@emnapi/"],
       "rangeStrategy": "replace",
       "groupName": "emnapi"
     }

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -12,3 +12,5 @@ npmPreapprovedPackages:
   - oxc-parser
   - '@oxc-parser/*'
   - '@oxc-project/*'
+  - emnapi
+  - '@emnapi/*'

--- a/cli/package.json
+++ b/cli/package.json
@@ -66,7 +66,7 @@
     "@octokit/rest": "^22.0.1",
     "clipanion": "^4.0.0-rc.4",
     "colorette": "^2.0.20",
-    "emnapi": "^1.11.0",
+    "emnapi": "^1.11.1",
     "es-toolkit": "^1.47.0",
     "js-yaml": "^4.2.0",
     "obug": "^2.1.2",

--- a/examples/napi/package.json
+++ b/examples/napi/package.json
@@ -69,7 +69,7 @@
     "timeout": "10m"
   },
   "dependencies": {
-    "@emnapi/core": "1.11.0",
-    "@emnapi/runtime": "1.11.0"
+    "@emnapi/core": "1.11.1",
+    "@emnapi/runtime": "1.11.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -135,13 +135,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/core@npm:1.11.0, @emnapi/core@npm:^1.1.0":
-  version: 1.11.0
-  resolution: "@emnapi/core@npm:1.11.0"
+"@emnapi/core@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@emnapi/core@npm:1.11.1"
   dependencies:
     "@emnapi/wasi-threads": "npm:1.2.2"
     tslib: "npm:^2.4.0"
-  checksum: 10c0/268498d6ea42ff1e51d543725c7c9c3ce01d39be19a5790d1587ebe98dcfb9329666f0ce9864bb23e067caa064199a45ec2c63c4050b5e42166c1d7d40750135
+  checksum: 10c0/2c6defdac2d1d26090384655d7d6c9614fa553853b1760597686749e9375dc2aa0dae80a2615b81c254600f5d531d07d8466cde0d331a8caae64b93f3ca5937e
   languageName: node
   linkType: hard
 
@@ -165,6 +165,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:^1.1.0":
+  version: 1.11.0
+  resolution: "@emnapi/core@npm:1.11.0"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.2.2"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/268498d6ea42ff1e51d543725c7c9c3ce01d39be19a5790d1587ebe98dcfb9329666f0ce9864bb23e067caa064199a45ec2c63c4050b5e42166c1d7d40750135
+  languageName: node
+  linkType: hard
+
 "@emnapi/runtime@npm:1.10.0":
   version: 1.10.0
   resolution: "@emnapi/runtime@npm:1.10.0"
@@ -174,12 +184,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/runtime@npm:1.11.0, @emnapi/runtime@npm:^1.1.0, @emnapi/runtime@npm:^1.11.0":
-  version: 1.11.0
-  resolution: "@emnapi/runtime@npm:1.11.0"
+"@emnapi/runtime@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@emnapi/runtime@npm:1.11.1"
   dependencies:
     tslib: "npm:^2.4.0"
-  checksum: 10c0/6c09d93934e4cf036d2a57672c1c932aee7b00063fc5851c0c6d2e65775adb5ec484e1e12b4ed3614d62e785e2472160d3b368fbdb50e49b566e631f7046e7db
+  checksum: 10c0/04332fb62076afc440aa23316c04bec42f584ca8b074e5507d08e2b33a47cbe0493b1aadb8f3c1057b64ae1e17f5bde1a7bc37f7facc9d0bc25c18197cbd366f
   languageName: node
   linkType: hard
 
@@ -198,6 +208,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/750edca117e0363ab2de10622f8ee60e57d8690c2f29c49704813da5cd627c641798d7f3cb0d953c62fdc71688e02e333ddbf2c1204f38b47e3e40657332a6f5
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:^1.1.0, @emnapi/runtime@npm:^1.11.0":
+  version: 1.11.0
+  resolution: "@emnapi/runtime@npm:1.11.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/6c09d93934e4cf036d2a57672c1c932aee7b00063fc5851c0c6d2e65775adb5ec484e1e12b4ed3614d62e785e2472160d3b368fbdb50e49b566e631f7046e7db
   languageName: node
   linkType: hard
 
@@ -440,8 +459,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/napi@workspace:examples/napi"
   dependencies:
-    "@emnapi/core": "npm:1.11.0"
-    "@emnapi/runtime": "npm:1.11.0"
+    "@emnapi/core": "npm:1.11.1"
+    "@emnapi/runtime": "npm:1.11.1"
     "@napi-rs/cli": "workspace:*"
     "@napi-rs/triples": "workspace:*"
     "@napi-rs/wasm-runtime": "workspace:*"
@@ -1406,7 +1425,7 @@ __metadata:
     ava: "npm:^8.0.1"
     clipanion: "npm:^4.0.0-rc.4"
     colorette: "npm:^2.0.20"
-    emnapi: "npm:^1.11.0"
+    emnapi: "npm:^1.11.1"
     empathic: "npm:^2.0.1"
     env-paths: "npm:^4.0.0"
     es-toolkit: "npm:^1.47.0"
@@ -6670,15 +6689,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"emnapi@npm:^1.11.0":
-  version: 1.11.0
-  resolution: "emnapi@npm:1.11.0"
+"emnapi@npm:^1.11.1":
+  version: 1.11.1
+  resolution: "emnapi@npm:1.11.1"
   peerDependencies:
     node-addon-api: ">= 6.1.0"
   peerDependenciesMeta:
     node-addon-api:
       optional: true
-  checksum: 10c0/c979a821279e142a4da366337327391b1e7689badbc54f1f517a7d43c6b058551ff25b6fe85366e0b2f438b440d18b357f42e6ee2d89744966a9b35102f4292e
+  checksum: 10c0/936a7de68b2466c59c5333b65735154ff8db16d45642af12d9fd6ff10d7e3a03c54f1101ddfb960f3f53dc393a5c38a8326beeb32962fc7a92b25c77d7047f39
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Fix the Renovate group rule so `@emnapi/*` scoped packages are actually matched. `matchPackageNames` only does exact-name matching, so the literal `"@emnapi/"` never matched `@emnapi/core` / `@emnapi/runtime` and Renovate opened separate PRs (#3324, #3325). Switched the scope to `matchPackagePrefixes` so all emnapi deps land in one grouped PR going forward.
- Bump `@emnapi/core` and `@emnapi/runtime` to `1.11.1` in `examples/napi`, folding in the two split Renovate PRs above.
- Add `emnapi` / `@emnapi/*` to `npmPreapprovedPackages` so Yarn's npm minimal-age gate (`npmMinimalAgeGate: 1440`) no longer quarantines fresh first-party emnapi releases.

## Notes

- Supersedes #3324 and #3325 — those can be closed once this lands.
- emnapi 1.11.1 ships the stale shared-memory buffer fix (toyobayashi/emnapi#218).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and tooling config only; no runtime application logic changes.
> 
> **Overview**
> Fixes Renovate so **all emnapi packages update in one PR** by using `matchPackagePrefixes` for `@emnapi/` (exact `matchPackageNames` never matched scoped packages).
> 
> Bumps **`emnapi` to ^1.11.1** in the CLI and pins **`@emnapi/core` / `@emnapi/runtime` to 1.11.1** in `examples/napi`, with lockfile updates. Adds **`emnapi` and `@emnapi/*` to `npmPreapprovedPackages`** so Yarn’s minimal-age gate does not block first-party emnapi releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b3d2faccc6b41cf55e9ba3002912d1d92fba617. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped `@emnapi/core` and `@emnapi/runtime` dependencies to v1.11.1.
  * Updated runtime dependency on emnapi to v1.11.1.
  * Adjusted package management config to preapprove emnapi and `@emnapi/`* packages.
  * Refined automated update rules to separately match the unscoped and `@emnapi-scoped` package patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->