### PR TITLE
fix(cli): require Android NDK for cross-builds

### DIFF
--- a/cli/src/api/__tests__/android-build.spec.ts
+++ b/cli/src/api/__tests__/android-build.spec.ts
@@ -1,0 +1,78 @@
+import { existsSync } from 'node:fs'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import ava, { type TestFn } from 'ava'
+
+import { buildProject } from '../build.js'
+
+const test = ava as TestFn<{ tmpDir: string; projectDir: string }>
+
+test.beforeEach(async (t) => {
+  const tmpDir = join(
+    tmpdir(),
+    'napi-rs-test',
+    `android-build-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  )
+  const projectDir = join(tmpDir, 'project')
+
+  await mkdir(join(projectDir, 'src'), { recursive: true })
+  await writeFile(
+    join(projectDir, 'Cargo.toml'),
+    `[package]
+name = "android_build"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "android-build"
+path = "src/main.rs"
+`,
+  )
+  await writeFile(join(projectDir, 'src', 'main.rs'), 'fn main() {}\n')
+  await writeFile(
+    join(projectDir, 'package.json'),
+    JSON.stringify({ name: 'android-build', version: '0.1.0' }),
+  )
+  t.context = { tmpDir, projectDir }
+})
+
+test.afterEach.always(async (t) => {
+  if (existsSync(t.context.tmpDir)) {
+    await rm(t.context.tmpDir, { recursive: true, force: true })
+  }
+})
+
+test.serial(
+  'requires ANDROID_NDK_LATEST_HOME before spawning an Android cross-build',
+  async (t) => {
+    const { projectDir } = t.context
+    const originalCargo = process.env.CARGO
+    const originalNdkHome = process.env.ANDROID_NDK_LATEST_HOME
+    process.env.CARGO = join(projectDir, 'cargo-must-not-run')
+    delete process.env.ANDROID_NDK_LATEST_HOME
+    try {
+      const error = await t.throwsAsync(() =>
+        buildProject({
+          cwd: projectDir,
+          target: 'aarch64-linux-android',
+          bin: 'android-build',
+        }),
+      )
+
+      t.regex(error!.message, /ANDROID_NDK_LATEST_HOME.+required/)
+    } finally {
+      if (originalCargo === undefined) {
+        delete process.env.CARGO
+      } else {
+        process.env.CARGO = originalCargo
+      }
+      if (originalNdkHome === undefined) {
+        delete process.env.ANDROID_NDK_LATEST_HOME
+      } else {
+        process.env.ANDROID_NDK_LATEST_HOME = originalNdkHome
+      }
+    }
+  },
+)

--- a/cli/src/api/build.ts
+++ b/cli/src/api/build.ts
@@ -740,18 +740,18 @@ class Builder {
   }
 
   private setAndroidEnv() {
-    const { ANDROID_NDK_LATEST_HOME } = process.env
-    if (!ANDROID_NDK_LATEST_HOME) {
-      debug.warn(
-        `${colors.red(
-          'ANDROID_NDK_LATEST_HOME',
-        )} environment variable is missing`,
-      )
-    }
-
     // skip cross compile setup if host is android
     if (process.platform === 'android') {
       return
+    }
+
+    const { ANDROID_NDK_LATEST_HOME } = process.env
+    if (!ANDROID_NDK_LATEST_HOME) {
+      throw new Error(
+        `${colors.red(
+          'ANDROID_NDK_LATEST_HOME',
+        )} environment variable is required when building an Android target from a non-Android host`,
+      )
     }
 
     const targetArch = this.target.arch === 'arm' ? 'armv7a' : 'aarch64'


### PR DESCRIPTION
## Summary

- leave Android-host builds on their native toolchain path
- require `ANDROID_NDK_LATEST_HOME` when targeting Android from another host
- fail before Cargo when the NDK environment is unavailable
- add a focused regression test

## Why

The previous path only warned when `ANDROID_NDK_LATEST_HOME` was missing and then constructed toolchain paths from an undefined value. That deferred the failure and produced a less actionable build error.

This now matches the documented Android flow in https://napi.rs/docs/cross-build#android.

## Validation

- `yarn workspace @napi-rs/cli test src/api/__tests__/android-build.spec.ts` (1 passed)
- full CLI suite on the combined change set (121 passed)
- focused Oxlint and Prettier checks