### PR TITLE
perf(wasm-runtime): remove sourcemap

### DIFF
--- a/wasm-runtime/rollup.config.js
+++ b/wasm-runtime/rollup.config.js
@@ -43,7 +43,6 @@ export default defineConfig([
     treeshake: true,
     output: {
       format: 'esm',
-      sourcemap: 'inline',
       dir: './dist',
     },
   },


### PR DESCRIPTION
The package size of `@napi-rs/wasm-runtime` is 6.26MB. This sourcemap takes ~5MB.

While the package size doesn't matter too much when bundled as it won't be directly shipped to end users, I think it is better to be reduced because:

- when using this in stackblitz, the whole package will be downloaded
- the sourcemap is normally not used by the package users


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed inline source map generation from one build output.
  * All other build formats, paths, and configurations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->