### PR TITLE
fix(wasi): avoid randomness during module registration

### DIFF
--- a/crates/napi/src/bindgen_runtime/module_register.rs
+++ b/crates/napi/src/bindgen_runtime/module_register.rs
@@ -375,7 +375,9 @@ pub unsafe extern "C" fn napi_register_module_v1(
   #[cfg(feature = "napi4")]
   create_custom_gc(env);
 
-  let mut exports_objects: HashSet<String> = HashSet::default();
+  // Registration keys are compile-time strings. Avoid `RandomState` so WASI module
+  // registration does not request randomness during workerd global initialization.
+  let mut exports_objects: HashSet<String, FxBuildHasher> = HashSet::with_hasher(FxBuildHasher);
 
   {
     let mut register_callback = MODULE_REGISTER_CALLBACK
@@ -384,7 +386,11 @@ pub unsafe extern "C" fn napi_register_module_v1(
     register_callback
       .iter_mut()
       .fold(
-        HashMap::<Option<&'static str>, Vec<(&'static str, ExportRegisterCallback)>>::new(),
+        HashMap::<
+          Option<&'static str>,
+          Vec<(&'static str, ExportRegisterCallback)>,
+          FxBuildHasher,
+        >::with_hasher(FxBuildHasher),
         |mut acc, (js_mod, item)| {
           if let Some(k) = acc.get_mut(js_mod) {
             k.push(*item);

--- a/examples/custom-async-runtime/Cargo.toml
+++ b/examples/custom-async-runtime/Cargo.toml
@@ -18,6 +18,7 @@ napi = { path = "../../crates/napi", default-features = false, features = [
   "napi4",
 ] }
 napi-derive = { path = "../../crates/macro", features = ["type-def"] }
+rustc-hash = "2"
 
 [build-dependencies]
 napi-build = { path = "../../crates/build" }

--- a/examples/custom-async-runtime/src/lib.rs
+++ b/examples/custom-async-runtime/src/lib.rs
@@ -1,5 +1,5 @@
 use std::{
-  collections::{HashMap, VecDeque},
+  collections::VecDeque,
   future::Future,
   pin::Pin,
   sync::{
@@ -28,6 +28,7 @@ use napi::bindgen_prelude::{
   JsValue, Object, PromiseRaw, Result, Status, Unknown,
 };
 use napi_derive::napi;
+use rustc_hash::FxHashMap;
 
 static RUNTIME_STATE: OnceLock<Arc<RuntimeState>> = OnceLock::new();
 static RUNTIME_REGISTRATION: Once = Once::new();
@@ -48,7 +49,7 @@ const THREADLESS_WASI_BLOCKING_UNSUPPORTED: &str =
 #[derive(Default)]
 struct SchedulerState {
   queue: VecDeque<Arc<Task>>,
-  tasks: HashMap<usize, Arc<Task>>,
+  tasks: FxHashMap<usize, Arc<Task>>,
   task_refs: Vec<Weak<Task>>,
   block_on_refs: Vec<Weak<BlockOnWaker>>,
   accepting: bool,

--- a/examples/custom-async-runtime/workerd/worker.mjs
+++ b/examples/custom-async-runtime/workerd/worker.mjs
@@ -4,16 +4,14 @@
 import wasmModule from '@examples/custom-async-runtime/wasm.wasm'
 import { dispose, instantiate } from '@examples/custom-async-runtime/workerd'
 
-// Instantiate lazily inside the handler, memoized across requests. Kicking it
-// off at top level fails on workerd with "Disallowed operation called within
-// global scope": the WASI/emnapi init path needs capabilities (e.g. random
-// values) that workerd only grants inside a handler.
-let apiPromise
+// Exercise module-scope initialization, which is required by root-package
+// `workerd` conditions that expose synchronous binding functions.
+let apiPromise = instantiate(wasmModule)
+await apiPromise
 
 export default {
   async fetch(request) {
     try {
-      apiPromise ??= instantiate(wasmModule)
       const api = await apiPromise
       if (new URL(request.url).pathname === '/dispose-reload') {
         // The minimal SPI base ships no env-cleanup preparation hook, so


### PR DESCRIPTION
Use deterministic hashers during N-API module registration. WASI's randomized hasher calls `random_get`, which Workerd rejects during global initialization.

Cover module-scope initialization in the custom async runtime Workerd fixture.

Validated with `cargo test -p napi --lib` and the `wasm32-wasip1` Workerd test.

AI assistance: Codex was used to implement and validate this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module initialization in WASI and workerd environments by avoiding runtime randomness requirements.
  * Ensured the WebAssembly API is initialized before request handling begins, improving first-request reliability.

* **Examples**
  * Updated the custom async runtime example to use a deterministic hash map for scheduler state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->