### PR TITLE
fix(napi): sync referred flag when creating a weak ThreadsafeFunction

### DIFF
--- a/crates/napi/src/threadsafe_function.rs
+++ b/crates/napi/src/threadsafe_function.rs
@@ -349,6 +349,10 @@ fn create_raw(
       unsafe { sys::napi_unref_threadsafe_function(env, raw_tsfn) },
       "Unref threadsafe function failed in Weak mode"
     )?;
+    // The tsfn is now unreferenced at the N-API level, so keep `referred` in
+    // sync. Otherwise the deprecated `refer`/`unref` would read a stale `true`
+    // and `refer` would skip its `napi_ref_threadsafe_function` call.
+    handle.referred.store(false, Ordering::Relaxed);
   }
 
   Ok(handle)


### PR DESCRIPTION
## What

`ThreadsafeFunctionHandle::referred` is initialized to `true`, but a **weak** `ThreadsafeFunction` is immediately unreferenced at the N-API level via `napi_unref_threadsafe_function` inside `create_raw`. The flag was never updated, so it disagreed with the real N-API ref state from the moment the tsfn was created.

```
new() → referred = true
create_raw(weak=true):
    napi_unref_threadsafe_function(...)   // real state: UNREF'd
    // referred stays true  ✗  (flag says "referred")
```

`referred` is read **only** by the deprecated `refer`/`unref` methods, so the stale `true` meant:

- **`refer()` → silent no-op** on a weak tsfn. Its guard is `if !referred`, so it skipped the real `napi_ref_threadsafe_function` call — a user asking to ref got nothing, no error.
- **`unref()` → redundant second unref** (guard `if referred` passed; N-API unref is idempotent, so harmless but wasteful).

## Fix

Store `false` right after the weak unref succeeds, so the cached flag matches reality:

```rust
if weak {
  check_status!(unsafe { sys::napi_unref_threadsafe_function(env, raw_tsfn) }, "...")?;
  handle.referred.store(false, Ordering::Relaxed);
}
```

After this, `refer()` on a weak tsfn actually refs, and `unref()` correctly skips.

## Notes

- Pre-existing bug, **not** introduced by the recent `create_raw` outlining (#3334) — that PR only moved this block. Surfaced while reviewing #3334.
- Scope is tiny: only the two deprecated methods read this flag, and only weak mode + manual `refer`/`unref` is affected. The recommended `clone()`-based lifetime management never touches it.
- `Ordering::Relaxed` matches every other `referred` access, and the store happens at construction before the handle is shared across threads.
- No new test: the only observable effect is event-loop liveness through deprecated APIs, which is inherently timing/process-exit based and flaky. Verified no regression — full `@examples/napi` suite (160 tests) passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single atomic store at construction in deprecated ref/unref path; no change to recommended clone-based API or main call paths.
> 
> **Overview**
> Weak **ThreadsafeFunction** handles are unreferenced in N-API inside `create_raw`, but the handle’s **`referred`** cache stayed **`true`** (default from `ThreadsafeFunctionHandle::new`). That mismatch only affected the deprecated **`refer`** / **`unref`** helpers: **`refer()`** could no-op instead of calling **`napi_ref_threadsafe_function`**, and **`unref()`** could issue a redundant unref.
> 
> After a successful weak-mode **`napi_unref_threadsafe_function`**, the change sets **`handle.referred`** to **`false`** with **`Ordering::Relaxed`**, matching how the flag is updated elsewhere. Recommended **`clone()`**-based lifetime management is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad4e41625f9f3b4e06d0e044fd7e09bb8106ee32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent reference state tracking in threadsafe function operations to prevent stale state from affecting subsequent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->