### PR TITLE
fix(cli): apply selected Node-API version to new projects

### DIFF
--- a/cli/src/api/__tests__/new-node-api-version.spec.ts
+++ b/cli/src/api/__tests__/new-node-api-version.spec.ts
@@ -1,0 +1,81 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { parse as parseToml } from '@std/toml'
+import test, { type ExecutionContext } from 'ava'
+
+import { newProject, updateCargoTomlNodeApiVersion } from '../new.js'
+
+async function rewriteNapiDependency(
+  t: ExecutionContext,
+  dependency: string,
+  minNodeApiVersion: number,
+) {
+  const directory = await mkdtemp(join(tmpdir(), 'napi-rs-new-node-api-'))
+  t.teardown(() => rm(directory, { recursive: true, force: true }))
+
+  const cargoTomlPath = join(directory, 'Cargo.toml')
+  await writeFile(
+    cargoTomlPath,
+    `[package]\nname = "fixture"\nversion = "0.0.0"\n\n[dependencies]\nnapi = ${dependency}\n`,
+  )
+
+  await updateCargoTomlNodeApiVersion(cargoTomlPath, minNodeApiVersion)
+
+  const cargoToml = parseToml(await readFile(cargoTomlPath, 'utf8')) as any
+  return cargoToml.dependencies.napi
+}
+
+test('sets the default Node-API feature to napi4', async (t) => {
+  const napiDependency = await rewriteNapiDependency(t, '"3.0.0"', 4)
+
+  t.is(napiDependency.version, '3.0.0')
+  t.deepEqual(napiDependency.features, ['napi4'])
+  t.false('default-features' in napiDependency)
+})
+
+test('sets a requested Node-API feature and replaces the template default', async (t) => {
+  const napiDependency = await rewriteNapiDependency(
+    t,
+    '{ version = "3.0.0", features = ["napi4", "serde-json"] }',
+    6,
+  )
+
+  t.deepEqual(napiDependency.features, ['napi6', 'serde-json'])
+  t.false('default-features' in napiDependency)
+})
+
+test('disables napi4 defaults for lower Node-API versions while retaining dynamic symbol loading', async (t) => {
+  const napiDependency = await rewriteNapiDependency(t, '"3.0.0"', 3)
+
+  t.is(napiDependency['default-features'], false)
+  t.deepEqual(napiDependency.features, ['napi3', 'dyn-symbols'])
+})
+
+test('preserves an explicitly disabled default feature configuration', async (t) => {
+  const napiDependency = await rewriteNapiDependency(
+    t,
+    '{ version = "3.0.0", default-features = false, features = ["napi8", "serde-json"] }',
+    2,
+  )
+
+  t.is(napiDependency['default-features'], false)
+  t.deepEqual(napiDependency.features, ['napi2', 'serde-json'])
+})
+
+for (const invalidVersion of [0, 10, 1.5]) {
+  test(`rejects invalid Node-API version ${invalidVersion}`, async (t) => {
+    const error = await t.throwsAsync(
+      newProject({
+        path: join(tmpdir(), 'unused-napi-rs-new-project'),
+        enableDefaultTargets: true,
+        minNodeApiVersion: invalidVersion,
+        dryRun: true,
+      }),
+      { instanceOf: RangeError },
+    )
+
+    t.regex(error.message, /Unsupported Node-API version/)
+  })
+}

--- a/cli/src/api/new.ts
+++ b/cli/src/api/new.ts
@@ -21,7 +21,10 @@ import {
   statAsync,
   type SupportedPackageManager,
 } from '../utils/index.js'
-import { napiEngineRequirement } from '../utils/version.js'
+import {
+  napiEngineRequirement,
+  SUPPORTED_NAPI_VERSIONS,
+} from '../utils/version.js'
 import { renameProject } from './rename.js'
 
 // Template imports removed as we're now using external templates
@@ -210,6 +213,52 @@ async function updateCargoTomlTypeDef(
   await fs.writeFile(filePath, stringifyToml(cargoToml))
 }
 
+export async function updateCargoTomlNodeApiVersion(
+  filePath: string,
+  minNodeApiVersion: number,
+): Promise<void> {
+  const content = await fs.readFile(filePath, 'utf-8')
+  const cargoToml = parseToml(content) as Record<string, any>
+  const dependencies = cargoToml.dependencies
+
+  if (!dependencies || !dependencies.napi) {
+    return
+  }
+
+  const napiDependency = dependencies.napi
+  const dependencyConfig =
+    typeof napiDependency === 'string'
+      ? { version: napiDependency }
+      : { ...napiDependency }
+  const usedDefaultFeatures = dependencyConfig['default-features'] !== false
+  const existingFeatures: string[] = Array.isArray(dependencyConfig.features)
+    ? dependencyConfig.features.filter(
+        (feature: unknown): feature is string => typeof feature === 'string',
+      )
+    : []
+
+  dependencyConfig.features = [
+    `napi${minNodeApiVersion}`,
+    ...existingFeatures.filter((feature) => !/^napi\d+$/.test(feature)),
+  ]
+
+  // napi's default features include napi4. Disable them for lower requested
+  // levels, while retaining the default dynamic Node-API symbol loading mode.
+  if (minNodeApiVersion < 4) {
+    dependencyConfig['default-features'] = false
+    if (
+      usedDefaultFeatures &&
+      !dependencyConfig.features.includes('dyn-symbols')
+    ) {
+      dependencyConfig.features.push('dyn-symbols')
+    }
+  }
+
+  dependencies.napi = dependencyConfig
+
+  await fs.writeFile(filePath, stringifyToml(cargoToml))
+}
+
 async function filterTargetsInGithubActions(
   filePath: string,
   enabledTargets: string[],
@@ -341,6 +390,17 @@ async function filterTargetsInGithubActions(
 
 function processOptions(options: RawNewOptions) {
   debug('Processing options...')
+  const minNodeApiVersion = options.minNodeApiVersion ?? 4
+  if (
+    !Number.isInteger(minNodeApiVersion) ||
+    !SUPPORTED_NAPI_VERSIONS.some((version) => version === minNodeApiVersion)
+  ) {
+    throw new RangeError(
+      `Unsupported Node-API version ${minNodeApiVersion}. Expected one of: ${SUPPORTED_NAPI_VERSIONS.join(', ')}`,
+    )
+  }
+  options.minNodeApiVersion = minNodeApiVersion
+
   if (!options.path) {
     throw new Error('Please provide the path as the argument')
   }
@@ -424,6 +484,10 @@ export async function newProject(userOptions: RawNewOptions) {
       const cargoTomlPath = path.join(options.path, 'Cargo.toml')
       if (existsSync(cargoTomlPath)) {
         await updateCargoTomlTypeDef(cargoTomlPath, options.enableTypeDef)
+        await updateCargoTomlNodeApiVersion(
+          cargoTomlPath,
+          options.minNodeApiVersion,
+        )
       }
 
       // Filter targets in package.json


### PR DESCRIPTION
## Summary

- validate that `minNodeApiVersion` is a supported integer
- rewrite the generated Cargo `napi` feature to the selected Node-API level
- preserve unrelated dependency features
- disable the default `napi4` feature for Node-API 1-3 while retaining dynamic symbol loading
- add network-free regression coverage

## Why

`napi new --min-node-api` updated the generated package's Node engine constraint but left Cargo on the template's default `napi4` feature. Projects requesting another Node-API level therefore advertised one minimum while compiling for another.

## Validation

- `yarn workspace @napi-rs/cli test src/api/__tests__/new-node-api-version.spec.ts` (7 passed)
- full CLI suite on the combined change set (121 passed)
- focused Oxlint and Prettier checks
- CLI build