### PR TITLE
fix(macro): recognize fully-qualified napi::Env as the special Env parameter

### DIFF
--- a/crates/backend/src/codegen/fn.rs
+++ b/crates/backend/src/codegen/fn.rs
@@ -679,8 +679,10 @@ impl NapiFn {
             }
           }
         } else {
-          if let syn::Type::Path(ele) = &*elem {
-            if let Some(syn::PathSegment { ident, .. }) = ele.path.segments.last() {
+          // `qself: None` keeps qualified-self paths like `&<T as Trait>::Env`
+          // on the normal `FromNapiRef` extraction path, matching typegen.
+          if let syn::Type::Path(syn::TypePath { qself: None, path }) = &*elem {
+            if let Some(syn::PathSegment { ident, .. }) = path.segments.last() {
               if ident == "Env" {
                 return Ok((quote! {}, NapiArgType::Env));
               } else if ident == "str" {

--- a/crates/backend/src/codegen/fn.rs
+++ b/crates/backend/src/codegen/fn.rs
@@ -449,7 +449,16 @@ impl NapiFn {
 
       match &arg.kind {
         NapiFnArgKind::PatType(pat_type) => {
-          if &pat_type.ty.to_token_stream().to_string() == "Env" {
+          let is_env_type = if let syn::Type::Path(syn::TypePath {
+            path: syn::Path { segments, .. },
+            ..
+          }) = pat_type.ty.as_ref()
+          {
+            segments.last().is_some_and(|s| s.ident == "Env")
+          } else {
+            false
+          };
+          if is_env_type {
             args.push(quote! { __wrapped_env });
             skipped_arg_count += 1;
           } else {

--- a/crates/backend/src/codegen/fn.rs
+++ b/crates/backend/src/codegen/fn.rs
@@ -450,8 +450,8 @@ impl NapiFn {
       match &arg.kind {
         NapiFnArgKind::PatType(pat_type) => {
           let is_env_type = if let syn::Type::Path(syn::TypePath {
+            qself: None,
             path: syn::Path { segments, .. },
-            ..
           }) = pat_type.ty.as_ref()
           {
             segments.last().is_some_and(|s| s.ident == "Env")

--- a/crates/backend/src/typegen/fn.rs
+++ b/crates/backend/src/typegen/fn.rs
@@ -197,9 +197,14 @@ impl NapiFn {
         .iter()
         .filter_map(|arg| match &arg.kind {
           crate::NapiFnArgKind::PatType(path) => {
-            let ty_string = path.ty.to_token_stream().to_string();
-            if ty_string == "Env" {
-              return None;
+            if let syn::Type::Path(syn::TypePath {
+              path: syn::Path { segments, .. },
+              ..
+            }) = path.ty.as_ref()
+            {
+              if segments.last().is_some_and(|s| s.ident == "Env") {
+                return None;
+              }
             }
             if let syn::Type::Reference(syn::TypeReference { elem, .. }) = &*path.ty {
               if let syn::Type::Path(path) = elem.as_ref() {

--- a/crates/backend/src/typegen/fn.rs
+++ b/crates/backend/src/typegen/fn.rs
@@ -198,8 +198,8 @@ impl NapiFn {
         .filter_map(|arg| match &arg.kind {
           crate::NapiFnArgKind::PatType(path) => {
             if let syn::Type::Path(syn::TypePath {
+              qself: None,
               path: syn::Path { segments, .. },
-              ..
             }) = path.ty.as_ref()
             {
               if segments.last().is_some_and(|s| s.ident == "Env") {
@@ -207,8 +207,8 @@ impl NapiFn {
               }
             }
             if let syn::Type::Reference(syn::TypeReference { elem, .. }) = &*path.ty {
-              if let syn::Type::Path(path) = elem.as_ref() {
-                if let Some(PathSegment { ident, .. }) = path.path.segments.last() {
+              if let syn::Type::Path(syn::TypePath { qself: None, path }) = elem.as_ref() {
+                if let Some(PathSegment { ident, .. }) = path.segments.last() {
                   if ident == "Env" {
                     return None;
                   }

--- a/examples/napi-cargo-test/src/lib.rs
+++ b/examples/napi-cargo-test/src/lib.rs
@@ -5,6 +5,22 @@ pub fn plus(a: i32, b: i32) -> napi::Result<i32> {
   Ok(a + b)
 }
 
+// Regression test for https://github.com/napi-rs/napi-rs/issues/1597
+//
+// The macro previously recognized the special-cased `Env` parameter only when
+// the type was spelled as the bare identifier `Env` (matching the whole
+// token stream against the literal string "Env"). Writing the fully
+// qualified path `napi::Env` (as below) produced a different token stream
+// and fell through to normal `FromNapiValue`-based argument extraction,
+// which fails to compile because `Env` does not implement `NapiValue`.
+//
+// This function using the fully-qualified path must expand and compile
+// successfully.
+#[napi]
+pub fn with_fully_qualified_env(_env: napi::Env, a: i32, b: i32) -> i32 {
+  a + b
+}
+
 #[napi]
 #[derive(Debug, PartialEq, Eq)]
 pub enum MyEnum {

--- a/examples/napi-cargo-test/src/lib.rs
+++ b/examples/napi-cargo-test/src/lib.rs
@@ -21,6 +21,30 @@ pub fn with_fully_qualified_env(_env: napi::Env, a: i32, b: i32) -> i32 {
   a + b
 }
 
+// Regression test: an associated type that happens to be named `Env`,
+// reached through a qualified-self path (`<T as Trait>::Env`), must NOT be
+// treated as napi's special environment parameter. The special-case check
+// only inspects the last path segment's ident, so without also requiring
+// `qself.is_none()` a qualified-self path ending in `Env` would be
+// misdetected and silently skipped instead of being extracted normally via
+// `FromNapiValue`. `HasEnv::Env` here is `i32`, which does implement
+// `FromNapiValue`, so this only compiles if the parameter is extracted
+// normally rather than treated as the special environment parameter.
+pub trait HasEnv {
+  type Env;
+}
+
+pub struct MyEnvHolder;
+
+impl HasEnv for MyEnvHolder {
+  type Env = i32;
+}
+
+#[napi]
+pub fn with_qualified_self_env_associated_type(env: <MyEnvHolder as HasEnv>::Env) -> i32 {
+  env
+}
+
 #[napi]
 #[derive(Debug, PartialEq, Eq)]
 pub enum MyEnum {

--- a/examples/napi-cargo-test/src/lib.rs
+++ b/examples/napi-cargo-test/src/lib.rs
@@ -45,6 +45,31 @@ pub fn with_qualified_self_env_associated_type(env: <MyEnvHolder as HasEnv>::Env
   env
 }
 
+// Same guard for the *borrowed* form: `&<T as Trait>::Env` must go through
+// normal `FromNapiRef` extraction in codegen (and stay a regular argument in
+// the generated TypeScript), not be special-cased as the napi environment.
+// `EnvHolder` is a napi class, so `&EnvHolder` implements `FromNapiRef`; this
+// only compiles if the parameter is extracted as a normal class reference.
+#[napi]
+pub struct EnvHolder {
+  pub value: i32,
+}
+
+pub trait HasEnvRef {
+  type Env;
+}
+
+pub struct MyEnvRefHolder;
+
+impl HasEnvRef for MyEnvRefHolder {
+  type Env = EnvHolder;
+}
+
+#[napi]
+pub fn with_qualified_self_env_ref(env: &<MyEnvRefHolder as HasEnvRef>::Env) -> i32 {
+  env.value
+}
+
 #[napi]
 #[derive(Debug, PartialEq, Eq)]
 pub enum MyEnum {


### PR DESCRIPTION
## Summary

Fixes #1597.

`#[napi]` fails to compile when a function parameter uses the fully-qualified path `napi::Env` (or `napi::env::Env`) instead of the bare `Env` identifier, with:

```
error[E0277]: the trait bound `Env: NapiValue` is not satisfied
```

## Root cause

The macro special-cases an `Env`-typed parameter so it receives the callback's `Env` directly instead of going through the normal `FromNapiValue` conversion path. In `crates/backend/src/codegen/fn.rs` this check was:

```rust
if &pat_type.ty.to_token_stream().to_string() == "Env" {
```

This compares the *entire* type's token stream against the literal string `"Env"`. That only matches the bare identifier — a qualified path like `napi::Env` renders as `"napi :: Env"`, which never equals `"Env"`, so the special case silently fails to trigger and the parameter falls through to ordinary `FromNapiValue`-based extraction (which doesn't exist for `Env`), producing the confusing trait-bound error from the issue.

The same whole-token-stream comparison pattern also existed in `crates/backend/src/typegen/fn.rs` (used for `.d.ts` generation), with the same defect.

## Fix

Both places now match on the resolved type's **last path segment ident** instead of the whole token stream — the same idiom already used elsewhere in these exact files for other special-cased parameter types (`Reference`, `This`, `WeakReference`) and in `crates/macro/src/parser/mod.rs` for `Env`/`Object` detection in `module_exports`. This makes recognition independent of how many path segments precede `Env`, so bare `Env`, `napi::Env`, and `napi::env::Env` are all now handled consistently.

All Env checks also require `qself: None`, so a qualified-self path like `<T as Trait>::Env` is never treated as the special environment parameter. That guard covers the borrowed-parameter branch in `codegen/fn.rs` too — without it, `&<T as Trait>::Env` was injected as the environment in codegen while typegen (already guarded) kept it as a regular argument, making the generated `.d.ts` disagree with runtime argument consumption.

## Test plan

- Added `with_fully_qualified_env` to `examples/napi-cargo-test/src/lib.rs`: a `#[napi]` function taking `napi::Env` (fully qualified) as a parameter, which only compiles successfully with this fix (verified it fails with the pre-fix code, reproducing the exact error from the issue).
- Added `with_qualified_self_env_associated_type`: a `#[napi]` function taking `<MyEnvHolder as HasEnv>::Env` (a qualified-self associated type resolving to `i32`), which only compiles when the parameter is extracted normally instead of being special-cased as the environment.
- Added `with_qualified_self_env_ref`: the borrowed form, `&<MyEnvRefHolder as HasEnvRef>::Env` resolving to a `#[napi]` class, which only compiles when it goes through normal `FromNapiRef` extraction (verified it fails with E0308 without the borrowed-branch guard).
- `cargo test -p napi-cargo-test` — 7 passed
- `cargo test -p napi-derive-backend -p napi-derive` — 17 passed (backend unit tests + macro crate)
- `cargo test -p napi` — 10 passed
- `cargo check -p napi-examples` (the full `examples/napi` crate, which exercises bare `Env` and `&Env` parameters extensively) — compiles clean, no regressions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved generated TypeScript signatures by correctly distinguishing the special environment parameter from qualified-self associated types named `Env`.
  - Qualified-self `Env` associated types are now retained as regular function arguments and processed through standard value conversion, including borrowed values.

- **Tests**
  - Added regression coverage for qualified-self associated types named `Env`, including owned and borrowed forms, extraction, and runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
