### PR TITLE
perf(napi): share tracing callsite

### DIFF
--- a/crates/backend/src/codegen/fn.rs
+++ b/crates/backend/src/codegen/fn.rs
@@ -16,7 +16,7 @@ fn gen_tracing_debug(js_name: &str, parent_js_name: Option<&String>) -> TokenStr
     js_name.to_string()
   };
   quote! {
-    napi::bindgen_prelude::tracing::debug!(target: "napi", "{}", #full_name);
+    napi::bindgen_prelude::trace_napi_call(#full_name);
   }
 }
 

--- a/crates/backend/src/codegen/struct.rs
+++ b/crates/backend/src/codegen/struct.rs
@@ -20,7 +20,7 @@ const STRUCT_FIELD_SPECIAL_CASE: &[&str] = &["Option", "Result"];
 fn gen_tracing_debug(class_name: &str, method_name: &str) -> TokenStream {
   let full_name = format!("{}::{}", class_name, method_name);
   quote! {
-    napi::bindgen_prelude::tracing::debug!(target: "napi", "{}", #full_name);
+    napi::bindgen_prelude::trace_napi_call(#full_name);
   }
 }
 

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -197,6 +197,17 @@ pub mod bindgen_prelude {
   #[cfg(feature = "tracing")]
   pub use ::tracing;
 
+  /// Emit NAPI call tracing through one shared callsite.
+  ///
+  /// Keep this out of line: every generated NAPI wrapper calls this function, and inlining the
+  /// tracing macro would duplicate its static callsite metadata in every wrapper.
+  #[cfg(feature = "tracing")]
+  #[doc(hidden)]
+  #[inline(never)]
+  pub fn trace_napi_call(name: &'static str) {
+    ::tracing::debug!(target: "napi", "{}", name);
+  }
+
   // This function's signature must be kept in sync with the one in tokio_runtime.rs, otherwise napi
   // will fail to compile without the `tokio_rt` feature.
 


### PR DESCRIPTION
Route generated NAPI tracing through one non-inlined helper so wrappers no longer duplicate tracing callsite metadata. Call names and entry-point coverage remain unchanged.

A Rolldown release build shrank by 67,840 bytes, from 16,609,072 to 16,541,232 bytes.

Validation:
- `cargo fmt --check`
- `cargo test -p napi --features tracing --lib`
- `cargo test -p napi-derive-backend --features tracing`
- `cargo check -p napi-examples --features napi/tracing,napi-derive/tracing`
- Loaded the resulting Rolldown binding in Node and verified `RD_LOG=napi=debug` still reports function and method names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracing output for generated N-API calls when tracing is enabled.
  * Standardized debug logging with the `napi` target for more consistent diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->