### PR TITLE
chore(napi): keep anyhow error cause when converting

### DIFF
--- a/crates/napi/src/error.rs
+++ b/crates/napi/src/error.rs
@@ -1273,7 +1273,21 @@ fn clear_pending_exception(env: sys::napi_env) {
 #[cfg(feature = "anyhow")]
 impl From<anyhow::Error> for Error {
   fn from(value: anyhow::Error) -> Self {
-    Error::new(Status::GenericFailure, format!("{:?}", value))
+    let mut chain = value.chain();
+
+    let mut error = Error::new(Status::GenericFailure, chain.next().unwrap().to_string());
+
+    let mut current = &mut error;
+
+    for cause in chain {
+      current.cause = Some(Box::new(Error::new(
+        Status::GenericFailure,
+        cause.to_string(),
+      )));
+      current = current.cause.as_deref_mut().unwrap();
+    }
+
+    error
   }
 }
 

--- a/crates/napi/src/error.rs
+++ b/crates/napi/src/error.rs
@@ -1542,7 +1542,7 @@ pub struct JsError<S: AsRef<str> = Status>(Error<S>);
 #[cfg(feature = "anyhow")]
 impl From<anyhow::Error> for JsError {
   fn from(value: anyhow::Error) -> Self {
-    JsError(Error::new(Status::GenericFailure, value.to_string()))
+    JsError(Error::from(value))
   }
 }
 


### PR DESCRIPTION
This makes the `cause` be added to napi::Error and napi::JsError when converting from anyhow errors.

Napi currently has an inconsistency where one of the conversions includes the causes in the error message, while the other does not. With this PR, causes only appear in the `cause` property, not in the `message`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages by preserving the full chain of underlying causes.
  * JavaScript errors now expose structured cause information instead of combining all details into a single text message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->