### PR TITLE
fix: de-flake Windows CI (ava import-from-project EPERM race + cli e2e timeout)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -111,7 +111,7 @@
     "extensions": [
       "ts"
     ],
-    "timeout": "2m",
+    "timeout": "5m",
     "workerThreads": false,
     "files": [
       "**/__tests__/**/*.spec.ts",

--- a/examples/napi-compat-mode/package.json
+++ b/examples/napi-compat-mode/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "napi-raw build --no-js --features latest",
-    "test": "ava reset-cache && ava"
+    "test": "ava reset-cache && node --import @oxc-node/core/register ../../node_modules/ava/entrypoints/cli.js"
   },
   "devDependencies": {
     "@napi-rs/cli": "workspace:*",
@@ -15,9 +15,6 @@
   "ava": {
     "extensions": [
       "ts"
-    ],
-    "require": [
-      "@oxc-node/core/register"
     ],
     "files": [
       "__tests__/**/*.spec.ts"


### PR DESCRIPTION
Two independent Windows CI flakes, both fixed here.

## 1. `napi-compat-mode` — ava `import-from-project.mjs` EPERM race (aarch64 Windows)

Windows CI flakily failed compat-mode with `1 uncaught exception` **even though every test passed**. The `tsfn-throw.js:5` throw in the log is a red herring — that's a child process crashing by design (its parent asserts `t.throws`), inherited stderr. The real failure:

```
Uncaught exception in __tests__\arraybuffer.spec.ts
Error: EPERM: operation not permitted, rename
  '...\.cache\ava\import-from-project.mjs.1235014559' -> '...\import-from-project.mjs'
```

**Root cause (ava@8.0.1):** the config `require: ["@oxc-node/core/register"]` routes every worker through ava's `importFromProject` (`ava/lib/worker/base.js:197`), which *unconditionally* rewrites the shared `node_modules/.cache/ava/import-from-project.mjs` stub via `write-file-atomic` (write temp → `fs.rename`). On Windows, concurrent workers renaming their temp over the same open target fail with `EPERM`; ava reports it as an uncaught exception and the file exits non-zero. Flaky, Windows-only (POSIX `rename` never `EPERM`s).

`@examples/napi` and `cli` never hit this — they load the hook via `node --import @oxc-node/core/register …/ava/cli.js` (propagates to workers via `fork` execArgv) with no `require` config, so the stub is never written. compat-mode was the only workspace still using `require`.

**Fix:** align compat-mode with the working suites — drop `require`, run the ava CLI under `node --import`. Workers still get `TS_NODE_PROJECT` from ava `environmentVariables`, so no `cross-env` dep is needed. Verified locally: 118 tests pass, stub no longer written.

## 2. `@napi-rs/cli` — e2e inactivity timeout on slow Windows disk (x64 Windows)

`e2e/cli.spec.ts` flakily fails with `Timed out while running tests / 4 tests remained pending`. ava's `timeout` is an *inactivity* timeout. Each e2e test's `beforeEach` runs `npm install` of the packed cli tarball and the build tests run a cold cargo compile; all four run concurrently.

On a **passing** x64 run the first e2e test completed only **~108s** after the `before` hook finished — just ~12s under the 2m timeout. Windows CI disk I/O is very slow, so any extra slowdown pushes the first completion past 2m and ava aborts, even though the work would have finished. It's a too-tight timeout for the environment, not a hang.

**Fix:** raise the cli ava timeout `2m → 5m`, matching the headroom the siblings already use (napi 10m, compat-mode 5m). cli was the outlier despite doing the heaviest per-test disk I/O.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-runner and timeout config only; no runtime, auth, or build logic changes.
> 
> **Overview**
> Addresses two Windows CI flakes by changing how Ava is configured, not application code.
> 
> **`@examples/napi-compat-mode`** stops loading `@oxc-node/core/register` via Ava’s `require` config (which made every worker rewrite a shared `import-from-project.mjs` stub and could hit `EPERM` on concurrent renames). The test script now matches **`@napi-rs/cli`**: run Ava through `node --import @oxc-node/core/register …/ava/entrypoints/cli.js` and drop the `require` block; `TS_NODE_PROJECT` stays on Ava `environmentVariables`.
> 
> **`@napi-rs/cli`** raises the Ava **inactivity** timeout from **2m to 5m** so heavy e2e work (`npm install` of the packed CLI plus cold cargo builds, often running in parallel) is less likely to abort on slow Windows disk I/O when the first test finishes just under the old limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20c6718d4d9e28233eaf013f4aec018a2f1028c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the example’s test command to use the newer AVA CLI startup flow.
  * Simplified the example’s test configuration by removing the older automatic registration setting.
  * Increased the CLI package’s AVA test timeout from 2 minutes to 5 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->