### PR TITLE
fix(napi): register the async runtime env cleanup hook per registration

### DIFF
--- a/crates/napi/src/bindgen_runtime/module_register.rs
+++ b/crates/napi/src/bindgen_runtime/module_register.rs
@@ -118,12 +118,17 @@ static MODULE_CLASS_PROPERTIES: LazyLock<ModuleClassProperty> = LazyLock::new(De
 static MODULE_COUNT: AtomicUsize = AtomicUsize::new(0);
 #[cfg(not(feature = "noop"))]
 static FIRST_MODULE_REGISTERED: AtomicBool = AtomicBool::new(false);
+/// Monotonic, never-dereferenced cookie handed to each `thread_cleanup` env-cleanup-hook
+/// registration. The same addon can be (re)loaded into the *same* env (see `unload.spec.js`),
+/// and Node's `napi_add_env_cleanup_hook` asserts every `(fn, arg)` pair is unique within an
+/// env — so a shared `null` arg would abort on the second load. A distinct cookie per
+/// registration keeps the pairs unique; `thread_cleanup` ignores the value.
 #[cfg(all(
   feature = "tokio_rt",
   not(target_family = "wasm"),
   not(feature = "noop")
 ))]
-static ENV_CLEANUP_HOOK_ADDED: RwLock<bool> = RwLock::new(false);
+static ENV_CLEANUP_HOOK_COOKIE: AtomicUsize = AtomicUsize::new(1);
 thread_local! {
   static REGISTERED_CLASSES: LazyCell<RegisteredClasses> = LazyCell::new(Default::default);
 }
@@ -579,16 +584,26 @@ pub unsafe extern "C" fn napi_register_module_v1(
       crate::tokio_runtime::start_async_runtime();
       #[cfg(not(target_family = "wasm"))]
       {
-        let mut env_cleanup_hook_added = ENV_CLEANUP_HOOK_ADDED.write().unwrap();
-        if !*env_cleanup_hook_added {
-          check_status_or_throw!(
-            env,
-            unsafe { sys::napi_add_env_cleanup_hook(env, Some(thread_cleanup), ptr::null_mut()) },
-            "Failed to add env cleanup hook"
-          );
-          *env_cleanup_hook_added = true;
-          drop(env_cleanup_hook_added);
-        }
+        // Register a cleanup hook for EVERY registration, not just the first one.
+        // `MODULE_COUNT` is incremented on every `napi_register_module_v1` call and
+        // `thread_cleanup` decrements it once per env teardown, shutting the shared
+        // async runtime down only when the count reaches zero (the last live env).
+        // A process-wide one-shot gate used to install the hook for the first
+        // registration only, so additional or recreated envs (`worker_threads`,
+        // Electron renderer reload) bumped the count with no matching cleanup hook:
+        // the count never returned to zero and `shutdown_async_runtime` was never
+        // called, leaking backend threads/tasks that outlived the addon image.
+        //
+        // Each registration gets a distinct cookie so repeated loads of the same
+        // addon into one env (`unload.spec.js`) don't collide on Node's unique
+        // `(fn, arg)` assertion; the cookie is opaque and never dereferenced.
+        let cleanup_cookie =
+          ENV_CLEANUP_HOOK_COOKIE.fetch_add(1, Ordering::Relaxed) as *mut std::ffi::c_void;
+        check_status_or_throw!(
+          env,
+          unsafe { sys::napi_add_env_cleanup_hook(env, Some(thread_cleanup), cleanup_cookie) },
+          "Failed to add env cleanup hook"
+        );
       }
     }
   }


### PR DESCRIPTION
## The bug

`napi_register_module_v1` runs once per env — the main thread, every `worker_threads` worker (own V8 isolate + env), and every Electron renderer reload (env destroyed + recreated). On each call it:

- increments `MODULE_COUNT` (`fetch_add(1)`), and
- calls `start_async_runtime()` (which lazily (re)creates the process-global shared runtime).

Teardown is refcounted: the env cleanup hook `thread_cleanup` does `MODULE_COUNT.fetch_sub(1)` and only calls `shutdown_async_runtime()` when the count reaches zero — i.e. the last live env.

The cleanup hook was installed behind a **process-wide one-shot gate** (`ENV_CLEANUP_HOOK_ADDED: RwLock<bool>`) that was **set once and never reset**, so it registered for the **first registration only**. Every additional or recreated env bumped `MODULE_COUNT` but registered **no matching cleanup hook**, so the count could never return to zero:

```
worker_threads (main + 1 worker):
  main register    MODULE_COUNT 0 -> 1   hook added (flag now true)
  worker register  MODULE_COUNT 1 -> 2   flag true  -> NO hook
  worker unload    (no hook)             MODULE_COUNT stays 2
  main unload      hook fires 2 -> 1     not zero   -> NO shutdown   <-- runtime leaks

Electron renderer reload (sequential envs):
  env A register   0 -> 1   hook added (flag true)
  env A unload     1 -> 0   shutdown
  env B register   0 -> 1   flag STILL true -> NO hook (runtime restarted)
  env B unload     (no hook)               MODULE_COUNT stays 1 -> NO shutdown
```

`shutdown_async_runtime` was never called on those envs' unload, so the runtime's backend threads/tasks outlived the addon image.

## The fix

Register the cleanup hook on **every registration** instead of once.

One subtlety makes a naive "always register" wrong: the same addon can be (re)loaded into the **same env** — `__tests__/unload.spec.js` deletes the `require` cache and re-`require`s the addon, so `napi_register_module_v1` runs twice in one env. Node's `napi_add_env_cleanup_hook` asserts every `(fn, arg)` pair is **unique within an env** (`AddEnvironmentCleanupHook` → `CHECK(result.second)`), so re-adding `(thread_cleanup, null)` aborts the process:

```
#  Assertion failed: (insertion_info.second) == (true)
1: node::Assert(...)
2: node::AddEnvironmentCleanupHook(...)
3: napi_add_env_cleanup_hook
4: napi_register_module_v1
```

So each registration is handed a **distinct, never-dereferenced cookie** (a monotonic counter cast to `*mut c_void`) instead of a shared `null`. `thread_cleanup` ignores its arg — the cookie only keeps the `(fn, arg)` pairs unique. One hook per registration also keeps `MODULE_COUNT` balanced (one decrement per increment), so the last env's teardown still shuts the runtime down exactly once.

## Verification

Reproduced the crash and the fix locally against the built `napi-examples` addon (node v24, `tokio_rt`), mirroring `unload.spec.js`:

```
BROKEN (shared null arg):
  load1 add(1,2)=3
  load2 (same env) -> Assertion failed: (insertion_info.second) == (true)
                      node::AddEnvironmentCleanupHook  -> SIGABRT

FIXED (unique cookie):
  load1 add(1,2)=3
  load2 add(1,2)=3
  load3 add(1,2)=3
  SURVIVED multi-load, exiting cleanly (exit 0)
```

`cargo build -p napi --features tokio_rt` / default / `--features full` build clean; `cargo clippy -p napi --features tokio_rt` reports no new warnings in `module_register.rs`.

## Scope

`async-runtime` is not a feature on `main` (it is introduced by #3352), so this fixes the pre-existing **`tokio_rt`** path here. Split out of the #3352 review (codex, `module_register.rs:577`); when #3352 rebases, its `any(feature = "tokio_rt", feature = "async-runtime")` cfg-widening of this block inherits the corrected per-registration behavior for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of the shared async runtime during module registration and environment teardown.
  * Ensures proper shutdown only when the last environment is torn down, avoiding issues during worker and Electron reloads.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->