### PR TITLE
fix(backend): keep the namespace when resolving cross-namespace type references

### DIFF
--- a/crates/backend/src/typegen.rs
+++ b/crates/backend/src/typegen.rs
@@ -39,7 +39,11 @@ thread_local! {
   static ALIAS: RefCell<HashMap<String, String>> = Default::default();
 }
 
-fn add_alias(name: String, alias: String) {
+fn add_alias(name: String, alias: String, js_mod: Option<&str>) {
+  let alias = match js_mod {
+    Some(js_mod) => format!("{js_mod}.{alias}"),
+    None => alias,
+  };
   ALIAS.with(|aliases| {
     aliases.borrow_mut().insert(name, alias);
   });
@@ -806,9 +810,11 @@ fn handle_type_path(
     } else if rust_ty == "FnArgs" {
       is_passthrough_type = true;
       Some(args.first().unwrap().to_owned())
-    } else if let Some(t) = crate::typegen::r#struct::CLASS_STRUCTS
-      .with(|c| c.borrow_mut().get(rust_ty.as_str()).cloned())
-    {
+    } else if let Some(t) = crate::typegen::r#struct::CLASS_STRUCTS.with(|c| {
+      c.borrow_mut()
+        .get(rust_ty.as_str())
+        .map(|c| c.qualified_name())
+    }) {
       Some((t, false))
     } else if let Some(&(known_ty, _, _)) = KNOWN_TYPES.get(rust_ty.as_str()) {
       handle_known_type(&rust_ty, known_ty, args, is_return_ty)
@@ -916,8 +922,8 @@ pub fn ty_to_ts_type(
 #[cfg(test)]
 mod tests {
   use super::{
-    escape_json, format_js_property_name, ty_to_ts_type, JSDoc, TypeDef,
-    BUFFER_TYPE_IMPORT_MARKER_BASE, BUFFER_TYPE_IMPORT_SENTINEL,
+    add_alias, escape_json, format_js_property_name, handle_generic_type, ty_to_ts_type, JSDoc,
+    TypeDef, BUFFER_TYPE_IMPORT_MARKER_BASE, BUFFER_TYPE_IMPORT_SENTINEL,
   };
 
   #[test]
@@ -1015,9 +1021,13 @@ mod tests {
   #[test]
   fn user_class_named_buffer_precedes_the_builtin_buffer_mapping() {
     crate::typegen::r#struct::CLASS_STRUCTS.with(|classes| {
-      classes
-        .borrow_mut()
-        .insert("Buffer".to_owned(), "UserBuffer".to_owned());
+      classes.borrow_mut().insert(
+        "Buffer".to_owned(),
+        crate::typegen::r#struct::ClassStructRef {
+          js_name: "UserBuffer".to_owned(),
+          js_mod: None,
+        },
+      );
     });
     let ty = syn::parse_str("Buffer").expect("Buffer must parse as a Rust type");
     assert_eq!(
@@ -1027,6 +1037,64 @@ mod tests {
     crate::typegen::r#struct::CLASS_STRUCTS.with(|classes| {
       classes.borrow_mut().clear();
     });
+  }
+
+  #[test]
+  fn class_reference_across_namespaces_keeps_namespace_qualifier() {
+    // Regression test for napi-rs/napi-rs#3406 (symptom 2): a function
+    // referencing a namespaced class resolved to the bare `js_name`,
+    // dropping the namespace. Two classes sharing a `js_name` in different
+    // namespaces ("alpha"/"beta") must each resolve to their own
+    // `<namespace>.<js_name>`, not a dangling unqualified name.
+    crate::typegen::r#struct::CLASS_STRUCTS.with(|classes| {
+      let mut classes = classes.borrow_mut();
+      classes.insert(
+        "AlphaClient".to_owned(),
+        crate::typegen::r#struct::ClassStructRef {
+          js_name: "Client".to_owned(),
+          js_mod: Some("alpha".to_owned()),
+        },
+      );
+      classes.insert(
+        "BetaClient".to_owned(),
+        crate::typegen::r#struct::ClassStructRef {
+          js_name: "Client".to_owned(),
+          js_mod: Some("beta".to_owned()),
+        },
+      );
+    });
+
+    let alpha_ty: syn::Type = syn::parse_str("AlphaClient").expect("AlphaClient must parse");
+    let beta_ty: syn::Type = syn::parse_str("BetaClient").expect("BetaClient must parse");
+
+    assert_eq!(
+      ty_to_ts_type(&alpha_ty, false, false, false),
+      ("alpha.Client".to_owned(), false)
+    );
+    assert_eq!(
+      ty_to_ts_type(&beta_ty, false, false, false),
+      ("beta.Client".to_owned(), false)
+    );
+
+    crate::typegen::r#struct::CLASS_STRUCTS.with(|classes| classes.borrow_mut().clear());
+  }
+
+  #[test]
+  fn non_class_alias_across_namespaces_keeps_namespace_qualifier() {
+    // Same underlying bug as #3406, but for the ALIAS-map path that enums,
+    // consts, and type aliases resolve through (CLASS_STRUCTS only covers
+    // classes/structs).
+    add_alias("AlphaStatus".to_owned(), "Status".to_owned(), Some("alpha"));
+    add_alias("BetaStatus".to_owned(), "Status".to_owned(), Some("beta"));
+
+    assert_eq!(
+      handle_generic_type("AlphaStatus", &[]),
+      Some(("alpha.Status".to_owned(), false))
+    );
+    assert_eq!(
+      handle_generic_type("BetaStatus", &[]),
+      Some(("beta.Status".to_owned(), false))
+    );
   }
 
   #[test]

--- a/crates/backend/src/typegen.rs
+++ b/crates/backend/src/typegen.rs
@@ -39,6 +39,10 @@ thread_local! {
   static ALIAS: RefCell<HashMap<String, String>> = Default::default();
 }
 
+/// Registers `name` (a Rust type identifier) as an alias for `alias` (its JS
+/// name), qualified by `js_mod` when the item was declared in a namespace, so
+/// later lookups by Rust identifier resolve to a reference that's valid from
+/// outside that namespace too.
 fn add_alias(name: String, alias: String, js_mod: Option<&str>) {
   let alias = match js_mod {
     Some(js_mod) => format!("{js_mod}.{alias}"),

--- a/crates/backend/src/typegen/const.rs
+++ b/crates/backend/src/typegen/const.rs
@@ -12,7 +12,11 @@ impl ToTypeDef for NapiConst {
       return None;
     }
 
-    add_alias(self.name.to_string(), self.js_name.to_string());
+    add_alias(
+      self.name.to_string(),
+      self.js_name.to_string(),
+      self.js_mod.as_deref(),
+    );
 
     Some(TypeDef {
       kind: "const".to_owned(),

--- a/crates/backend/src/typegen/enum.rs
+++ b/crates/backend/src/typegen/enum.rs
@@ -7,7 +7,11 @@ impl ToTypeDef for NapiEnum {
       return None;
     }
 
-    add_alias(self.name.to_string(), self.js_name.to_string());
+    add_alias(
+      self.name.to_string(),
+      self.js_name.to_string(),
+      self.js_mod.as_deref(),
+    );
 
     Some(TypeDef {
       kind: if self.is_string_enum {

--- a/crates/backend/src/typegen/fn.rs
+++ b/crates/backend/src/typegen/fn.rs
@@ -321,7 +321,7 @@ impl NapiFn {
         .map(|i| {
           let origin_name = i.to_string();
           let parent = CLASS_STRUCTS
-            .with_borrow(|c| c.get(&origin_name).cloned())
+            .with_borrow(|c| c.get(&origin_name).map(|c| c.js_name.clone()))
             .unwrap_or_else(|| to_case(origin_name, Case::Pascal));
 
           if self.is_async {

--- a/crates/backend/src/typegen/struct.rs
+++ b/crates/backend/src/typegen/struct.rs
@@ -7,16 +7,45 @@ use crate::{typegen::JSDoc, util::to_case, NapiImpl, NapiStruct, NapiStructField
 
 thread_local! {
   pub(crate) static TASK_STRUCTS: RefCell<HashMap<String, String>> = Default::default();
-  pub(crate) static CLASS_STRUCTS: RefCell<HashMap<String, String>> = Default::default();
+  pub(crate) static CLASS_STRUCTS: RefCell<HashMap<String, ClassStructRef>> = Default::default();
+}
+
+/// A registered `#[napi]` class's JS name plus the namespace it was declared
+/// in, so lookups elsewhere (cross-references to the class from other type
+/// positions) can rebuild a namespace-qualified reference instead of the
+/// bare `js_name`, which would be ambiguous or dangling once two classes in
+/// different namespaces share a `js_name`.
+#[derive(Clone)]
+pub(crate) struct ClassStructRef {
+  pub(crate) js_name: String,
+  pub(crate) js_mod: Option<String>,
+}
+
+impl ClassStructRef {
+  pub(crate) fn qualified_name(&self) -> String {
+    match &self.js_mod {
+      Some(js_mod) => format!("{js_mod}.{}", self.js_name),
+      None => self.js_name.clone(),
+    }
+  }
 }
 
 impl ToTypeDef for NapiStruct {
   fn to_type_def(&self) -> Option<TypeDef> {
     CLASS_STRUCTS.with(|c| {
-      c.borrow_mut()
-        .insert(self.name.to_string(), self.js_name.clone());
+      c.borrow_mut().insert(
+        self.name.to_string(),
+        ClassStructRef {
+          js_name: self.js_name.clone(),
+          js_mod: self.js_mod.clone(),
+        },
+      );
     });
-    add_alias(self.name.to_string(), self.js_name.to_string());
+    add_alias(
+      self.name.to_string(),
+      self.js_name.to_string(),
+      self.js_mod.as_deref(),
+    );
 
     let mut js_doc = JSDoc::new(&self.comments);
     if self.is_generator {

--- a/crates/backend/src/typegen/struct.rs
+++ b/crates/backend/src/typegen/struct.rs
@@ -22,6 +22,8 @@ pub(crate) struct ClassStructRef {
 }
 
 impl ClassStructRef {
+  /// Renders the class's JS name qualified by its namespace (`{js_mod}.{js_name}`),
+  /// or the bare `js_name` when it has none.
   pub(crate) fn qualified_name(&self) -> String {
     match &self.js_mod {
       Some(js_mod) => format!("{js_mod}.{}", self.js_name),

--- a/crates/backend/src/typegen/type.rs
+++ b/crates/backend/src/typegen/type.rs
@@ -12,7 +12,11 @@ impl ToTypeDef for NapiType {
       return None;
     }
 
-    add_alias(self.name.to_string(), self.js_name.to_string());
+    add_alias(
+      self.name.to_string(),
+      self.js_name.to_string(),
+      self.js_mod.as_deref(),
+    );
 
     Some(TypeDef {
       kind: "type".to_owned(),


### PR DESCRIPTION
Fixes #3406.

The issue's write-up pointed at the `ALIAS` map (`typegen.rs` / `handle_generic_type`), but tracing it further, `CLASS_STRUCTS` is actually what resolves a class reference in a function arg/return type or struct field — it's checked before `ALIAS`/`KNOWN_TYPES` in `handle_type_path`, and it also only stores the bare `js_name` with no namespace. So `AlphaClient` and `BetaClient` (both `js_name = "Client"`, different namespaces) are each retrievable fine by their own Rust identifier, but both resolve to the same unqualified `"Client"` string — which can't be correct for both call sites, and produces the dangling top-level reference described in the issue.

This namespace-qualifies both maps:
- `CLASS_STRUCTS` now stores a small `ClassStructRef { js_name, js_mod }` instead of a bare `String`, and the `handle_type_path` lookup renders it as `{js_mod}.{js_name}` when namespaced. The one place that wants the bare name — a factory method's return type, self-referencing its own class from inside that class's own body — still asks for `.js_name` directly, so that unqualified (and correct) self-reference is unaffected.
- `add_alias` takes the same `js_mod` and qualifies the stored alias, since enums/consts/type-aliases never touch `CLASS_STRUCTS` and resolve through `ALIAS` instead — same bug, same fix, for the paths the issue's repro didn't happen to exercise.

Symptom 1 (the `classDefs` merge collision in `cli/src/utils/typegen.ts`) looks like it's already fixed on `main` — `preprocessTypeDef` keys `classDefs` by `${namespace}\0${def.name}` now, not the bare name — so this PR only covers symptom 2.

Added two regression tests in `crates/backend/src/typegen.rs` covering both paths (`class_reference_across_namespaces_keeps_namespace_qualifier` for `CLASS_STRUCTS`, `non_class_alias_across_namespaces_keeps_namespace_qualifier` for `ALIAS`), plus updated the existing `user_class_named_buffer_precedes_the_builtin_buffer_mapping` test for the new `ClassStructRef` shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated type definitions for classes, constants, enums, and aliases in namespaced JavaScript modules.
  * Preserved module-qualified class names during type resolution.
  * Improved factory return types by using the correct JavaScript class names.
  * Ensured aliases retain their associated module qualification.
* **Tests**
  * Added coverage for namespaced classes and non-class aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->