### PR TITLE
perf(napi): outline non-generic core of ThreadsafeFunction::create

### DIFF
--- a/crates/napi/src/threadsafe_function.rs
+++ b/crates/napi/src/threadsafe_function.rs
@@ -394,6 +394,10 @@ impl<
     >,
   > {
     let callback_ptr = Box::into_raw(Box::new(callback));
+    // `napi_create_threadsafe_function` only takes ownership of `callback_ptr`
+    // (registering `thread_finalize_cb` to reclaim it) once it succeeds. If
+    // `create_raw` returns early on any FFI error, neither N-API nor Rust owns
+    // the box, so reclaim it here to avoid leaking the callback.
     let handle = create_raw(
       env,
       func,
@@ -402,7 +406,10 @@ impl<
       callback_ptr.cast(),
       Some(thread_finalize_cb::<T, NewArgs, R>),
       Some(call_js_cb::<T, Return, NewArgs, ErrorStatus, R, CalleeHandled>),
-    )?;
+    )
+    .inspect_err(|_| {
+      drop(unsafe { Box::from_raw(callback_ptr) });
+    })?;
 
     Ok(ThreadsafeFunction {
       handle,

--- a/crates/napi/src/threadsafe_function.rs
+++ b/crates/napi/src/threadsafe_function.rs
@@ -266,6 +266,94 @@ impl<
 {
 }
 
+/// Non-generic core of [`ThreadsafeFunction::create`].
+///
+/// All of the heavy FFI setup (async resource name creation, the
+/// `napi_create_threadsafe_function` call, the weak-ref handling) is
+/// type-independent, so it is extracted here to be emitted once instead of
+/// being monomorphized for every `<T, Return, CallJsBackArgs, ...>`
+/// combination. The only per-type parts — the boxed user callback and the two
+/// `extern "C"` trampolines — are passed in as raw pointers / function
+/// pointers by the generic `create` shell.
+fn create_raw(
+  env: sys::napi_env,
+  func: sys::napi_value,
+  max_queue_size: usize,
+  weak: bool,
+  callback_ptr: *mut c_void,
+  thread_finalize_cb: sys::napi_finalize,
+  call_js_cb: sys::napi_threadsafe_function_call_js,
+) -> Result<Arc<ThreadsafeFunctionHandle>> {
+  let mut async_resource_name = ptr::null_mut();
+  static THREAD_SAFE_FUNCTION_ASYNC_RESOURCE_NAME: &str = "napi_rs_threadsafe_function";
+
+  #[cfg(feature = "napi10")]
+  {
+    let mut copied = false;
+    check_status!(
+      unsafe {
+        sys::node_api_create_external_string_latin1(
+          env,
+          THREAD_SAFE_FUNCTION_ASYNC_RESOURCE_NAME.as_ptr().cast(),
+          27,
+          None,
+          ptr::null_mut(),
+          &mut async_resource_name,
+          &mut copied,
+        )
+      },
+      "Create external string latin1 in ThreadsafeFunction::create failed"
+    )?;
+  }
+
+  #[cfg(not(feature = "napi10"))]
+  {
+    check_status!(
+      unsafe {
+        sys::napi_create_string_utf8(
+          env,
+          THREAD_SAFE_FUNCTION_ASYNC_RESOURCE_NAME.as_ptr().cast(),
+          27,
+          &mut async_resource_name,
+        )
+      },
+      "Create string utf8 in ThreadsafeFunction::create failed"
+    )?;
+  }
+
+  let mut raw_tsfn = ptr::null_mut();
+  let handle = ThreadsafeFunctionHandle::null();
+  check_status!(
+    unsafe {
+      sys::napi_create_threadsafe_function(
+        env,
+        func,
+        ptr::null_mut(),
+        async_resource_name,
+        max_queue_size,
+        1,
+        Arc::downgrade(&handle).into_raw().cast_mut().cast(), // pass handler to thread_finalize_cb
+        thread_finalize_cb,
+        callback_ptr,
+        call_js_cb,
+        &mut raw_tsfn,
+      )
+    },
+    "Create threadsafe function in ThreadsafeFunction::create failed"
+  )?;
+  handle.set_raw(raw_tsfn);
+
+  // Weak ThreadsafeFunction will not prevent the event loop from exiting
+  if weak {
+    check_status!(
+      unsafe { sys::napi_unref_threadsafe_function(env, raw_tsfn) },
+      "Unref threadsafe function failed in Weak mode"
+    )?;
+  }
+
+  Ok(handle)
+}
+
 impl<
     T: 'static,
     Return: FromNapiValue,
@@ -305,73 +393,16 @@ impl<
       { MaxQueueSize },
     >,
   > {
-    let mut async_resource_name = ptr::null_mut();
-    static THREAD_SAFE_FUNCTION_ASYNC_RESOURCE_NAME: &str = "napi_rs_threadsafe_function";
-
-    #[cfg(feature = "napi10")]
-    {
-      let mut copied = false;
-      check_status!(
-        unsafe {
-          sys::node_api_create_external_string_latin1(
-            env,
-            THREAD_SAFE_FUNCTION_ASYNC_RESOURCE_NAME.as_ptr().cast(),
-            27,
-            None,
-            ptr::null_mut(),
-            &mut async_resource_name,
-            &mut copied,
-          )
-        },
-        "Create external string latin1 in ThreadsafeFunction::create failed"
-      )?;
-    }
-
-    #[cfg(not(feature = "napi10"))]
-    {
-      check_status!(
-        unsafe {
-          sys::napi_create_string_utf8(
-            env,
-            THREAD_SAFE_FUNCTION_ASYNC_RESOURCE_NAME.as_ptr().cast(),
-            27,
-            &mut async_resource_name,
-          )
-        },
-        "Create string utf8 in ThreadsafeFunction::create failed"
-      )?;
-    }
-
-    let mut raw_tsfn = ptr::null_mut();
     let callback_ptr = Box::into_raw(Box::new(callback));
-    let handle = ThreadsafeFunctionHandle::null();
-    check_status!(
-      unsafe {
-        sys::napi_create_threadsafe_function(
-          env,
-          func,
-          ptr::null_mut(),
-          async_resource_name,
-          MaxQueueSize,
-          1,
-          Arc::downgrade(&handle).into_raw().cast_mut().cast(), // pass handler to thread_finalize_cb
-          Some(thread_finalize_cb::<T, NewArgs, R>),
-          callback_ptr.cast(),
-          Some(call_js_cb::<T, Return, NewArgs, ErrorStatus, R, CalleeHandled>),
-          &mut raw_tsfn,
-        )
-      },
-      "Create threadsafe function in ThreadsafeFunction::create failed"
+    let handle = create_raw(
+      env,
+      func,
+      MaxQueueSize,
+      Weak,
+      callback_ptr.cast(),
+      Some(thread_finalize_cb::<T, NewArgs, R>),
+      Some(call_js_cb::<T, Return, NewArgs, ErrorStatus, R, CalleeHandled>),
     )?;
-    handle.set_raw(raw_tsfn);
-
-    // Weak ThreadsafeFunction will not prevent the event loop from exiting
-    if Weak {
-      check_status!(
-        unsafe { sys::napi_unref_threadsafe_function(env, raw_tsfn) },
-        "Unref threadsafe function failed in Weak mode"
-      )?;
-    }
 
     Ok(ThreadsafeFunction {
       handle,


### PR DESCRIPTION
## What

`ThreadsafeFunction::create` is generic over `<T, Return, CallJsBackArgs, ErrorStatus, const CalleeHandled, const Weak, const MaxQueueSize>`, but almost its entire body is type-independent: creating the async resource name string, calling `napi_create_threadsafe_function`, and the `Weak` unref. Only two things actually depend on the type parameters — the boxed user callback and the two `extern "C"` trampolines (`thread_finalize_cb`, `call_js_cb`).

Because the whole body is monomorphized, every distinct callback signature emits its own full copy of that FFI setup. For addons that register many threadsafe functions this is pure duplication.

This PR extracts the type-independent work into a non-generic `create_raw(env, func, max_queue_size, weak, callback_ptr, thread_finalize_cb, call_js_cb)`. The generic `create` shrinks to a thin shell that boxes the callback and forwards the two trampoline function pointers. The struct's runtime state is already non-generic (`Arc<ThreadsafeFunctionHandle>`), so nothing about the public API, the runtime behavior, or the emitted FFI calls changes.

## Why

Less monomorphized code → smaller addons and less LLVM work, for every napi-rs consumer. Measured on rolldown (~42 distinct threadsafe-function instantiations) via a local `[patch.crates-io]` pointing at this branch:

| metric | before | after |
| --- | --- | --- |
| `ThreadsafeFunction::create` LLVM IR | 12,768 lines / 42 copies | 2,058 / 42 (−84%) |
| `napi` crate `.text` in the built addon | 492.1 KiB | 468.0 KiB (−24 KiB) |

The 42 instantiations remain, but each is now a small shell delegating to the single shared `create_raw`.

## Notes

- Pure internal refactor; the public API is untouched. Verified that the `napi` crate compiles and that a downstream consumer (rolldown's native addon) builds and links against it.
- The same outlining applies to the `call_async` / `call` family and the `Either`/`Vec`/`Option` `from_napi_value` impls, which are larger still. Happy to follow up with those in separate PRs if this direction looks good.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal initialization for thread-safe function handling by centralizing native resource setup and reducing duplicated logic.
* **Bug Fixes**
  * Improved cleanup when thread-safe function creation fails, preventing potential callback memory leaks and improving overall reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->