### PR TITLE
fix(cli): compatible with emnapi v1 & v2

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -63,11 +63,10 @@
   "dependencies": {
     "@inquirer/prompts": "^8.5.2",
     "@napi-rs/cross-toolchain": "^1.0.3",
-    "@napi-rs/wasm-tools": "^1.0.1",
+    "@napi-rs/wasm-tools": "^1.1.0",
     "@octokit/rest": "^22.0.1",
     "clipanion": "^4.0.0-rc.4",
     "colorette": "^2.0.20",
-    "emnapi": "2.0.0-alpha.4",
     "es-toolkit": "^1.47.0",
     "js-yaml": "^4.2.0",
     "obug": "^2.1.2",
@@ -76,7 +75,8 @@
     "typescript": "^6.0.3"
   },
   "devDependencies": {
-    "@emnapi/runtime": "2.0.0-alpha.4",
+    "@emnapi/core": "^2.0.0-alpha.4",
+    "@emnapi/runtime": "^2.0.0-alpha.4",
     "@oxc-node/core": "^0.1.0",
     "@std/toml": "npm:@jsr/std__toml@^1.0.11",
     "@types/inquirer": "^9.0.9",
@@ -84,6 +84,7 @@
     "@types/node": "^25.9.2",
     "@types/semver": "^7.7.1",
     "ava": "^8.0.1",
+    "emnapi": "^2.0.0-alpha.4",
     "empathic": "^2.0.1",
     "env-paths": "^4.0.0",
     "oxc-parser": "^0.144.0",
@@ -92,10 +93,18 @@
     "tslib": "^2.8.1"
   },
   "peerDependencies": {
-    "@emnapi/runtime": "2.0.0-alpha.4"
+    "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+    "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4",
+    "emnapi": "^1.7.1 || ^2.0.0-alpha.4"
   },
   "peerDependenciesMeta": {
+    "@emnapi/core": {
+      "optional": true
+    },
     "@emnapi/runtime": {
+      "optional": true
+    },
+    "emnapi": {
       "optional": true
     }
   },

--- a/examples/napi/package.json
+++ b/examples/napi/package.json
@@ -74,7 +74,7 @@
     "timeout": "10m"
   },
   "dependencies": {
-    "@emnapi/core": "2.0.0-alpha.4",
-    "@emnapi/runtime": "2.0.0-alpha.4"
+    "@emnapi/core": "^2.0.0-alpha.4",
+    "@emnapi/runtime": "^2.0.0-alpha.4"
   }
 }

--- a/examples/shared-async-runtime/package.json
+++ b/examples/shared-async-runtime/package.json
@@ -21,7 +21,7 @@
     "@napi-rs/wasm-runtime": "workspace:*"
   },
   "dependencies": {
-    "@emnapi/core": "2.0.0-alpha.4",
-    "@emnapi/runtime": "2.0.0-alpha.4"
+    "@emnapi/core": "^2.0.0-alpha.4",
+    "@emnapi/runtime": "^2.0.0-alpha.4"
   }
 }

--- a/wasm-runtime/package.json
+++ b/wasm-runtime/package.json
@@ -29,7 +29,7 @@
     "dist/*.js"
   ],
   "devDependencies": {
-    "@emnapi/core": "2.0.0-alpha.4",
+    "@emnapi/core": "^2.0.0-alpha.4",
     "buffer": "^6.0.3",
     "events": "^3.3.0",
     "memfs": "^4.64.0",
@@ -44,8 +44,8 @@
     "@tybys/wasm-util": "^0.10.3"
   },
   "peerDependencies": {
-    "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
-    "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
+    "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+    "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
   },
   "scripts": {
     "build": "rolldown -c",

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,8 +401,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/napi@workspace:examples/napi"
   dependencies:
-    "@emnapi/core": "npm:2.0.0-alpha.4"
-    "@emnapi/runtime": "npm:2.0.0-alpha.4"
+    "@emnapi/core": "npm:^2.0.0-alpha.4"
+    "@emnapi/runtime": "npm:^2.0.0-alpha.4"
     "@napi-rs/cli": "workspace:*"
     "@napi-rs/triples": "workspace:*"
     "@napi-rs/wasm-runtime": "workspace:*"
@@ -436,8 +436,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/shared-async-runtime@workspace:examples/shared-async-runtime"
   dependencies:
-    "@emnapi/core": "npm:2.0.0-alpha.4"
-    "@emnapi/runtime": "npm:2.0.0-alpha.4"
+    "@emnapi/core": "npm:^2.0.0-alpha.4"
+    "@emnapi/runtime": "npm:^2.0.0-alpha.4"
     "@napi-rs/async-runtime": "workspace:*"
     "@napi-rs/cli": "workspace:*"
     "@napi-rs/wasm-runtime": "workspace:*"
@@ -1589,10 +1589,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@napi-rs/cli@workspace:cli"
   dependencies:
-    "@emnapi/runtime": "npm:2.0.0-alpha.4"
+    "@emnapi/core": "npm:^2.0.0-alpha.4"
+    "@emnapi/runtime": "npm:^2.0.0-alpha.4"
     "@inquirer/prompts": "npm:^8.5.2"
     "@napi-rs/cross-toolchain": "npm:^1.0.3"
-    "@napi-rs/wasm-tools": "npm:^1.0.1"
+    "@napi-rs/wasm-tools": "npm:^1.1.0"
     "@octokit/rest": "npm:^22.0.1"
     "@oxc-node/core": "npm:^0.1.0"
     "@std/toml": "npm:@jsr/std__toml@^1.0.11"
@@ -1603,7 +1604,7 @@ __metadata:
     ava: "npm:^8.0.1"
     clipanion: "npm:^4.0.0-rc.4"
     colorette: "npm:^2.0.20"
-    emnapi: "npm:2.0.0-alpha.4"
+    emnapi: "npm:^2.0.0-alpha.4"
     empathic: "npm:^2.0.1"
     env-paths: "npm:^4.0.0"
     es-toolkit: "npm:^1.47.0"
@@ -1617,9 +1618,15 @@ __metadata:
     typanion: "npm:^3.14.0"
     typescript: "npm:^6.0.3"
   peerDependencies:
-    "@emnapi/runtime": 2.0.0-alpha.4
+    "@emnapi/core": ^1.7.1 || ^2.0.0-alpha.4
+    "@emnapi/runtime": ^1.7.1 || ^2.0.0-alpha.4
+    emnapi: ^1.7.1 || ^2.0.0-alpha.4
   peerDependenciesMeta:
+    "@emnapi/core":
+      optional: true
     "@emnapi/runtime":
+      optional: true
+    emnapi:
       optional: true
   bin:
     napi: ./dist/cli.js
@@ -2052,7 +2059,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@napi-rs/wasm-runtime@workspace:wasm-runtime"
   dependencies:
-    "@emnapi/core": "npm:2.0.0-alpha.4"
+    "@emnapi/core": "npm:^2.0.0-alpha.4"
     "@tybys/wasm-util": "npm:^0.10.3"
     buffer: "npm:^6.0.3"
     events: "npm:^3.3.0"
@@ -2064,8 +2071,8 @@ __metadata:
     rolldown: "npm:^1.2.1"
     tslib: "npm:^2.8.1"
   peerDependencies:
-    "@emnapi/core": ^1.7.1 || ^2.0.0-alpha.3
-    "@emnapi/runtime": ^1.7.1 || ^2.0.0-alpha.3
+    "@emnapi/core": ^1.7.1 || ^2.0.0-alpha.4
+    "@emnapi/runtime": ^1.7.1 || ^2.0.0-alpha.4
   languageName: unknown
   linkType: soft
 
@@ -2164,7 +2171,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/wasm-tools@npm:^1.0.1":
+"@napi-rs/wasm-tools@npm:^1.1.0":
   version: 1.1.0
   resolution: "@napi-rs/wasm-tools@npm:1.1.0"
   dependencies:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency and peer-range metadata only; expands compatibility rather than changing runtime behavior. Consumers may see different optional peer resolution, but no auth, data, or core logic is modified.
> 
> **Overview**
> Makes `@napi-rs/cli` and `@napi-rs/wasm-runtime` compatible with **both emnapi v1 and v2** by widening peer dependency ranges to `^1.7.1 || ^2.0.0-alpha.4`.
> 
> In the CLI, `emnapi` moves out of direct dependencies into **optional peerDependencies**, alongside new optional peers for `@emnapi/core` and `@emnapi/runtime`. Exact `2.0.0-alpha.4` pins are relaxed to caret ranges across examples and related packages, and `@napi-rs/wasm-tools` is bumped to `^1.1.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9bf01241437891710a735aead1c9f82dc853cf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated runtime tooling and compatibility requirements.
  * Expanded support for newer runtime releases.
  * Improved flexibility for optional runtime integrations.
  * Relaxed version constraints to allow compatible updates across development tools and example projects.
  * Updated example configurations to work with compatible runtime versions without requiring exact version pins.
  * Improved compatibility for projects using newer alpha releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->