### PR TITLE
fix(cli): omit the WASI package from `optionalDependencies` when native targets exist

### DIFF
--- a/cli/docs/wasi.md
+++ b/cli/docs/wasi.md
@@ -153,6 +153,28 @@ module runs inside the host process, so `wasm32` or host-OS restrictions would
 make npm reject a direct install or skip the optional dependency on otherwise
 supported hosts.
 
+Because nothing gates the install, the root package does not declare the WASI
+package in `optionalDependencies` when native targets are also configured. npm
+evaluates every `optionalDependencies` entry independently, so a declared WASI
+package is downloaded by every consumer, including the ones that already
+resolved a native package and will never load the `.wasm` binary. The generated
+binding loader picks WASI at require time instead, and environments without a
+native package are expected to install it on demand.
+
+When WASI is the only configured target it is the primary artifact rather than a
+fallback, so it is always declared. Set `napi.wasm.optionalDependency` to
+override the default in either direction:
+
+```json
+{
+  "napi": {
+    "wasm": {
+      "optionalDependency": true
+    }
+  }
+}
+```
+
 `napi.wasm.initialMemory` is measured in 64 KiB WebAssembly pages. The regular
 Node and browser loaders retain the historical 4,000-page (250 MiB) default.
 The deferred `./workerd` loader defaults to 1,024 pages (64 MiB), leaving

--- a/cli/docs/wasi.md
+++ b/cli/docs/wasi.md
@@ -162,7 +162,7 @@ binding loader picks WASI at require time instead, and environments without a
 native package are expected to install it on demand.
 
 When WASI is the only configured target it is the primary artifact rather than a
-fallback, so it is always declared. Set `napi.wasm.optionalDependency` to
+fallback, so it is declared by default. Set `napi.wasm.optionalDependency` to
 override the default in either direction:
 
 ```json

--- a/cli/src/api/__tests__/pre-publish.spec.ts
+++ b/cli/src/api/__tests__/pre-publish.spec.ts
@@ -1,0 +1,106 @@
+import test from 'ava'
+
+import { resolveRootOptionalDependencies } from '../pre-publish.js'
+import { parseTriple } from '../../utils/index.js'
+
+const PACKAGE_NAME = '@scope/pkg'
+const VERSION = '1.2.3'
+
+const NATIVE_TARGETS = ['aarch64-apple-darwin', 'x86_64-unknown-linux-gnu'].map(
+  parseTriple,
+)
+const WASI_TARGET = parseTriple('wasm32-wasip1-threads')
+const THREADLESS_WASI_TARGET = parseTriple('wasm32-wasip1')
+
+const NATIVE_ENTRIES = {
+  [`${PACKAGE_NAME}-darwin-arm64`]: VERSION,
+  [`${PACKAGE_NAME}-linux-x64-gnu`]: VERSION,
+}
+
+function resolve(
+  targets: Parameters<typeof resolveRootOptionalDependencies>[0]['targets'],
+  overrides: Partial<
+    Parameters<typeof resolveRootOptionalDependencies>[0]
+  > = {},
+) {
+  return resolveRootOptionalDependencies({
+    existing: undefined,
+    managedPackageNames: [PACKAGE_NAME],
+    packageName: PACKAGE_NAME,
+    targets,
+    version: VERSION,
+    ...overrides,
+  })
+}
+
+test('omits the WASI package when native targets are configured', (t) => {
+  // The WASI binary is a require-time fallback, not something npm should
+  // install on hosts that already resolved a native package.
+  t.deepEqual(resolve([...NATIVE_TARGETS, WASI_TARGET]), NATIVE_ENTRIES)
+})
+
+test('omits the threadless WASI package too', (t) => {
+  t.deepEqual(
+    resolve([...NATIVE_TARGETS, THREADLESS_WASI_TARGET]),
+    NATIVE_ENTRIES,
+  )
+})
+
+test('declares the WASI package when it is the only target', (t) => {
+  // With no native package to fall back from, WASI is the primary artifact.
+  t.deepEqual(resolve([WASI_TARGET]), {
+    [`${PACKAGE_NAME}-wasm32-wasi`]: VERSION,
+  })
+})
+
+test('declares every WASI flavor when only WASI targets are configured', (t) => {
+  t.deepEqual(resolve([WASI_TARGET, THREADLESS_WASI_TARGET]), {
+    [`${PACKAGE_NAME}-wasm32-wasi`]: VERSION,
+    [`${PACKAGE_NAME}-wasm32-wasip1`]: VERSION,
+  })
+})
+
+test('wasm.optionalDependency=true opts back into declaring WASI', (t) => {
+  t.deepEqual(
+    resolve([...NATIVE_TARGETS, WASI_TARGET], {
+      wasm: { optionalDependency: true },
+    }),
+    {
+      ...NATIVE_ENTRIES,
+      [`${PACKAGE_NAME}-wasm32-wasi`]: VERSION,
+    },
+  )
+})
+
+test('wasm.optionalDependency=false opts out even for WASI-only builds', (t) => {
+  t.deepEqual(
+    resolve([WASI_TARGET], { wasm: { optionalDependency: false } }),
+    {},
+  )
+})
+
+test('drops a stale WASI entry left over from a previous release', (t) => {
+  // Consumers upgrading from a release that did declare the WASI package must
+  // not keep the entry, otherwise the regression survives the fix.
+  t.deepEqual(
+    resolve([...NATIVE_TARGETS, WASI_TARGET], {
+      existing: {
+        ...NATIVE_ENTRIES,
+        [`${PACKAGE_NAME}-wasm32-wasi`]: '1.2.2',
+      },
+    }),
+    NATIVE_ENTRIES,
+  )
+})
+
+test('preserves unmanaged optionalDependencies', (t) => {
+  t.deepEqual(
+    resolve([...NATIVE_TARGETS, WASI_TARGET], {
+      existing: { 'unrelated-package': '^1.0.0' },
+    }),
+    {
+      'unrelated-package': '^1.0.0',
+      ...NATIVE_ENTRIES,
+    },
+  )
+})

--- a/cli/src/api/pre-publish.ts
+++ b/cli/src/api/pre-publish.ts
@@ -60,6 +60,7 @@ import {
   type CommonPackageJsonFields,
   type FileSystemTransactionWrite,
   type Target,
+  type UserNapiConfig,
 } from '../utils/index.js'
 
 const debug = debugFactory('pre-publish')
@@ -227,6 +228,61 @@ async function copyOwnedTemporaryPath(source: string, destination: string) {
   }
 }
 
+function wasiIsOnlyTarget(targets: Target[]) {
+  return (
+    targets.length > 0 && targets.every((target) => target.platform === 'wasi')
+  )
+}
+
+/**
+ * Build the root package's `optionalDependencies` map.
+ *
+ * A WASI package is a fallback for hosts that cannot load a `.node` binary, and
+ * the generated binding loader selects it at require time rather than npm
+ * selecting it at install time. Declaring it as an `optionalDependency`
+ * alongside the native packages cannot express "install this only when nothing
+ * else matched": npm evaluates every entry independently, so every consumer
+ * downloads a `.wasm` binary they will never load.
+ *
+ * It is therefore only declared when WASI is the only configured target, which
+ * makes it the primary artifact rather than a fallback.
+ * `napi.wasm.optionalDependency` overrides the default in both directions.
+ *
+ * See https://github.com/rolldown/rolldown/issues/10556
+ */
+export function resolveRootOptionalDependencies({
+  existing,
+  managedPackageNames,
+  packageName,
+  targets,
+  version,
+  wasm,
+}: {
+  existing: unknown
+  managedPackageNames: Iterable<string>
+  packageName: string
+  targets: Target[]
+  version: string
+  wasm?: UserNapiConfig['wasm']
+}): Record<string, unknown> {
+  const optionalDependencies: Record<string, unknown> = {
+    ...asRecord(existing),
+  }
+  for (const managedPackageName of managedPackageNames) {
+    for (const suffix of MANAGED_OPTIONAL_DEPENDENCY_SUFFIXES) {
+      delete optionalDependencies[`${managedPackageName}-${suffix}`]
+    }
+  }
+  const declareWasi = wasm?.optionalDependency ?? wasiIsOnlyTarget(targets)
+  for (const target of targets) {
+    if (target.platform === 'wasi' && !declareWasi) {
+      continue
+    }
+    optionalDependencies[`${packageName}-${target.platformArchABI}`] = version
+  }
+  return optionalDependencies
+}
+
 export async function prePublish(userOptions: PrePublishOptions) {
   debug('Receive pre-publish options:')
   debug('  %O', userOptions)
@@ -341,9 +397,6 @@ export async function prePublish(userOptions: PrePublishOptions) {
             rootFacade,
           )
         }
-        const optionalDependencies = {
-          ...asRecord(packageJson.optionalDependencies),
-        }
         const managedPackageNames = new Set([packageName])
         for (const flavorPackage of rootFacadeReconciliation.managedFlavorPackages) {
           for (const suffix of MANAGED_OPTIONAL_DEPENDENCY_SUFFIXES) {
@@ -353,22 +406,19 @@ export async function prePublish(userOptions: PrePublishOptions) {
             }
           }
         }
-        for (const managedPackageName of managedPackageNames) {
-          for (const suffix of MANAGED_OPTIONAL_DEPENDENCY_SUFFIXES) {
-            delete optionalDependencies[`${managedPackageName}-${suffix}`]
-          }
-        }
-        for (const target of targets) {
-          optionalDependencies[`${packageName}-${target.platformArchABI}`] =
-            packageJson.version
-        }
-        const nodeEngine =
-          targets.length > 0 &&
-          targets.every((target) => target.platform === 'wasi')
-            ? restrictWasiNodeEngine(
-                packageJson.engines?.node ?? MINIMUM_WASI_NODE_VERSION,
-              )
-            : undefined
+        const optionalDependencies = resolveRootOptionalDependencies({
+          existing: packageJson.optionalDependencies,
+          managedPackageNames,
+          packageName,
+          targets,
+          version: packageJson.version,
+          wasm,
+        })
+        const nodeEngine = wasiIsOnlyTarget(targets)
+          ? restrictWasiNodeEngine(
+              packageJson.engines?.node ?? MINIMUM_WASI_NODE_VERSION,
+            )
+          : undefined
         const rootReleasePlan: RootReleaseMaterializationPlan = {
           packageJson: reconciledPackageJson,
           optionalDependencies,

--- a/cli/src/utils/config.ts
+++ b/cli/src/utils/config.ts
@@ -83,7 +83,7 @@ export interface UserNapiConfig {
      * the environments that need it.
      *
      * When WASI is the only configured target it is the primary artifact and is
-     * always declared.
+     * declared by default.
      *
      * Set this explicitly to override either default.
      *

--- a/cli/src/utils/config.ts
+++ b/cli/src/utils/config.ts
@@ -73,9 +73,28 @@ export interface UserNapiConfig {
     maximumMemory?: number
 
     /**
+     * Whether the generated `<packageName>-wasm32-wasi` package is declared as
+     * an `optionalDependency` of the root package.
+     *
+     * When native targets are configured the WASI package is a fallback for
+     * hosts that cannot load a `.node` binary, so declaring it would make every
+     * consumer download the `.wasm` binary they will never load. It is
+     * therefore omitted by default and is expected to be installed on demand by
+     * the environments that need it.
+     *
+     * When WASI is the only configured target it is the primary artifact and is
+     * always declared.
+     *
+     * Set this explicitly to override either default.
+     *
+     * @default true when every configured target is WASI, false otherwise
+     */
+    optionalDependency?: boolean
+
+    /**
      * Browser wasm binding configuration
      */
-    browser: {
+    browser?: {
       /**
        * Whether to use fs module in browser
        */


### PR DESCRIPTION
Fixes the regression reported in https://github.com/rolldown/rolldown/issues/10556.

## Problem

#3353 stopped emitting `cpu: ["wasm32"]` for generated WASI packages. That part is correct. A WASI module runs inside an ordinary host process, `process.arch` is never `wasm32`, and the field only ever worked as an always-false predicate that made npm refuse a direct install with `EBADPLATFORM`.

The problem is that `pre-publish` still declares the WASI package in the root package's `optionalDependencies`, and `cpu` was the only thing stopping that entry from resolving. Removing the gate without removing the entry flips the WASI package from "never installed" to "always installed". npm evaluates every `optionalDependencies` entry independently, so there is no way to express "install this one only when nothing else matched". Every consumer now downloads a `.wasm` binary the generated loader will never reach, because it prefers the native addon npm already installed alongside it.

For rolldown this doubled the install on every supported platform, 16 MB to 35 MB on `darwin-arm64`.

The middle ground the removal was reaching for does not exist in npm's metadata model. An `optionalDependency` is best-effort-install, not install-on-demand. When native targets exist the WASI package is a fallback, and which artifact wins is decided at require time by the generated binding loader, not at install time by npm. So the two halves have to move together: dropping `cpu` is only safe if the entry is dropped too.

## Reproduction

rolldown 1.2.0 was published with `@napi-rs/cli` 3.7.3 and 1.2.1 with 3.8.0, so the two releases isolate this change.

```json
{
  "name": "repro",
  "devDependencies": {
    "rolldown": "1.2.1"
  }
}
```

```sh
npm install
ls node_modules/@rolldown
```

`binding-wasm32-wasi` is installed next to the native `binding-darwin-arm64`, 10 MB of `.wasm` the loader never reaches. Pinning `1.2.0` instead installs only the native package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configuration support to control whether WASI packages are installed as optional dependencies.
  - WASI-only setups include the WASI package automatically, while mixed native/WASI setups omit it by default.
  - WASI browser configuration is now optional.

- **Bug Fixes**
  - Improved optional dependency reconciliation while preserving unrelated existing dependencies.

- **Documentation**
  - Documented WASI package installation behavior and available configuration overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->