### PR TITLE
docs: point sponsors image at napi.rs/sponsors.svg

### DIFF
--- a/crates/napi/README.md
+++ b/crates/napi/README.md
@@ -16,7 +16,7 @@ A framework for building compiled `Node.js` add-ons in `Rust` via Node-API. Webs
 
 ## Sponsors
 
-![](https://sponsors.napi.rs/sponsors.svg)
+![](https://napi.rs/sponsors.svg)
 
 ## Platform Support
 


### PR DESCRIPTION
The `sponsors.napi.rs` generator is retired. `napi.rs` now serves the sponsor wall image directly at `/sponsors.svg` (KV/R2-cached, refreshed daily by cron + on GitHub Sponsors webhook events, with clickable per-sponsor links when opened directly).

```diff
 ## Sponsors
-![](https://sponsors.napi.rs/sponsors.svg)
+![](https://napi.rs/sponsors.svg)
```

Root `README.md` is a symlink to `crates/napi/README.md`, so this single change updates the **GitHub repo README**, **crates.io/crates/napi**, and the **npm** package page together. New URL verified live (200, `image/svg+xml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL change with no runtime or security impact.
> 
> **Overview**
> Updates the **Sponsors** section in `crates/napi/README.md` so the embedded image loads from **`https://napi.rs/sponsors.svg`** instead of the retired **`sponsors.napi.rs`** host.
> 
> Because the repo root README is a symlink to this file, the same URL change applies wherever that README is shown (e.g. GitHub, crates.io, npm).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21d2f1353df83c0c78f32ba61de44fac46aa2460. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Sponsors badge in the NAPI README to use the current image asset link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->