### PR TITLE
perf(napi-derive): outline #[napi(object)] field-error decoration

### DIFF
--- a/crates/backend/src/codegen/struct.rs
+++ b/crates/backend/src/codegen/struct.rs
@@ -598,20 +598,14 @@ impl NapiStruct {
           // Getters remain the same
           if is_optional_field && !self.use_nullable {
             obj_field_getters.push(quote! {
-              let #alias_ident: #ty = obj.get(#field_js_name).map_err(|mut err| {
-                err.reason = format!("{} on {}.{}", err.reason, #name_str, #field_js_name);
-                err
-              })?;
+              let #alias_ident: #ty = obj.get(#field_js_name)
+                .map_err(|err| napi::bindgen_prelude::decorate_field_error(err, #name_str, #field_js_name))?;
             });
           } else {
             obj_field_getters.push(quote! {
-              let #alias_ident: #ty = obj.get(#field_js_name).map_err(|mut err| {
-                err.reason = format!("{} on {}.{}", err.reason, #name_str, #field_js_name);
-                err
-              })?.ok_or_else(|| napi::bindgen_prelude::Error::new(
-                napi::bindgen_prelude::Status::InvalidArg,
-                format!("Missing field `{}`", #field_js_name),
-              ))?;
+              let #alias_ident: #ty = obj.get(#field_js_name)
+                .map_err(|err| napi::bindgen_prelude::decorate_field_error(err, #name_str, #field_js_name))?
+                .ok_or_else(|| napi::bindgen_prelude::missing_field_error(#field_js_name))?;
             });
           }
         }
@@ -668,10 +662,8 @@ impl NapiStruct {
             obj_field_getters.push(quote! { let #arg_name: #ty = obj.get(#field_js_name)?; });
           } else {
             obj_field_getters.push(quote! {
-              let #arg_name: #ty = obj.get(#field_js_name)?.ok_or_else(|| napi::bindgen_prelude::Error::new(
-                napi::bindgen_prelude::Status::InvalidArg,
-                format!("Missing field `{}`", #field_js_name),
-              ))?;
+              let #arg_name: #ty = obj.get(#field_js_name)?
+                .ok_or_else(|| napi::bindgen_prelude::missing_field_error(#field_js_name))?;
             });
           }
         }
@@ -1114,20 +1106,14 @@ impl NapiStruct {
             // Getters remain the same
             if is_optional_field && !self.use_nullable {
               obj_field_getters.push(quote! {
-                let #alias_ident: #ty = obj.get(#field_js_name).map_err(|mut err| {
-                  err.reason = format!("{} on {}.{}", err.reason, #name_str, #field_js_name);
-                  err
-                })?;
+                let #alias_ident: #ty = obj.get(#field_js_name)
+                  .map_err(|err| napi::bindgen_prelude::decorate_field_error(err, #name_str, #field_js_name))?;
               });
             } else {
               obj_field_getters.push(quote! {
-                let #alias_ident: #ty = obj.get(#field_js_name).map_err(|mut err| {
-                  err.reason = format!("{} on {}.{}", err.reason, #name_str, #field_js_name);
-                  err
-                })?.ok_or_else(|| napi::bindgen_prelude::Error::new(
-                  napi::bindgen_prelude::Status::InvalidArg,
-                  format!("Missing field `{}`", #field_js_name),
-                ))?;
+                let #alias_ident: #ty = obj.get(#field_js_name)
+                  .map_err(|err| napi::bindgen_prelude::decorate_field_error(err, #name_str, #field_js_name))?
+                  .ok_or_else(|| napi::bindgen_prelude::missing_field_error(#field_js_name))?;
               });
             }
           }
@@ -1183,10 +1169,8 @@ impl NapiStruct {
               obj_field_getters.push(quote! { let #arg_name: #ty = obj.get(#field_js_name)?; });
             } else {
               obj_field_getters.push(quote! {
-                let #arg_name: #ty = obj.get(#field_js_name)?.ok_or_else(|| napi::bindgen_prelude::Error::new(
-                  napi::bindgen_prelude::Status::InvalidArg,
-                  format!("Missing field `{}`", #field_js_name),
-                ))?;
+                let #arg_name: #ty = obj.get(#field_js_name)?
+                  .ok_or_else(|| napi::bindgen_prelude::missing_field_error(#field_js_name))?;
               });
             }
           }
@@ -1272,13 +1256,9 @@ impl NapiStruct {
             let env_wrapper = napi::bindgen_prelude::Env::from(env);
             #[allow(unused_mut)]
             let mut obj = napi::bindgen_prelude::Object::from_napi_value(env, napi_val)?;
-            let type_: String = obj.get(#discriminant).map_err(|mut err| {
-              err.reason = format!("{} on {}.{}", err.reason, #name_str, #discriminant);
-              err
-            })?.ok_or_else(|| napi::bindgen_prelude::Error::new(
-              napi::bindgen_prelude::Status::InvalidArg,
-              format!("Missing field `{}`", #discriminant),
-            ))?;
+            let type_: String = obj.get(#discriminant)
+              .map_err(|err| napi::bindgen_prelude::decorate_field_error(err, #name_str, #discriminant))?
+              .ok_or_else(|| napi::bindgen_prelude::missing_field_error(#discriminant))?;
             let val = match type_.as_str() {
               #(#variant_arm_getters)*
               _ => return Err(napi::bindgen_prelude::Error::new(

--- a/crates/napi/src/error.rs
+++ b/crates/napi/src/error.rs
@@ -275,6 +275,32 @@ impl<S: AsRef<str> + Clone> Error<S> {
   }
 }
 
+/// Outlined helper for `#[napi(object)]` deserialization: decorate a field-getter
+/// error with its `Struct.field` location.
+///
+/// The `#[napi]` derive used to inline this `format!` into every generated
+/// `FromNapiValue` impl, once per field — hundreds of identical copies in a large
+/// addon. Keeping it non-generic and out-of-line collapses all of them to a single
+/// shared function on the (cold) error path. The produced message is byte-for-byte
+/// identical to the previous inline version.
+#[cold]
+#[inline(never)]
+#[doc(hidden)]
+pub fn decorate_field_error(mut err: Error, struct_name: &str, field: &str) -> Error {
+  err.reason = format!("{} on {}.{}", err.reason, struct_name, field);
+  err
+}
+
+/// Outlined helper for `#[napi(object)]` deserialization: build the error returned
+/// when a required field is missing. Non-generic and out-of-line for the same
+/// code-size reason as [`decorate_field_error`]; the message is unchanged.
+#[cold]
+#[inline(never)]
+#[doc(hidden)]
+pub fn missing_field_error(field: &str) -> Error {
+  Error::new(Status::InvalidArg, format!("Missing field `{}`", field))
+}
+
 impl Error {
   pub fn from_reason<T: Into<String>>(reason: T) -> Self {
     Error {


### PR DESCRIPTION
## What

The struct `FromNapiValue` codegen (`crates/backend/src/codegen/struct.rs`) inlines two `format!` calls at **every field of every `#[napi(object)]` struct / structured enum**:

- the `"{} on {}.{}"` field-location decoration (`map_err`), and
- the `"Missing field \`{}\`"` error for a required field (`ok_or_else`).

In a large addon that's hundreds of identical copies of `alloc::fmt::format` + `Error` construction, plus their drop glue and (panic=unwind) cleanup landing pads — all on the cold deserialization-error path, all duplicated per generated impl.

This moves both into two non-generic, `#[inline(never)]` helpers in the runtime crate:

```rust
pub fn decorate_field_error(err: Error, struct_name: &str, field: &str) -> Error;
pub fn missing_field_error(field: &str) -> Error;
```

and has the derive emit calls to them at all 7 codegen sites (object named/tuple, structured-enum named/tuple, and the discriminant getter). The shareable bulk is type-independent (keys are `&str`, `Error` is concrete), so the per-field copies collapse to one shared function each.

## Behavior / perf

Error messages are **byte-for-byte identical**. The only runtime change is a single non-inlined call on the already-cold error path — no hot-path cost.

This is the same "outline the type-independent core" pattern as the earlier `ThreadsafeFunction::create` → `create_raw` change, applied to the per-field object codegen. Motivated by native-addon binary-size work (the inlined per-field decoration is a measurable chunk of `from_napi_value` text across many `#[napi(object)]` structs).

## Verification

`cargo build` of the runtime crate, `napi-cargo-test`, and `napi-examples` (which exercise objects, structured enums and discriminant enums) all compile against the new codegen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages during JavaScript object parsing, providing clearer context about which specific fields are missing or contain invalid data to better assist with debugging
  * Standardized error handling across all object and structured enum conversion operations, ensuring developers receive consistent and user-friendly error reporting whenever data validation fails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->