### PR TITLE
fix(napi): release JsDeferred tsfn on null-env teardown drain + transactional construction

### DIFF
--- a/crates/napi/src/js_values/deferred.rs
+++ b/crates/napi/src/js_values/deferred.rs
@@ -112,7 +112,8 @@ struct DeferredHookData {
   /// Whether the env cleanup hook is currently registered: set once registration succeeds,
   /// cleared when the teardown hook runs (Node's teardown drain consumes hooks as it runs them).
   /// The finalize callback only unregisters the hook while this is set — Node-API requires the
-  /// removed pair to still be registered, otherwise the process may abort (Bun ≤ 1.2.18 panics).
+  /// removed pair to still be registered, otherwise the process may abort (Bun ≤ 1.2.20 aborts via
+  /// `NAPI_PERISH`; fixed in 1.2.21 to match Node's silent no-op).
   hook_registered: AtomicBool,
 }
 
@@ -187,7 +188,7 @@ impl<Data: ToNapiValue, Resolver: FnOnce(Env) -> Result<Data>> JsDeferred<Data, 
     // before Node finalizes the threadsafe function.
     #[cfg(not(target_family = "wasm"))]
     {
-      check_status!(
+      if let Err(err) = check_status!(
         unsafe {
           sys::napi_add_env_cleanup_hook(
             env.0,
@@ -196,16 +197,55 @@ impl<Data: ToNapiValue, Resolver: FnOnce(Env) -> Result<Data>> JsDeferred<Data, 
           )
         },
         "Register env cleanup hook in JsDeferred failed"
-      )?;
+      ) {
+        // The tsfn exists but no teardown hook guards it yet. Release it so it cannot keep the loop
+        // alive; its finalize callback owns the boxed `DeferredHookData`, frees it, and — seeing
+        // `hook_registered == false` — skips the unregister. Do NOT free the box here: that would
+        // double-free against the finalize callback.
+        if let Some(tsfn) = handle
+          .pending_tsfn
+          .lock()
+          .expect("JsDeferred pending lock failed")
+          .take()
+        {
+          unsafe {
+            sys::napi_release_threadsafe_function(tsfn, sys::ThreadsafeFunctionReleaseMode::abort)
+          };
+        }
+        return Err(err);
+      }
       unsafe { &*hook_data_ptr }
         .hook_registered
         .store(true, Ordering::Release);
     }
 
+    // Create the trace ref LAST, after every fallible step. `DeferredTrace` has no `Drop` (its
+    // `napi_ref` is deleted by hand when the promise settles), so building it before a step that can
+    // still fail would leak that ref on the error path. On its own failure there is no trace ref yet
+    // to leak, and we release the still-`Some` tsfn so it cannot strand the loop either — its
+    // finalize still frees the boxed `DeferredHookData`, so (as above) we must not free it here.
+    #[cfg(feature = "deferred_trace")]
+    let trace = match DeferredTrace::new(env.0) {
+      Ok(trace) => trace,
+      Err(err) => {
+        if let Some(tsfn) = handle
+          .pending_tsfn
+          .lock()
+          .expect("JsDeferred pending lock failed")
+          .take()
+        {
+          unsafe {
+            sys::napi_release_threadsafe_function(tsfn, sys::ThreadsafeFunctionReleaseMode::abort)
+          };
+        }
+        return Err(err);
+      }
+    };
+
     let deferred = Self {
       handle,
       #[cfg(feature = "deferred_trace")]
-      trace: DeferredTrace::new(env.0)?,
+      trace,
       finalize_callback: Default::default(),
       _data: PhantomData,
       _resolver: PhantomData,
@@ -389,10 +429,21 @@ extern "C" fn napi_resolve_deferred<Data: ToNapiValue, Resolver: FnOnce(Env) -> 
 ) {
   let deferred_data: Box<DeferredData<Data, Resolver>> = unsafe { Box::from_raw(data.cast()) };
 
-  // Node invokes leftover queue items with a null env while the threadsafe function closes
-  // during env teardown; there is no promise left to settle, and the threadsafe function is
-  // already being torn down, so only the queued data must be freed.
+  // A leftover queue item is drained with a null env while the threadsafe function closes during env
+  // teardown. There is no promise left to settle, but this item still owns the release of the
+  // threadsafe function's thread count (moved here by the settle in `call_tsfn`). Recent Node (its
+  // `MaybeDelete` only frees the threadsafe function once the count reaches zero) and emnapi will
+  // otherwise leak the threadsafe function, so we must release it here too instead of only on the
+  // settle path below. This is safe during the teardown drain: `EmptyQueue` runs this callback
+  // without holding the tsfn lock, and while it is closing the release only drops the count — the
+  // object is deleted exactly once by the finalize that immediately follows.
   if env.is_null() {
+    unsafe {
+      sys::napi_release_threadsafe_function(
+        deferred_data.tsfn,
+        sys::ThreadsafeFunctionReleaseMode::release,
+      )
+    };
     return;
   }
 


### PR DESCRIPTION
Follow-up hardening on top of #3404 (JsDeferred env-teardown guard). Reviewed against Node v22.22.2 + v24.18.0 and Bun 1.2.18/1.3.14 source; built on native (±`deferred_trace`) and wasm, `clippy -D` clean, `examples/napi` suite green, `index.d.cts` byte-identical.

## 1. Threadsafe-function leak on the null-env teardown drain (the real fix)

A settle (`call_tsfn`) takes `pending_tsfn` and queues its `DeferredData`; the release of the threadsafe function's initial thread count moves into that queued item, to be discharged when `napi_resolve_deferred` runs. If the env tears down before the loop dispatches it, Node drains the leftover item by invoking the callback with a **null env**, and the early return skipped `napi_release_threadsafe_function`.

On current Node the teardown delete is **thread-count-gated**, so that skip leaks the threadsafe function:

```
Node v22:  Finalize() -> EmptyQueueAndDelete()  -> delete this   (unconditional)      -> no leak
Node v24:  Finalize() -> EmptyQueue(); MaybeDelete()
                         MaybeDelete(): if thread_count > 0 { ReleaseResources(); return }  // skip
                                        delete this
           -> queued item drained with null env never released -> thread_count stays 1
           -> threadsafe function never deleted -> LEAK (accumulates across teardown races)
```

emnapi (WASM runtime) gates deletion the same way. Fix: release the threadsafe function in the null-env branch too. This is safe during the teardown drain — `EmptyQueue` runs the callback **without holding the tsfn lock** (no re-entrant deadlock), and `state == kClosing` there (`kClosed` is set later in `ReleaseResources`), so `Release` decrements `thread_count` 1→0 and returns `napi_ok` **without** `delete this`; the `MaybeDelete` that immediately follows performs the single delete. On v22 `Release` never deletes and `EmptyQueueAndDelete` does the single delete — so no double-free on either.

## 2. Transactional `JsDeferred::new`

The threadsafe function is created before two more fallible steps (`napi_add_env_cleanup_hook`, and under `deferred_trace` `DeferredTrace::new`). A failure in either stranded the ref'd tsfn (which keeps the event loop alive until env teardown), and — because `DeferredTrace` has no `Drop` (its `napi_ref` is deleted by hand) — one ordering also leaked the trace ref. Now the trace ref is created **last** (nothing fallible after it), and both post-tsfn error paths release the tsfn without freeing the boxed `DeferredHookData` (the tsfn finalize owns and frees it — freeing here would double-free).

## 3. Doc accuracy

`hook_registered`'s comment said "Bun ≤ 1.2.18 panics". The `NAPI_PERISH` abort on removing an unregistered cleanup-hook pair actually persisted through **1.2.20** and was fixed in **1.2.21** (oven-sh/bun#21883) to match Node's silent no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches N-API threadsafe-function lifecycle and env teardown ordering; behavior is runtime-specific but scoped to deferred promise construction/teardown error paths.
> 
> **Overview**
> Hardens **`JsDeferred`** (async deferred promises) around env teardown and failed construction.
> 
> **Null-env teardown drain:** When the event loop tears down before a queued settle runs, Node invokes `napi_resolve_deferred` with a **null env**. The handler now calls `napi_release_threadsafe_function` in that branch so the thread count owned by the queued item is dropped. Without this, Node v24+ and emnapi can **leak** the threadsafe function because deletion is gated on `thread_count == 0`.
> 
> **Transactional `JsDeferred::new`:** If `napi_add_env_cleanup_hook` or (with `deferred_trace`) `DeferredTrace::new` fails after the tsfn is created, the code **abort-releases** the tsfn instead of leaving it ref’d (which could keep the loop alive). `DeferredTrace` is created **last** so a later failure does not leak its `napi_ref`. `DeferredHookData` is still freed only by the tsfn finalize callback to avoid double-free.
> 
> **Docs:** Bun cleanup-hook unregister behavior is documented as aborting through **1.2.20** (`NAPI_PERISH`), fixed in **1.2.21**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af8ec6fb679b745e52263d65bb9254979c0d86d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved promise cleanup during application and runtime shutdown.
  * Prevented resource leaks when deferred operations fail or are interrupted during teardown.
  * Improved handling of cleanup errors across Node.js and Bun environments.
  * Ensured queued operations are properly released when the runtime is shutting down.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->