### PR TITLE
refactor(cli): remove unused non-portable __dirname from ESM loader.

### DIFF
--- a/cli/src/api/__tests__/templates.spec.ts
+++ b/cli/src/api/__tests__/templates.spec.ts
@@ -294,3 +294,25 @@ test('createEsmBinding is Node 12 compatible', (t) => {
   t.false(code.includes('?.'), 'ESM loader must not use optional chaining')
   t.false(code.includes('??'), 'ESM loader must not use nullish coalescing')
 })
+
+test('createEsmBinding builds native addon loading on portable ESM primitives', (t) => {
+  const code = createEsmBinding('test', '@scope/test', ['sum'])
+  assertValidJS(t, code, 'esm')
+  t.true(
+    code.includes(`import { createRequire } from 'module'`),
+    'ESM loader must import createRequire so native .node addons can be loaded without the CommonJS `require` global',
+  )
+  t.true(
+    code.includes('const require = createRequire(import.meta.url)'),
+    'ESM loader must derive `require` from the current module, not rely on a CommonJS global',
+  )
+  // `@napi-rs/cli` is a valid Node package but is not running under Deno. Deno
+  // rejects `URL.pathname` treated as a filesystem path, which is exactly how a
+  // `__dirname` built from `new URL('.', import.meta.url).pathname` behaves on
+  // Windows (percent-encoded, forward-slash separated). The ESM native loader
+  // never used `__dirname` anyway, so it must not emit that construct at all.
+  t.false(
+    /new URL\(['"]\.['"], import\.meta\.url\)\.pathname/.test(code),
+    'ESM loader must not treat URL.pathname as a filesystem path',
+  )
+})

--- a/cli/src/api/templates/js-binding.ts
+++ b/cli/src/api/templates/js-binding.ts
@@ -157,7 +157,6 @@ ${idents.map((ident) => `export { ${ident} }`).join('\n')}`
   return `${bindingHeader}
 import { createRequire } from 'module'
 const require = createRequire(import.meta.url)
-const __dirname = new URL('.', import.meta.url).pathname
 
 ${createCommonBinding(
   localName,


### PR DESCRIPTION
## Summary

Remove the unused and non-portable `__dirname` generation from the generated ESM binding loader.

## What changed

The generated ESM loader previously emitted:


const __dirname = new URL('.', import.meta.url).pathname

This value was never used by the generated loader. It also relied on URL.pathname as a filesystem path, which can produce incorrect results across platforms (for example, percent-encoding and Windows path handling).

This change removes the dead code and keeps the loader using the supported ESM pattern:

import { createRequire } from 'module'

const require = createRequire(import.meta.url)

Native .node addons continue to be resolved relative to import.meta.url through createRequire.

Why this change

The ESM loader should avoid generating filesystem paths manually from URLs when they are not required. Removing unused path construction makes the generated output simpler and avoids carrying a potentially incorrect path conversion pattern into downstream packages.

Compatibility

CommonJS output is unchanged.

Native addon loading behavior is unchanged.

Platform/architecture detection is unchanged.

WASI loading behavior is unchanged.


Tests

Added a regression test to ensure generated ESM bindings:

use createRequire(import.meta.url) for native addon loading;

do not emit new URL('.', import.meta.url).pathname as a filesystem path.


Notes

This change is a portability cleanup of generated ESM output. It does not add new runtime behavior; the loader continues to rely on existing ESM-compatible native addon loading primitives.