### PR TITLE
fix(cli): support npm 12 pack output

### DIFF
--- a/cli/src/api/__tests__/pre-publish.spec.ts
+++ b/cli/src/api/__tests__/pre-publish.spec.ts
@@ -1,6 +1,9 @@
 import test from 'ava'
 
-import { resolveRootOptionalDependencies } from '../pre-publish.js'
+import {
+  parseNpmPackFiles,
+  resolveRootOptionalDependencies,
+} from '../pre-publish.js'
 import { parseTriple } from '../../utils/index.js'
 
 const PACKAGE_NAME = '@scope/pkg'
@@ -103,4 +106,36 @@ test('preserves unmanaged optionalDependencies', (t) => {
       ...NATIVE_ENTRIES,
     },
   )
+})
+
+const NPM_PACK_FILES = [
+  { path: './package.json' },
+  { path: 'dist\\index.js' },
+  { path: 42 },
+]
+
+test('parses npm 11 pack JSON output', (t) => {
+  t.deepEqual(
+    [...parseNpmPackFiles(JSON.stringify([{ files: NPM_PACK_FILES }]))],
+    ['package.json', 'dist/index.js'],
+  )
+})
+
+test('parses npm 12 pack JSON output', (t) => {
+  t.deepEqual(
+    [
+      ...parseNpmPackFiles(
+        JSON.stringify({
+          [PACKAGE_NAME]: { files: NPM_PACK_FILES },
+        }),
+      ),
+    ],
+    ['package.json', 'dist/index.js'],
+  )
+})
+
+test('rejects an unexpected npm pack JSON result', (t) => {
+  t.throws(() => parseNpmPackFiles(JSON.stringify({ files: [] })), {
+    message: 'npm pack returned an unexpected JSON result',
+  })
 })

--- a/cli/src/api/pre-publish.ts
+++ b/cli/src/api/pre-publish.ts
@@ -1691,24 +1691,30 @@ function readNpmPackFiles(packageDir: string, packageDescription: string) {
       maxBuffer: 64 * 1024 * 1024,
       stdio: ['ignore', 'pipe', 'pipe'],
     })
-    const packResult = JSON.parse(output) as {
-      files?: { path?: unknown }[]
-    }[]
-    if (!Array.isArray(packResult) || !Array.isArray(packResult[0]?.files)) {
-      throw new Error('npm pack returned an unexpected JSON result')
-    }
-    return new Set(
-      packResult[0].files
-        .map(({ path }) => path)
-        .filter((path): path is string => typeof path === 'string')
-        .map((path) => path.replaceAll('\\', '/').replace(/^\.\//, '')),
-    )
+    return parseNpmPackFiles(output)
   } catch (error) {
     throw new Error(
       `Failed to validate the ${packageDescription} with npm pack --dry-run. Ensure npm is available and the package can be packed.`,
       { cause: error },
     )
   }
+}
+
+export function parseNpmPackFiles(output: string) {
+  const parsedResult: unknown = JSON.parse(output)
+  const packResults = Array.isArray(parsedResult)
+    ? parsedResult
+    : Object.values(asRecord(parsedResult) ?? {})
+  const files = asRecord(packResults[0])?.files
+  if (!Array.isArray(files)) {
+    throw new Error('npm pack returned an unexpected JSON result')
+  }
+  return new Set(
+    files
+      .map((file) => asRecord(file)?.path)
+      .filter((path): path is string => typeof path === 'string')
+      .map((path) => path.replaceAll('\\', '/').replace(/^\.\//, '')),
+  )
 }
 
 function validateRootFacadePacklist(


### PR DESCRIPTION
## Summary

- support both npm 11 array results and npm 12 package-keyed results from `npm pack --dry-run --json`
- preserve the existing pack-file validation and path normalization
- add regression coverage for npm 11, npm 12, and malformed JSON result shapes

## Root cause

npm 12 changed the JSON result shape for scoped packages from an array to an object keyed by package name. The pre-publish validator assumed the npm 11 array shape, so it rejected a valid pack result and surfaced a generic package validation error.

## Impact

Projects can run `napi pre-publish` with npm 12 without failing while validating release packages.

## Validation

- `yarn workspace @napi-rs/cli test` — 153 tests passed
- `yarn lint`
- `yarn prettier --check cli/src/api/pre-publish.ts cli/src/api/__tests__/pre-publish.spec.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to CLI pack JSON parsing with regression tests; no auth, security, or publish semantics beyond fixing false validation failures on npm 12.
> 
> **Overview**
> **`napi pre-publish`** no longer fails when **`npm pack --dry-run --json`** returns npm 12’s object shape (package name → `{ files }`) instead of npm 11’s top-level array.
> 
> Parsing is moved into exported **`parseNpmPackFiles`**, which accepts either shape, still normalizes paths (backslashes, `./` prefix), and ignores non-string `path` entries. **`readNpmPackFiles`** delegates to it, so root packlist checks, legacy deep-import export generation, and release-package validation behave the same on both npm versions.
> 
> Tests cover npm 11 JSON, npm 12 scoped-package JSON, and malformed results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a87ed9237a6d0b232e7cf4ddad52d27eba14e48a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package file detection across npm 11 and npm 12 output formats.
  * Normalized file paths consistently across platforms.
  * Ignored malformed file entries and provided clearer errors for unexpected package results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->