### PR TITLE
fix(cli): declare Node versions required by prompts

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": ">= 16"
+    "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
   },
   "bin": {
     "napi": "./dist/cli.js",


### PR DESCRIPTION
## Summary

Update `@napi-rs/cli`'s Node engine range to match its direct `@inquirer/prompts@8.5.2` dependency:

```
>=23.5.0 || ^22.13.0 || ^20.17.0
```

## Why

The CLI currently advertises Node 16 support even though its prompt dependency requires newer Node releases. Package managers can therefore install a CLI combination that cannot run on the declared runtime.

## Validation

- confirmed with `npm info @inquirer/prompts@8.5.2 engines --json`
- `yarn workspace @napi-rs/cli build`
- Prettier check