### PR TITLE
fix(wasm-runtime): preserve emnapi v1 compatibility

### DIFF
--- a/cli/src/api/__tests__/create-npm-dirs.spec.ts
+++ b/cli/src/api/__tests__/create-npm-dirs.spec.ts
@@ -451,6 +451,52 @@ test('should set @emnapi/core and @emnapi/runtime versions to match emnapi for W
 })
 
 test.serial(
+  'should keep generated WASM runtime dependencies within the resolved minor',
+  async (t) => {
+    const { tmpDir, packageJsonPath } = t.context
+    const registryServer = await startRegistryServer({
+      'dist-tags': {
+        latest: '1.1.6',
+      },
+    })
+
+    process.env.npm_config_registry = `${registryServer.origin}/npm`
+
+    const packageJson = {
+      name: 'test-wasm-runtime-range',
+      version: '1.0.0',
+      napi: {
+        binaryName: 'test-wasm-runtime-range',
+        targets: ['wasm32-wasip1', 'wasm32-wasip1-threads'],
+      },
+    }
+
+    await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2))
+
+    try {
+      await createNpmDirs({
+        cwd: tmpDir,
+        packageJsonPath: 'package.json',
+      })
+
+      for (const packageDir of ['wasm32-wasip1', 'wasm32-wasi']) {
+        const scopedPackageJson = JSON.parse(
+          await readFile(
+            join(tmpDir, 'npm', packageDir, 'package.json'),
+            'utf-8',
+          ),
+        )
+
+        t.is(scopedPackageJson.dependencies['@napi-rs/wasm-runtime'], '~1.1.6')
+      }
+      t.deepEqual(registryServer.requests, ['/npm/@napi-rs/wasm-runtime'])
+    } finally {
+      await registryServer.close()
+    }
+  },
+)
+
+test.serial(
   'should reject an empty latest dist-tag when resolving wasm runtime metadata',
   async (t) => {
     const { tmpDir, packageJsonPath } = t.context

--- a/cli/src/api/create-npm-dirs.ts
+++ b/cli/src/api/create-npm-dirs.ts
@@ -554,7 +554,9 @@ async function createNpmDirsUnlocked(
       }
       const emnapiVersion = require('emnapi/package.json').version
       scopedPackageJson.dependencies = {
-        '@napi-rs/wasm-runtime': `^${wasmRuntimeVersion}`,
+        // Runtime minor releases can target a different emnapi generation.
+        // Keep generated packages on the resolved minor while allowing fixes.
+        '@napi-rs/wasm-runtime': `~${wasmRuntimeVersion}`,
         '@emnapi/core': emnapiVersion,
         '@emnapi/runtime': emnapiVersion,
         ...(wasm?.browser?.buffer === true &&

--- a/wasm-runtime/emnapi-plugins.js
+++ b/wasm-runtime/emnapi-plugins.js
@@ -1,0 +1,4 @@
+export {
+  asyncWork as emnapiAsyncWorkPlugin,
+  tsfn as emnapiTSFNPlugin,
+} from '@emnapi/core/plugins'

--- a/wasm-runtime/package.json
+++ b/wasm-runtime/package.json
@@ -29,6 +29,7 @@
     "dist/*.js"
   ],
   "devDependencies": {
+    "@emnapi/core": "2.0.0-alpha.3",
     "@rollup/plugin-alias": "^6.0.0",
     "@rollup/plugin-commonjs": "^29.0.3",
     "@rollup/plugin-inject": "^5.0.5",
@@ -50,12 +51,12 @@
     "@tybys/wasm-util": "^0.10.3"
   },
   "peerDependencies": {
-    "@emnapi/core": "^2.0.0-alpha.3",
-    "@emnapi/runtime": "^2.0.0-alpha.3"
+    "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+    "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
   },
   "scripts": {
     "build": "rollup -c rollup.config.js",
-    "test": "node --test"
+    "test": "yarn run build && node --test"
   },
   "funding": {
     "type": "github",

--- a/wasm-runtime/rollup.config.js
+++ b/wasm-runtime/rollup.config.js
@@ -54,4 +54,20 @@ export default defineConfig([
       file: './dist/fs-proxy.cjs',
     },
   },
+  {
+    input: './emnapi-plugins.js',
+    plugins: [nodeResolve()],
+    treeshake: true,
+    output: [
+      {
+        format: 'esm',
+        file: './dist/emnapi-plugins.js',
+      },
+      {
+        format: 'commonjs',
+        exports: 'named',
+        file: './dist/emnapi-plugins.cjs',
+      },
+    ],
+  },
 ])

--- a/wasm-runtime/runtime.cjs
+++ b/wasm-runtime/runtime.cjs
@@ -13,11 +13,13 @@ const {
 // instantiation fails with a LinkError naming the missing import. Threaded
 // (shared-memory) builds link the C implementations and need no plugins;
 // this mirrors the upstream @emnapi/core v2 plugin split (v1 bundled these
-// implementations in the core runtime).
+// implementations in the core runtime). The plugins are bundled into this
+// package so loading the runtime with @emnapi/core v1 does not resolve the
+// v2-only `@emnapi/core/plugins` package export.
 const {
-  asyncWork: emnapiAsyncWorkPlugin,
-  tsfn: emnapiTSFNPlugin,
-} = require('@emnapi/core/plugins')
+  emnapiAsyncWorkPlugin,
+  emnapiTSFNPlugin,
+} = require('./dist/emnapi-plugins.cjs')
 const { createContext, getDefaultContext } = require('@emnapi/runtime')
 const { WASI } = require('@tybys/wasm-util')
 

--- a/wasm-runtime/runtime.js
+++ b/wasm-runtime/runtime.js
@@ -1,8 +1,15 @@
-export {
-  instantiateNapiModuleSync,
-  instantiateNapiModule,
-  MessageHandler,
-} from '@emnapi/core'
+import * as emnapiCore from '@emnapi/core'
+import * as emnapiRuntime from '@emnapi/runtime'
+
+import {
+  emnapiAsyncWorkPlugin,
+  emnapiTSFNPlugin,
+} from './dist/emnapi-plugins.js'
+
+const { instantiateNapiModuleSync, instantiateNapiModule, MessageHandler } =
+  emnapiCore
+const { createContext, getDefaultContext } = emnapiRuntime
+
 // Single-threaded (non-shared-memory) WASI builds link an emnapi archive
 // without the C async-work and threadsafe-function implementations (they are
 // unconditional `napi_generic_failure` stubs without threads), so the
@@ -13,11 +20,17 @@ export {
 // instantiation fails with a LinkError naming the missing import. Threaded
 // (shared-memory) builds link the C implementations and need no plugins;
 // this mirrors the upstream @emnapi/core v2 plugin split (v1 bundled these
-// implementations in the core runtime).
+// implementations in the core runtime). The plugins are bundled into this
+// package so loading the runtime with @emnapi/core v1 does not resolve the
+// v2-only `@emnapi/core/plugins` package export.
 export {
-  asyncWork as emnapiAsyncWorkPlugin,
-  tsfn as emnapiTSFNPlugin,
-} from '@emnapi/core/plugins'
-export { createContext, getDefaultContext } from '@emnapi/runtime'
+  MessageHandler,
+  createContext,
+  emnapiAsyncWorkPlugin,
+  emnapiTSFNPlugin,
+  getDefaultContext,
+  instantiateNapiModule,
+  instantiateNapiModuleSync,
+}
 export * from '@tybys/wasm-util'
 export { createOnMessage, createFsProxy } from './fs-proxy.js'

--- a/wasm-runtime/runtime.test.js
+++ b/wasm-runtime/runtime.test.js
@@ -1,0 +1,209 @@
+import assert from 'node:assert/strict'
+import { cp, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { createRequire } from 'node:module'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const runtimeDirectory = dirname(fileURLToPath(import.meta.url))
+
+const writeModulePackage = async (
+  fixtureDirectory,
+  packageName,
+  version,
+  esmSource,
+  cjsSource,
+  extraExports = {},
+) => {
+  const packageDirectory = join(
+    fixtureDirectory,
+    'node_modules',
+    ...packageName.split('/'),
+  )
+  await mkdir(packageDirectory, { recursive: true })
+  await Promise.all([
+    writeFile(
+      join(packageDirectory, 'package.json'),
+      JSON.stringify({
+        name: packageName,
+        version,
+        type: 'module',
+        exports: {
+          '.': {
+            import: './index.js',
+            require: './index.cjs',
+          },
+          ...extraExports,
+        },
+      }),
+    ),
+    writeFile(join(packageDirectory, 'index.js'), esmSource),
+    writeFile(join(packageDirectory, 'index.cjs'), cjsSource),
+  ])
+}
+
+const createRuntimeFixture = async (generation) => {
+  const fixtureDirectory = await mkdtemp(
+    join(tmpdir(), `napi-rs-wasm-runtime-${generation}-`),
+  )
+  const emnapiVersion = generation === 'v1' ? '1.11.1' : '2.0.0-alpha.3'
+
+  await Promise.all([
+    mkdir(join(fixtureDirectory, 'dist'), { recursive: true }),
+    writeFile(
+      join(fixtureDirectory, 'package.json'),
+      JSON.stringify({ type: 'module' }),
+    ),
+    cp(
+      join(runtimeDirectory, 'runtime.cjs'),
+      join(fixtureDirectory, 'runtime.cjs'),
+    ),
+    cp(
+      join(runtimeDirectory, 'runtime.js'),
+      join(fixtureDirectory, 'runtime.js'),
+    ),
+    cp(
+      join(runtimeDirectory, 'dist', 'emnapi-plugins.cjs'),
+      join(fixtureDirectory, 'dist', 'emnapi-plugins.cjs'),
+    ),
+    cp(
+      join(runtimeDirectory, 'dist', 'emnapi-plugins.js'),
+      join(fixtureDirectory, 'dist', 'emnapi-plugins.js'),
+    ),
+    writeFile(
+      join(fixtureDirectory, 'fs-proxy.js'),
+      `export const createFsProxy = () => 'fs-proxy-${generation}'
+export const createOnMessage = () => 'on-message-${generation}'
+`,
+    ),
+    writeFile(
+      join(fixtureDirectory, 'dist', 'fs-proxy.cjs'),
+      `module.exports = {
+  createFsProxy: () => 'fs-proxy-${generation}',
+  createOnMessage: () => 'on-message-${generation}',
+}
+`,
+    ),
+  ])
+
+  const unavailablePluginExport =
+    generation === 'v1'
+      ? {}
+      : {
+          './plugins': {
+            import: './plugins.js',
+            require: './plugins.cjs',
+          },
+        }
+
+  await Promise.all([
+    writeModulePackage(
+      fixtureDirectory,
+      '@emnapi/core',
+      emnapiVersion,
+      `export const version = '${emnapiVersion}'
+export class MessageHandler {
+  static generation = '${generation}'
+}
+export const instantiateNapiModule = () => 'async-${generation}'
+export const instantiateNapiModuleSync = () => 'sync-${generation}'
+`,
+      `module.exports = {
+  version: '${emnapiVersion}',
+  MessageHandler: class MessageHandler {
+    static generation = '${generation}'
+  },
+  instantiateNapiModule: () => 'async-${generation}',
+  instantiateNapiModuleSync: () => 'sync-${generation}',
+}
+`,
+      unavailablePluginExport,
+    ),
+    writeModulePackage(
+      fixtureDirectory,
+      '@emnapi/runtime',
+      emnapiVersion,
+      `export const createContext = () => 'context-${generation}'
+export const getDefaultContext = () => 'default-context-${generation}'
+`,
+      `module.exports = {
+  createContext: () => 'context-${generation}',
+  getDefaultContext: () => 'default-context-${generation}',
+}
+`,
+    ),
+    writeModulePackage(
+      fixtureDirectory,
+      '@tybys/wasm-util',
+      '0.10.3',
+      `export class WASI {
+  static generation = '${generation}'
+}
+export const wasmUtilGeneration = '${generation}'
+`,
+      `module.exports = {
+  WASI: class WASI {
+    static generation = '${generation}'
+  },
+  wasmUtilGeneration: '${generation}',
+}
+`,
+    ),
+  ])
+
+  if (generation === 'v2') {
+    const coreDirectory = join(
+      fixtureDirectory,
+      'node_modules',
+      '@emnapi',
+      'core',
+    )
+    await Promise.all([
+      writeFile(
+        join(coreDirectory, 'plugins.js'),
+        `throw new Error('runtime must use its bundled emnapi plugins')\n`,
+      ),
+      writeFile(
+        join(coreDirectory, 'plugins.cjs'),
+        `throw new Error('runtime must use its bundled emnapi plugins')\n`,
+      ),
+    ])
+  }
+
+  return fixtureDirectory
+}
+
+const assertRuntimeExports = (runtime, generation) => {
+  assert.equal(runtime.MessageHandler.generation, generation)
+  assert.equal(runtime.instantiateNapiModule(), `async-${generation}`)
+  assert.equal(runtime.instantiateNapiModuleSync(), `sync-${generation}`)
+  assert.equal(runtime.createContext(), `context-${generation}`)
+  assert.equal(runtime.getDefaultContext(), `default-context-${generation}`)
+  assert.equal(typeof runtime.emnapiAsyncWorkPlugin, 'function')
+  assert.equal(typeof runtime.emnapiTSFNPlugin, 'function')
+  assert.equal(runtime.WASI.generation, generation)
+  assert.equal(runtime.createFsProxy(), `fs-proxy-${generation}`)
+  assert.equal(runtime.createOnMessage(), `on-message-${generation}`)
+}
+
+for (const generation of ['v1', 'v2']) {
+  test(`loads ${generation} emnapi packages from CommonJS and ESM`, async (t) => {
+    const fixtureDirectory = await createRuntimeFixture(generation)
+    t.after(() => rm(fixtureDirectory, { force: true, recursive: true }))
+
+    const fixtureRequire = createRequire(
+      join(fixtureDirectory, 'test-entry.cjs'),
+    )
+    const commonjsRuntime = fixtureRequire(
+      join(fixtureDirectory, 'runtime.cjs'),
+    )
+    assertRuntimeExports(commonjsRuntime, generation)
+
+    const esmRuntime = await import(
+      pathToFileURL(join(fixtureDirectory, 'runtime.js')).href
+    )
+    assertRuntimeExports(esmRuntime, generation)
+    assert.equal(esmRuntime.wasmUtilGeneration, generation)
+  })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2093,6 +2093,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@napi-rs/wasm-runtime@workspace:wasm-runtime"
   dependencies:
+    "@emnapi/core": "npm:2.0.0-alpha.3"
     "@rollup/plugin-alias": "npm:^6.0.0"
     "@rollup/plugin-commonjs": "npm:^29.0.3"
     "@rollup/plugin-inject": "npm:^5.0.5"
@@ -2111,8 +2112,8 @@ __metadata:
     rollup-plugin-polyfill-node: "npm:^0.13.0"
     tslib: "npm:^2.8.1"
   peerDependencies:
-    "@emnapi/core": ^2.0.0-alpha.3
-    "@emnapi/runtime": ^2.0.0-alpha.3
+    "@emnapi/core": ^1.7.1 || ^2.0.0-alpha.3
+    "@emnapi/runtime": ^1.7.1 || ^2.0.0-alpha.3
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

- bundle the emnapi v2 async-work and TSFN plugins into `@napi-rs/wasm-runtime` so its root CJS and ESM entrypoints no longer resolve the v2-only `@emnapi/core/plugins` subpath
- accept both the emnapi v1 and v2 peer ranges while preserving the v2 plugin exports needed by new threadless-WASI loaders
- generate `~<version>` runtime dependencies so a binding remains within the emnapi generation selected when it was built
- add CJS and ESM resolver regressions for both emnapi generations

## Root cause

Published v1-generated WASI packages such as `@rolldown/binding-wasm32-wasi@1.1.5` declare `@napi-rs/wasm-runtime: ^1.1.6` with emnapi 1.11.1. That caret began selecting runtime 1.2.0, whose root entrypoint unconditionally imported `@emnapi/core/plugins`. emnapi v1 does not export that subpath, so the binding failed before instantiation and Rolldown surfaced the failure as a generic “Cannot find native binding” error.

Changing only peer metadata would silence the package-manager warning without fixing module loading. This patch bundles the v2 plugin implementations locally, allowing the root runtime to load with either peer generation.

## Validation

- `yarn workspace @napi-rs/wasm-runtime test` — 4/4 passed
- `yarn workspace @napi-rs/cli test src/api/__tests__/create-npm-dirs.spec.ts` — 14/14 passed
- `yarn lint`
- Prettier and diff checks
- browser bundle smoke test with esbuild
- packed-package matrix:
  - Rolldown WASI 1.1.5 + emnapi 1.11.1 + patched runtime: CJS/ESM load and 75 binding exports
  - Rolldown WASI 1.2.1 + emnapi 2.0.0-alpha.3 + patched runtime: CJS/ESM load and 75 binding exports

A full CLI run reached one unrelated network failure while fetching the runtime metadata from the npm registry; the complete affected test file passes in isolation.

Fixes #3424

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WASM loader resolution and npm dependency ranges for all generated WASI packages; behavior change is intentional but affects install-time semver for existing bindings.
> 
> **Overview**
> Fixes WASI bindings built against emnapi v1 failing when `^` on `@napi-rs/wasm-runtime` pulled a release whose entrypoint imported the v2-only `@emnapi/core/plugins` subpath.
> 
> **`@napi-rs/wasm-runtime`** now **Rollup-bundles** async-work and TSFN plugins into `dist/emnapi-plugins.*`, and the CJS/ESM entrypoints load those bundles instead of `@emnapi/core/plugins`. **Peer dependencies** accept **`@emnapi/core` / `@emnapi/runtime` v1 or v2**, and new **`runtime.test.js`** asserts CJS/ESM loads for both generations.
> 
> **CLI `createNpmDirs`** writes **`~<resolved>`** (not `^`) for `@napi-rs/wasm-runtime` on generated WASM scoped packages so installs stay on the emnapi generation chosen at build time; a matching test was added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6f3739c42e2511a2d2a5212b0feb236449d90fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WASM runtime compatibility with both `@emnapi` v1 and v2.
  - Runtime plugin loading now works reliably across CommonJS and ESM environments.
  - WASM runtime dependencies are constrained to updates within the resolved minor version, improving version consistency.

- **New Features**
  - Added packaged ESM and CommonJS plugin bundles for runtime integrations.
  - Added support for using the runtime’s bundled asynchronous work and thread-safe function plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->