### PR TITLE
fix(cli,build): make wasm32-wasip1-threads link with wasi-sdk 34 and Rust nightly

### DIFF
--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -1184,6 +1184,7 @@ jobs:
       - test-custom-async-runtime-wasi
       - test-shared-async-runtime-wasi
       - test-node-wasi
+      - wasi-sdk
       - test-latest-bun
     steps:
       # `skipped` is included because a failed `audit` (or a failed

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -1025,7 +1025,7 @@ jobs:
   # selection honest.
   wasi-sdk:
     runs-on: ubuntu-latest
-    name: WASI via wasi-sdk ${{ matrix.wasi-sdk }}
+    name: WASI via wasi-sdk ${{ matrix.wasi-sdk }} on ${{ matrix.toolchain }} Rust
     timeout-minutes: 20
     needs: audit
     permissions:
@@ -1034,16 +1034,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Legacy 4-argument futex ABI. Rust's bundled `crt1` comes from this
-          # era too, so the module it produces also runs.
+          # Legacy 4-argument futex ABI, on the toolchain most users have.
+          # Stable rustc does not link `crt1-reactor.o`, so napi-build still
+          # supplies it, and that `crt1` matches this sysroot.
           - wasi-sdk: '33'
-            run-artifact: true
-          # 3-argument futex ABI. Linking proves the archive selection, but the
-          # module cannot instantiate yet: Rust still ships a pre-34 `crt1` that
-          # calls `__wasi_init_tp`, which wasi-sdk 34 no longer defines. Fixed by
-          # rust-lang/rust#161773, landing in Rust 1.100. See #3491.
+            toolchain: stable
+          # 3-argument futex ABI. This lane needs nightly. wasi-sdk 34 deleted
+          # `__wasi_init_tp`, which stable's pre-34 `crt1-reactor.o` still
+          # calls, so a stable build links but cannot instantiate. Nightly
+          # ships an sdk-34 era `crt1` and links it itself, which is the case
+          # `rustc_links_reactor_crt()` detects. Stable gets the same sysroot
+          # in 1.100, via rust-lang/rust#161773. See #3491.
           - wasi-sdk: '34'
-            run-artifact: false
+            toolchain: nightly
     steps:
       - uses: actions/checkout@v7
       - name: Setup node
@@ -1055,7 +1058,7 @@ jobs:
       - name: Install
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
           targets: wasm32-wasip1-threads
       - name: Setup wasi-sdk ${{ matrix.wasi-sdk }}
         shell: bash
@@ -1087,7 +1090,6 @@ jobs:
             exit 1
           fi
       - name: Test
-        if: ${{ matrix.run-artifact }}
         run: yarn workspace @examples/napi test -s
         env:
           WASI_TEST: 'true'

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -1011,6 +1011,89 @@ jobs:
           yarn workspace @examples/napi playwright install chromium
           yarn workspace @examples/napi vitest
 
+  # `test-node-wasi` above links through `rust-lld` against the wasi-libc that
+  # ships with the Rust standard library. This job links through a real
+  # wasi-sdk instead, which is what `WASI_SDK_PATH` selects.
+  #
+  # wasi-libc dropped the unused `int op` parameter from
+  # `__wasilibc_futex_wait_atomic_wait` / `__wasilibc_futex_wait_maybe_busy`,
+  # and wasi-sdk 34 is the first release shipping the 3-argument signature.
+  # emnapi therefore publishes two archive sets for the threaded target, and
+  # the CLI picks between them by wasi-sdk version. Linking the wrong one makes
+  # `wasm-ld` report `function signature mismatch` and emit an invalid wasm
+  # module, so building against both a pre-34 and a post-34 sdk keeps that
+  # selection honest.
+  wasi-sdk:
+    runs-on: ubuntu-latest
+    name: WASI via wasi-sdk ${{ matrix.wasi-sdk }}
+    timeout-minutes: 20
+    needs: audit
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Legacy 4-argument futex ABI. Rust's bundled `crt1` comes from this
+          # era too, so the module it produces also runs.
+          - wasi-sdk: '33'
+            run-artifact: true
+          # 3-argument futex ABI. Linking proves the archive selection, but the
+          # module cannot instantiate yet: Rust still ships a pre-34 `crt1` that
+          # calls `__wasi_init_tp`, which wasi-sdk 34 no longer defines. Fixed by
+          # rust-lang/rust#161773, landing in Rust 1.100. See #3491.
+          - wasi-sdk: '34'
+            run-artifact: false
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: 'yarn'
+          cache-dependency-path: 'yarn.lock'
+      - name: Install
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: wasm32-wasip1-threads
+      - name: Setup wasi-sdk ${{ matrix.wasi-sdk }}
+        shell: bash
+        run: |
+          sdk="wasi-sdk-${{ matrix.wasi-sdk }}.0-x86_64-linux"
+          curl -fsSL -o "$sdk.tar.gz" \
+            "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${{ matrix.wasi-sdk }}/$sdk.tar.gz"
+          tar -xf "$sdk.tar.gz"
+          echo "WASI_SDK_PATH=$(pwd)/$sdk" >> "$GITHUB_ENV"
+      - name: Install dependencies
+        run: yarn install --immutable --mode=skip-build
+      - name: Build
+        shell: bash
+        run: |
+          yarn build
+          yarn workspace @examples/napi build \
+            --target wasm32-wasip1-threads --profile wasi 2>&1 | tee wasi-sdk-build.log
+        env:
+          RUSTFLAGS: '--cfg tokio_unstable'
+      # The build above already fails hard when the archive ABI does not match
+      # the sysroot. This guard catches the quieter case: emnapi without the
+      # wasi-sdk 34 archives, where the CLI warns and falls back to the legacy
+      # set instead of erroring.
+      - name: Assert the emnapi archive selection did not degrade
+        shell: bash
+        run: |
+          if grep -q 'does not ship the wasm32-wasip1-threads-wasi-sdk-34' wasi-sdk-build.log; then
+            echo "::error::The CLI fell back to the legacy emnapi archives for wasi-sdk ${{ matrix.wasi-sdk }}."
+            exit 1
+          fi
+      - name: Test
+        if: ${{ matrix.run-artifact }}
+        run: yarn workspace @examples/napi test -s
+        env:
+          WASI_TEST: 'true'
+          NODE_OPTIONS: '--max-old-space-size=8192'
+          SKIP_UNWIND_TEST: 1
+
   test-latest-bun:
     runs-on: ubuntu-latest
     name: Test latest bun

--- a/cli/src/api/__tests__/build.spec.ts
+++ b/cli/src/api/__tests__/build.spec.ts
@@ -25,9 +25,11 @@ import ava, { type ExecutionContext, type TestFn } from 'ava'
 
 import {
   buildProject,
+  EMNAPI_WASI_SDK_34_LINK_DIR,
   generateTypeDef,
   napiCrossToolchainEnvs,
   resolveBuildFormat,
+  selectEmnapiLinkDir,
   validateCrossCompileFlags,
   validateNapiCrossSupport,
   writeJsBinding,
@@ -1108,3 +1110,122 @@ const isNapiCrossUnsupportedHost =
     )
   },
 )
+
+async function createEmnapiLibDir(root: string, dirNames: string[]) {
+  const emnapiLibDir = join(root, 'emnapi', 'lib')
+  for (const dirName of dirNames) {
+    await mkdir(join(emnapiLibDir, dirName), { recursive: true })
+  }
+  return emnapiLibDir
+}
+
+async function createWasiSdkDir(root: string, version: string) {
+  const wasiSdkPath = join(root, `wasi-sdk-${version}`)
+  await mkdir(wasiSdkPath, { recursive: true })
+  await writeFile(join(wasiSdkPath, 'VERSION'), `${version}\n`)
+  return wasiSdkPath
+}
+
+test('selects the wasi-sdk 34 emnapi archives for wasi-sdk >= 34', async (t) => {
+  const { projectDir } = t.context
+  const emnapiLibDir = await createEmnapiLibDir(projectDir, [
+    'wasm32-wasip1',
+    'wasm32-wasip1-threads',
+    EMNAPI_WASI_SDK_34_LINK_DIR,
+  ])
+  const wasiSdkPath = await createWasiSdkDir(projectDir, '34.0')
+
+  t.deepEqual(
+    selectEmnapiLinkDir(
+      emnapiLibDir,
+      'wasm32-wasip1-threads',
+      true,
+      wasiSdkPath,
+    ),
+    {
+      linkDirName: EMNAPI_WASI_SDK_34_LINK_DIR,
+      wasiSdkMajor: 34,
+      needsWasiSdk34: true,
+    },
+  )
+})
+
+test('keeps the legacy emnapi archives for wasi-sdk <= 33', async (t) => {
+  const { projectDir } = t.context
+  const emnapiLibDir = await createEmnapiLibDir(projectDir, [
+    'wasm32-wasip1-threads',
+    EMNAPI_WASI_SDK_34_LINK_DIR,
+  ])
+  const wasiSdkPath = await createWasiSdkDir(projectDir, '33.0')
+
+  t.deepEqual(
+    selectEmnapiLinkDir(
+      emnapiLibDir,
+      'wasm32-wasip1-threads',
+      true,
+      wasiSdkPath,
+    ),
+    {
+      linkDirName: 'wasm32-wasip1-threads',
+      wasiSdkMajor: 33,
+      needsWasiSdk34: false,
+    },
+  )
+})
+
+test('keeps the legacy emnapi archives without WASI_SDK_PATH', async (t) => {
+  const { projectDir } = t.context
+  const emnapiLibDir = await createEmnapiLibDir(projectDir, [
+    'wasm32-wasip1-threads',
+    EMNAPI_WASI_SDK_34_LINK_DIR,
+  ])
+
+  t.deepEqual(
+    selectEmnapiLinkDir(emnapiLibDir, 'wasm32-wasip1-threads', true, undefined),
+    {
+      linkDirName: 'wasm32-wasip1-threads',
+      wasiSdkMajor: null,
+      needsWasiSdk34: false,
+    },
+  )
+})
+
+test('never selects the wasi-sdk 34 archives for the threadless target', async (t) => {
+  const { projectDir } = t.context
+  const emnapiLibDir = await createEmnapiLibDir(projectDir, [
+    'wasm32-wasip1',
+    EMNAPI_WASI_SDK_34_LINK_DIR,
+  ])
+  const wasiSdkPath = await createWasiSdkDir(projectDir, '34.0')
+
+  t.deepEqual(
+    selectEmnapiLinkDir(emnapiLibDir, 'wasm32-wasip1', false, wasiSdkPath),
+    {
+      linkDirName: 'wasm32-wasip1',
+      wasiSdkMajor: 34,
+      needsWasiSdk34: false,
+    },
+  )
+})
+
+test('falls back to the legacy archives when emnapi has no wasi-sdk 34 directory', async (t) => {
+  const { projectDir } = t.context
+  const emnapiLibDir = await createEmnapiLibDir(projectDir, [
+    'wasm32-wasip1-threads',
+  ])
+  const wasiSdkPath = await createWasiSdkDir(projectDir, '34.0')
+
+  t.deepEqual(
+    selectEmnapiLinkDir(
+      emnapiLibDir,
+      'wasm32-wasip1-threads',
+      true,
+      wasiSdkPath,
+    ),
+    {
+      linkDirName: 'wasm32-wasip1-threads',
+      wasiSdkMajor: 34,
+      needsWasiSdk34: true,
+    },
+  )
+})

--- a/cli/src/api/__tests__/build.spec.ts
+++ b/cli/src/api/__tests__/build.spec.ts
@@ -1126,6 +1126,22 @@ async function createWasiSdkDir(root: string, version: string) {
   return wasiSdkPath
 }
 
+async function createWasiLibcArchive(
+  projectDir: string,
+  abi: 'legacy' | 'new',
+) {
+  const libcPath = join(projectDir, `libc-${abi}.a`)
+  // Only the archive member names matter: wasi-libc moved the futex helpers
+  // into `futex.c` when it dropped the `int op` parameter, and kept `__wait.c`
+  // for other symbols.
+  const members =
+    abi === 'new'
+      ? ['__wait.c.obj', 'futex.c.obj']
+      : ['__wait.c.obj', '__wasilibc_busywait.c.obj']
+  await writeFile(libcPath, `!<arch>\n${members.join('\n')}\n`)
+  return libcPath
+}
+
 test('selects the wasi-sdk 34 emnapi archives for wasi-sdk >= 34', async (t) => {
   const { projectDir } = t.context
   const emnapiLibDir = await createEmnapiLibDir(projectDir, [
@@ -1173,7 +1189,7 @@ test('keeps the legacy emnapi archives for wasi-sdk <= 33', async (t) => {
   )
 })
 
-test('keeps the legacy emnapi archives without WASI_SDK_PATH', async (t) => {
+test('keeps the legacy emnapi archives when the wasi-libc ABI is unknown', async (t) => {
   const { projectDir } = t.context
   const emnapiLibDir = await createEmnapiLibDir(projectDir, [
     'wasm32-wasip1-threads',
@@ -1181,11 +1197,68 @@ test('keeps the legacy emnapi archives without WASI_SDK_PATH', async (t) => {
   ])
 
   t.deepEqual(
-    selectEmnapiLinkDir(emnapiLibDir, 'wasm32-wasip1-threads', true, undefined),
+    // `null` stands in for a Rust sysroot that cannot be probed.
+    selectEmnapiLinkDir(
+      emnapiLibDir,
+      'wasm32-wasip1-threads',
+      true,
+      undefined,
+      null,
+    ),
     {
       linkDirName: 'wasm32-wasip1-threads',
       wasiSdkMajor: null,
       needsWasiSdk34: false,
+    },
+  )
+})
+
+test('keeps the legacy emnapi archives for a pre wasi-sdk 34 Rust toolchain', async (t) => {
+  const { projectDir } = t.context
+  const emnapiLibDir = await createEmnapiLibDir(projectDir, [
+    'wasm32-wasip1-threads',
+    EMNAPI_WASI_SDK_34_LINK_DIR,
+  ])
+  const rustWasiLibc = await createWasiLibcArchive(projectDir, 'legacy')
+
+  t.deepEqual(
+    selectEmnapiLinkDir(
+      emnapiLibDir,
+      'wasm32-wasip1-threads',
+      true,
+      undefined,
+      rustWasiLibc,
+    ),
+    {
+      linkDirName: 'wasm32-wasip1-threads',
+      wasiSdkMajor: null,
+      needsWasiSdk34: false,
+    },
+  )
+})
+
+test('selects the wasi-sdk 34 archives for a Rust toolchain that bundles the new wasi-libc', async (t) => {
+  const { projectDir } = t.context
+  const emnapiLibDir = await createEmnapiLibDir(projectDir, [
+    'wasm32-wasip1-threads',
+    EMNAPI_WASI_SDK_34_LINK_DIR,
+  ])
+  const rustWasiLibc = await createWasiLibcArchive(projectDir, 'new')
+
+  t.deepEqual(
+    // No wasi-sdk is configured: cargo links Rust's bundled wasi-libc, and
+    // Rust picked up wasi-sdk 34 in rust-lang/rust#161773.
+    selectEmnapiLinkDir(
+      emnapiLibDir,
+      'wasm32-wasip1-threads',
+      true,
+      undefined,
+      rustWasiLibc,
+    ),
+    {
+      linkDirName: EMNAPI_WASI_SDK_34_LINK_DIR,
+      wasiSdkMajor: null,
+      needsWasiSdk34: true,
     },
   )
 })

--- a/cli/src/api/__tests__/build.spec.ts
+++ b/cli/src/api/__tests__/build.spec.ts
@@ -1203,7 +1203,7 @@ test('keeps the legacy emnapi archives when the wasi-libc ABI is unknown', async
       'wasm32-wasip1-threads',
       true,
       undefined,
-      null,
+      { rustWasiLibc: null },
     ),
     {
       linkDirName: 'wasm32-wasip1-threads',
@@ -1227,7 +1227,7 @@ test('keeps the legacy emnapi archives for a pre wasi-sdk 34 Rust toolchain', as
       'wasm32-wasip1-threads',
       true,
       undefined,
-      rustWasiLibc,
+      { rustWasiLibc },
     ),
     {
       linkDirName: 'wasm32-wasip1-threads',
@@ -1253,7 +1253,7 @@ test('selects the wasi-sdk 34 archives for a Rust toolchain that bundles the new
       'wasm32-wasip1-threads',
       true,
       undefined,
-      rustWasiLibc,
+      { rustWasiLibc },
     ),
     {
       linkDirName: EMNAPI_WASI_SDK_34_LINK_DIR,

--- a/cli/src/api/build.ts
+++ b/cli/src/api/build.ts
@@ -45,6 +45,8 @@ import {
   targetToEnvVar,
   tryInstallCargoBinary,
   unlinkAsync,
+  rustBundledWasiLibc,
+  wasiLibcHasNewFutexAbi,
   wasiLoaderSuffix,
   wasiSdkMajorVersion,
   wasiTargetHasThreads,
@@ -234,7 +236,7 @@ export const EMNAPI_WASI_SDK_34_LINK_DIR = 'wasm32-wasip1-threads-wasi-sdk-34'
 export interface EmnapiLinkDirSelection {
   /** Directory name under `emnapi/lib` whose archives should be linked. */
   linkDirName: string
-  /** Detected wasi-sdk major version, `null` when it could not be detected. */
+  /** Detected wasi-sdk major version, `null` when no wasi-sdk is configured. */
   wasiSdkMajor: number | null
   /** `true` when the toolchain needs the wasi-sdk 34 archives. */
   needsWasiSdk34: boolean
@@ -251,23 +253,37 @@ export interface EmnapiLinkDirSelection {
  * wasm module, so emnapi publishes a second archive set for the new ABI and
  * the directory has to be chosen by wasi-sdk version, not by target triple.
  *
- * The legacy directory stays the default. Without `WASI_SDK_PATH`, cargo
- * links through `rust-lld` against the wasi-libc that ships with the Rust
- * standard library, which still uses the 4-argument signature; older emnapi
- * releases also ship the legacy directory alone.
+ * Without `WASI_SDK_PATH`, cargo links through `rust-lld` against the
+ * wasi-libc bundled with the Rust standard library, so that archive is
+ * probed instead. Rust picked up wasi-sdk 34 in rust-lang/rust#161773, which
+ * lands in 1.100, and a toolchain carrying it needs the new archives even
+ * though no wasi-sdk is configured.
+ *
+ * The legacy directory stays the default whenever the ABI cannot be
+ * determined, and older emnapi releases ship it alone.
  */
 export function selectEmnapiLinkDir(
   emnapiLibDir: string,
   wasiTarget: string,
   hasThreads: boolean,
   wasiSdkPath: string | undefined,
+  // `undefined` resolves the Rust sysroot lazily, so a configured wasi-sdk
+  // never pays for a `rustc` invocation. Pass `null` to skip the probe.
+  rustWasiLibc?: string | null,
 ): EmnapiLinkDirSelection {
-  const wasiSdkMajor =
-    wasiSdkPath && existsSync(wasiSdkPath)
-      ? wasiSdkMajorVersion(wasiSdkPath)
-      : null
-  const needsWasiSdk34 =
-    hasThreads && wasiSdkMajor !== null && wasiSdkMajor >= 34
+  const usingWasiSdk = Boolean(wasiSdkPath) && existsSync(wasiSdkPath!)
+  const wasiSdkMajor = usingWasiSdk ? wasiSdkMajorVersion(wasiSdkPath!) : null
+  // Whichever wasi-libc actually gets linked decides the ABI: the wasi-sdk
+  // sysroot when one is configured, otherwise the copy bundled with the Rust
+  // standard library.
+  const newFutexAbi = usingWasiSdk
+    ? wasiSdkMajor !== null && wasiSdkMajor >= 34
+    : wasiLibcHasNewFutexAbi(
+        rustWasiLibc === undefined
+          ? rustBundledWasiLibc(wasiTarget)
+          : rustWasiLibc,
+      ) === true
+  const needsWasiSdk34 = hasThreads && newFutexAbi
   const linkDirName =
     needsWasiSdk34 &&
     existsSync(join(emnapiLibDir, EMNAPI_WASI_SDK_34_LINK_DIR))

--- a/cli/src/api/build.ts
+++ b/cli/src/api/build.ts
@@ -1533,14 +1533,18 @@ class Builder {
       emnapi,
       hasThreads ? 'libemnapi-napi-rs-mt.a' : 'libemnapi-basic-napi-rs.a',
     )
+    const fellBackToLegacy =
+      needsWasiSdk34 && linkDirName !== EMNAPI_WASI_SDK_34_LINK_DIR
     if (!existsSync(emnapiArchive)) {
       throw new Error(
-        needsWasiSdk34
-          ? `emnapi@${emnapiVersion} is missing the ${linkDirName} archive required by napi-rs at ${emnapiArchive}. wasi-sdk ${wasiSdkMajor} needs the ${EMNAPI_WASI_SDK_34_LINK_DIR} archives, so upgrade emnapi to a version that ships them.`
-          : `emnapi@${emnapiVersion} is missing the ${linkDirName} archive required by napi-rs at ${emnapiArchive}. Install emnapi v2 with support for this target.`,
+        fellBackToLegacy
+          ? `emnapi@${emnapiVersion} does not ship the ${EMNAPI_WASI_SDK_34_LINK_DIR} archives that wasi-sdk ${wasiSdkMajor} requires, and the ${linkDirName} archive it fell back to is missing too at ${emnapiArchive}. Upgrade emnapi to a version that ships the wasi-sdk 34 archives.`
+          : needsWasiSdk34
+            ? `emnapi@${emnapiVersion} is missing the ${linkDirName} archive required by napi-rs at ${emnapiArchive}. wasi-sdk ${wasiSdkMajor} needs those archives, so upgrade emnapi to a version that ships them.`
+            : `emnapi@${emnapiVersion} is missing the ${linkDirName} archive required by napi-rs at ${emnapiArchive}. Install emnapi v2 with support for this target.`,
       )
     }
-    if (needsWasiSdk34 && linkDirName !== EMNAPI_WASI_SDK_34_LINK_DIR) {
+    if (fellBackToLegacy) {
       debug.warn(
         `emnapi@${emnapiVersion} does not ship the ${EMNAPI_WASI_SDK_34_LINK_DIR} archives that wasi-sdk ${wasiSdkMajor} requires. Falling back to ${linkDirName}, which links the legacy wasi-libc futex ABI and may fail with \`wasm-ld: function signature mismatch\`. Upgrade emnapi to fix this.`,
       )

--- a/cli/src/api/build.ts
+++ b/cli/src/api/build.ts
@@ -275,15 +275,18 @@ export function selectEmnapiLinkDir(
   const wasiSdkMajor = usingWasiSdk ? wasiSdkMajorVersion(wasiSdkPath!) : null
   // Whichever wasi-libc actually gets linked decides the ABI: the wasi-sdk
   // sysroot when one is configured, otherwise the copy bundled with the Rust
-  // standard library.
-  const newFutexAbi = usingWasiSdk
-    ? wasiSdkMajor !== null && wasiSdkMajor >= 34
-    : wasiLibcHasNewFutexAbi(
-        rustWasiLibc === undefined
-          ? rustBundledWasiLibc(wasiTarget)
-          : rustWasiLibc,
-      ) === true
-  const needsWasiSdk34 = hasThreads && newFutexAbi
+  // standard library. Only the threaded target has a second archive set, so
+  // `hasThreads` gates the probe as well as the result — a threadless build
+  // must not pay for a `rustc` invocation and an archive read it cannot use.
+  const needsWasiSdk34 =
+    hasThreads &&
+    (usingWasiSdk
+      ? wasiSdkMajor !== null && wasiSdkMajor >= 34
+      : wasiLibcHasNewFutexAbi(
+          rustWasiLibc === undefined
+            ? rustBundledWasiLibc(wasiTarget)
+            : rustWasiLibc,
+        ) === true)
   const linkDirName =
     needsWasiSdk34 &&
     existsSync(join(emnapiLibDir, EMNAPI_WASI_SDK_34_LINK_DIR))

--- a/cli/src/api/build.ts
+++ b/cli/src/api/build.ts
@@ -46,6 +46,7 @@ import {
   tryInstallCargoBinary,
   unlinkAsync,
   wasiLoaderSuffix,
+  wasiSdkMajorVersion,
   wasiTargetHasThreads,
   writeFileAtomic,
   withFileSystemReconciliation,
@@ -221,6 +222,58 @@ export function getTypeDefCacheFolder(options: {
     .substring(0, 16)
 
   return join(options.targetDir, 'napi-rs', `${options.crateName}-${hash}`)
+}
+
+/**
+ * Name of the emnapi archive directory built against the wasi-sdk 34 ABI.
+ * Only the threaded target has one: the signature change it carries lives in
+ * the threads-only futex code.
+ */
+export const EMNAPI_WASI_SDK_34_LINK_DIR = 'wasm32-wasip1-threads-wasi-sdk-34'
+
+export interface EmnapiLinkDirSelection {
+  /** Directory name under `emnapi/lib` whose archives should be linked. */
+  linkDirName: string
+  /** Detected wasi-sdk major version, `null` when it could not be detected. */
+  wasiSdkMajor: number | null
+  /** `true` when the toolchain needs the wasi-sdk 34 archives. */
+  needsWasiSdk34: boolean
+}
+
+/**
+ * Pick the emnapi archive directory for a WASI build.
+ *
+ * wasi-libc removed the unused `int op` parameter from
+ * `__wasilibc_futex_wait_atomic_wait` / `__wasilibc_futex_wait_maybe_busy`,
+ * and wasi-sdk 34 is the first release shipping the 3-argument signature.
+ * Linking the legacy 4-argument archives against a wasi-sdk >= 34 sysroot
+ * makes `wasm-ld` report `function signature mismatch` and emit an invalid
+ * wasm module, so emnapi publishes a second archive set for the new ABI and
+ * the directory has to be chosen by wasi-sdk version, not by target triple.
+ *
+ * The legacy directory stays the default. Without `WASI_SDK_PATH`, cargo
+ * links through `rust-lld` against the wasi-libc that ships with the Rust
+ * standard library, which still uses the 4-argument signature; older emnapi
+ * releases also ship the legacy directory alone.
+ */
+export function selectEmnapiLinkDir(
+  emnapiLibDir: string,
+  wasiTarget: string,
+  hasThreads: boolean,
+  wasiSdkPath: string | undefined,
+): EmnapiLinkDirSelection {
+  const wasiSdkMajor =
+    wasiSdkPath && existsSync(wasiSdkPath)
+      ? wasiSdkMajorVersion(wasiSdkPath)
+      : null
+  const needsWasiSdk34 =
+    hasThreads && wasiSdkMajor !== null && wasiSdkMajor >= 34
+  const linkDirName =
+    needsWasiSdk34 &&
+    existsSync(join(emnapiLibDir, EMNAPI_WASI_SDK_34_LINK_DIR))
+      ? EMNAPI_WASI_SDK_34_LINK_DIR
+      : wasiTarget
+  return { linkDirName, wasiSdkMajor, needsWasiSdk34 }
 }
 
 export function createWasiCompilerFlags(
@@ -1461,8 +1514,20 @@ class Builder {
   private setWasiEnv() {
     const hasThreads = wasiTargetHasThreads(this.target)
     const wasiTarget = hasThreads ? 'wasm32-wasip1-threads' : 'wasm32-wasip1'
-    const emnapi = join(require.resolve('emnapi'), '..', 'lib', wasiTarget)
+    const emnapiLibDir = join(require.resolve('emnapi'), '..', 'lib')
     const emnapiVersion = require('emnapi/package.json').version
+    const { WASI_SDK_PATH } = process.env
+    // `wasiTarget` stays the real target triple, because it is what the clang
+    // driver is told to build for below. The emnapi archive directory is a
+    // separate choice: emnapi ships two archive sets for the threaded target,
+    // one per wasi-libc futex ABI. See `selectEmnapiLinkDir`.
+    const { linkDirName, wasiSdkMajor, needsWasiSdk34 } = selectEmnapiLinkDir(
+      emnapiLibDir,
+      wasiTarget,
+      hasThreads,
+      WASI_SDK_PATH,
+    )
+    const emnapi = join(emnapiLibDir, linkDirName)
     // Keep this in sync with `emnapi_link_library` in `crates/build/src/wasi.rs`.
     const emnapiArchive = join(
       emnapi,
@@ -1470,7 +1535,14 @@ class Builder {
     )
     if (!existsSync(emnapiArchive)) {
       throw new Error(
-        `emnapi@${emnapiVersion} is missing the ${wasiTarget} archive required by napi-rs at ${emnapiArchive}. Install emnapi v2 with support for this target.`,
+        needsWasiSdk34
+          ? `emnapi@${emnapiVersion} is missing the ${linkDirName} archive required by napi-rs at ${emnapiArchive}. wasi-sdk ${wasiSdkMajor} needs the ${EMNAPI_WASI_SDK_34_LINK_DIR} archives, so upgrade emnapi to a version that ships them.`
+          : `emnapi@${emnapiVersion} is missing the ${linkDirName} archive required by napi-rs at ${emnapiArchive}. Install emnapi v2 with support for this target.`,
+      )
+    }
+    if (needsWasiSdk34 && linkDirName !== EMNAPI_WASI_SDK_34_LINK_DIR) {
+      debug.warn(
+        `emnapi@${emnapiVersion} does not ship the ${EMNAPI_WASI_SDK_34_LINK_DIR} archives that wasi-sdk ${wasiSdkMajor} requires. Falling back to ${linkDirName}, which links the legacy wasi-libc futex ABI and may fail with \`wasm-ld: function signature mismatch\`. Upgrade emnapi to fix this.`,
       )
     }
     this.envs.EMNAPI_LINK_DIR = emnapi
@@ -1499,7 +1571,6 @@ class Builder {
         `emnapi version mismatch: emnapi@${emnapiVersion}, @emnapi/core@${emnapiCoreVersion}, @emnapi/runtime@${emnapiRuntimeVersion}. Please ensure all emnapi packages are the same version.`,
       )
     }
-    const { WASI_SDK_PATH } = process.env
 
     if (WASI_SDK_PATH && existsSync(WASI_SDK_PATH)) {
       this.envs.CARGO_TARGET_WASM32_WASI_PREVIEW1_THREADS_LINKER = join(

--- a/cli/src/api/build.ts
+++ b/cli/src/api/build.ts
@@ -267,9 +267,17 @@ export function selectEmnapiLinkDir(
   wasiTarget: string,
   hasThreads: boolean,
   wasiSdkPath: string | undefined,
-  // `undefined` resolves the Rust sysroot lazily, so a configured wasi-sdk
-  // never pays for a `rustc` invocation. Pass `null` to skip the probe.
-  rustWasiLibc?: string | null,
+  {
+    cwd,
+    rustWasiLibc,
+  }: {
+    // The directory Cargo is spawned in. It selects the toolchain, so the
+    // sysroot probe has to use it too.
+    cwd?: string
+    // Omit to resolve the Rust sysroot lazily, so a configured wasi-sdk never
+    // pays for a `rustc` invocation. Pass `null` to skip the probe.
+    rustWasiLibc?: string | null
+  } = {},
 ): EmnapiLinkDirSelection {
   const usingWasiSdk = Boolean(wasiSdkPath) && existsSync(wasiSdkPath!)
   const wasiSdkMajor = usingWasiSdk ? wasiSdkMajorVersion(wasiSdkPath!) : null
@@ -284,7 +292,7 @@ export function selectEmnapiLinkDir(
       ? wasiSdkMajor !== null && wasiSdkMajor >= 34
       : wasiLibcHasNewFutexAbi(
           rustWasiLibc === undefined
-            ? rustBundledWasiLibc(wasiTarget)
+            ? rustBundledWasiLibc(wasiTarget, cwd)
             : rustWasiLibc,
         ) === true)
   const linkDirName =
@@ -1545,6 +1553,7 @@ class Builder {
       wasiTarget,
       hasThreads,
       WASI_SDK_PATH,
+      { cwd: this.options.cwd },
     )
     const emnapi = join(emnapiLibDir, linkDirName)
     // Keep this in sync with `emnapi_link_library` in `crates/build/src/wasi.rs`.

--- a/cli/src/utils/__tests__/target.spec.ts
+++ b/cli/src/utils/__tests__/target.spec.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import test from 'ava'
 
 import {
+  wasiLibcHasNewFutexAbi,
   parseTriple,
   getSystemDefaultTarget,
   wasiSdkMajorVersion,
@@ -112,4 +113,33 @@ test('should return null instead of throwing on a malformed VERSION', async (t) 
 
 test('should return null when the wasi-sdk path does not exist', (t) => {
   t.is(wasiSdkMajorVersion(join(os.tmpdir(), 'napi-rs-missing-wasi-sdk')), null)
+})
+
+test('should detect the new futex ABI from a wasi-libc archive', async (t) => {
+  const dir = await mkdtemp(join(os.tmpdir(), 'napi-rs-wasi-libc-'))
+  try {
+    // wasi-libc moved the futex helpers into `futex.c` when it dropped the
+    // unused `int op` parameter. `__wait.c` survives either way, so only the
+    // presence of `futex.c` separates the two ABIs.
+    const newAbi = join(dir, 'libc-new.a')
+    const legacyAbi = join(dir, 'libc-legacy.a')
+    await writeFile(newAbi, '!<arch>\n__wait.c.obj\nfutex.c.obj\n')
+    await writeFile(
+      legacyAbi,
+      '!<arch>\n__wait.c.obj\n__wasilibc_busywait.c.obj\n',
+    )
+
+    t.true(wasiLibcHasNewFutexAbi(newAbi))
+    t.false(wasiLibcHasNewFutexAbi(legacyAbi))
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('should return null when the wasi-libc archive is unavailable', (t) => {
+  t.is(wasiLibcHasNewFutexAbi(null), null)
+  t.is(
+    wasiLibcHasNewFutexAbi(join(os.tmpdir(), 'napi-rs-missing-libc.a')),
+    null,
+  )
 })

--- a/cli/src/utils/__tests__/target.spec.ts
+++ b/cli/src/utils/__tests__/target.spec.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { realpathSync } from 'node:fs'
+import { chmod, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import os from 'os'
 import { join } from 'node:path'
 
@@ -8,6 +9,7 @@ import {
   wasiLibcHasNewFutexAbi,
   parseTriple,
   getSystemDefaultTarget,
+  rustBundledWasiLibc,
   wasiSdkMajorVersion,
   AVAILABLE_TARGETS,
 } from '../target.js'
@@ -142,4 +144,97 @@ test('should return null when the wasi-libc archive is unavailable', (t) => {
     wasiLibcHasNewFutexAbi(join(os.tmpdir(), 'napi-rs-missing-libc.a')),
     null,
   )
+})
+
+// A fake `rustc` must be an executable file, and `execFileSync` cannot run a
+// Windows `.cmd` shim without a shell. The behaviour under test does not
+// depend on the platform, so cover it on POSIX only.
+const posixOnly = process.platform === 'win32' ? test.serial.skip : test.serial
+
+/**
+ * Installs a `rustc` that reports its own working directory as the sysroot,
+ * so a test can tell which directory the probe ran in.
+ */
+async function withFakeRustc(
+  envVar: 'RUSTC' | 'CARGO_BUILD_RUSTC',
+  body: (dir: string) => Promise<void> | void,
+) {
+  const dir = await mkdtemp(join(os.tmpdir(), 'napi-rs-fake-rustc-'))
+  const rustc = join(dir, 'rustc')
+  // `$PWD` comes from the inherited environment, so ask the kernel for the
+  // real working directory. `-P` also resolves the `/var` symlink on macOS.
+  await writeFile(rustc, '#!/bin/sh\necho "$(pwd -P)/sysroot"\n')
+  await chmod(rustc, 0o755)
+  const previous = process.env[envVar]
+  process.env[envVar] = rustc
+  try {
+    await body(dir)
+  } finally {
+    if (previous === undefined) {
+      delete process.env[envVar]
+    } else {
+      process.env[envVar] = previous
+    }
+  }
+}
+
+posixOnly('probes the Rust sysroot from the build cwd', async (t) => {
+  await withFakeRustc('RUSTC', async (dir) => {
+    const caller = join(dir, 'caller')
+    const project = join(dir, 'project')
+    await mkdir(caller)
+    await mkdir(project)
+
+    // `rustc` is a rustup shim, so the directory it runs in picks the
+    // toolchain. Cargo is spawned with the build cwd; the probe must match it.
+    t.is(
+      rustBundledWasiLibc('wasm32-wasip1-threads', project),
+      join(
+        realpathSync(project),
+        'sysroot',
+        'lib',
+        'rustlib',
+        'wasm32-wasip1-threads',
+        'lib',
+        'self-contained',
+        'libc.a',
+      ),
+    )
+    t.not(
+      rustBundledWasiLibc('wasm32-wasip1-threads', caller),
+      rustBundledWasiLibc('wasm32-wasip1-threads', project),
+    )
+  })
+})
+
+posixOnly('falls back to CARGO_BUILD_RUSTC when RUSTC is unset', async (t) => {
+  const previousRustc = process.env.RUSTC
+  delete process.env.RUSTC
+  try {
+    await withFakeRustc('CARGO_BUILD_RUSTC', (dir) => {
+      t.true(
+        rustBundledWasiLibc('wasm32-wasip1-threads', dir)?.startsWith(
+          realpathSync(dir),
+        ),
+      )
+    })
+  } finally {
+    if (previousRustc !== undefined) {
+      process.env.RUSTC = previousRustc
+    }
+  }
+})
+
+posixOnly('returns null when the compiler cannot be run', (t) => {
+  const previous = process.env.RUSTC
+  process.env.RUSTC = join(os.tmpdir(), 'napi-rs-no-such-rustc')
+  try {
+    t.is(rustBundledWasiLibc('wasm32-wasip1-threads'), null)
+  } finally {
+    if (previous === undefined) {
+      delete process.env.RUSTC
+    } else {
+      process.env.RUSTC = previous
+    }
+  }
 })

--- a/cli/src/utils/__tests__/target.spec.ts
+++ b/cli/src/utils/__tests__/target.spec.ts
@@ -1,12 +1,45 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import os from 'os'
+import { join } from 'node:path'
 
 import test from 'ava'
 
 import {
   parseTriple,
   getSystemDefaultTarget,
+  wasiSdkMajorVersion,
   AVAILABLE_TARGETS,
 } from '../target.js'
+
+async function withWasiSdkDir(
+  setup: (wasiSdkPath: string) => Promise<void>,
+  assertion: (wasiSdkPath: string) => void,
+) {
+  const wasiSdkPath = await mkdtemp(join(os.tmpdir(), 'napi-rs-wasi-sdk-'))
+  try {
+    await setup(wasiSdkPath)
+    assertion(wasiSdkPath)
+  } finally {
+    await rm(wasiSdkPath, { recursive: true, force: true })
+  }
+}
+
+async function writeVersionFile(wasiSdkPath: string, content: string) {
+  await writeFile(join(wasiSdkPath, 'VERSION'), content)
+}
+
+async function writeVersionHeader(wasiSdkPath: string, content: string) {
+  const headerDir = join(
+    wasiSdkPath,
+    'share',
+    'wasi-sysroot',
+    'include',
+    'wasm32-wasip1-threads',
+    'wasi',
+  )
+  await mkdir(headerDir, { recursive: true })
+  await writeFile(join(headerDir, 'version.h'), content)
+}
 
 test('should parse triple correctly', (t) => {
   t.snapshot(AVAILABLE_TARGETS.map(parseTriple))
@@ -16,4 +49,67 @@ test('should get system default target correctly', (t) => {
   const target = getSystemDefaultTarget()
 
   t.is(target.platform, os.platform())
+})
+
+test('should read the wasi-sdk major version from VERSION', async (t) => {
+  await withWasiSdkDir(
+    (wasiSdkPath) => writeVersionFile(wasiSdkPath, '34.0\n'),
+    (wasiSdkPath) => t.is(wasiSdkMajorVersion(wasiSdkPath), 34),
+  )
+})
+
+test('should ignore the build suffix in VERSION', async (t) => {
+  await withWasiSdkDir(
+    (wasiSdkPath) => writeVersionFile(wasiSdkPath, '33.0+m\n'),
+    (wasiSdkPath) => t.is(wasiSdkMajorVersion(wasiSdkPath), 33),
+  )
+})
+
+test('should read a pre wasi-sdk 30 VERSION', async (t) => {
+  await withWasiSdkDir(
+    (wasiSdkPath) => writeVersionFile(wasiSdkPath, '27.0\n'),
+    (wasiSdkPath) => t.is(wasiSdkMajorVersion(wasiSdkPath), 27),
+  )
+})
+
+test('should fall back to the wasi/version.h header', async (t) => {
+  await withWasiSdkDir(
+    (wasiSdkPath) =>
+      writeVersionHeader(
+        wasiSdkPath,
+        '#define __wasi_sdk_major__ 30\n#define __wasi_sdk_minor__ 0\n',
+      ),
+    (wasiSdkPath) => t.is(wasiSdkMajorVersion(wasiSdkPath), 30),
+  )
+})
+
+test('should prefer VERSION over the wasi/version.h header', async (t) => {
+  await withWasiSdkDir(
+    async (wasiSdkPath) => {
+      await writeVersionFile(wasiSdkPath, '34.0\n')
+      await writeVersionHeader(wasiSdkPath, '#define __wasi_sdk_major__ 33\n')
+    },
+    (wasiSdkPath) => t.is(wasiSdkMajorVersion(wasiSdkPath), 34),
+  )
+})
+
+test('should return null when no version signal exists', async (t) => {
+  await withWasiSdkDir(
+    () => Promise.resolve(),
+    (wasiSdkPath) => t.is(wasiSdkMajorVersion(wasiSdkPath), null),
+  )
+})
+
+test('should return null instead of throwing on a malformed VERSION', async (t) => {
+  await withWasiSdkDir(
+    (wasiSdkPath) => writeVersionFile(wasiSdkPath, 'not a version at all\n'),
+    (wasiSdkPath) => {
+      t.notThrows(() => wasiSdkMajorVersion(wasiSdkPath))
+      t.is(wasiSdkMajorVersion(wasiSdkPath), null)
+    },
+  )
+})
+
+test('should return null when the wasi-sdk path does not exist', (t) => {
+  t.is(wasiSdkMajorVersion(join(os.tmpdir(), 'napi-rs-missing-wasi-sdk')), null)
 })

--- a/cli/src/utils/target.ts
+++ b/cli/src/utils/target.ts
@@ -1,4 +1,6 @@
 import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 
 export type Platform = NodeJS.Platform | 'wasm' | 'wasi' | 'openharmony'
 
@@ -154,6 +156,65 @@ export function wasiTargetHasThreads(
   target: string | Pick<Target, 'triple'>,
 ): boolean {
   return getWasiTarget(target)?.flavor === 'threads'
+}
+
+function readTextFileOrNull(path: string): string | null {
+  try {
+    return readFileSync(path, 'utf8')
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Detect the major version of a wasi-sdk installation.
+ *
+ * wasi-libc dropped the unused `int op` parameter from
+ * `__wasilibc_futex_wait_atomic_wait` and `__wasilibc_futex_wait_maybe_busy`,
+ * and wasi-sdk 34 is the first release that ships the 3-argument signature.
+ * Static archives compiled against the two signatures cannot be mixed, so the
+ * emnapi archives have to be picked by wasi-sdk version, not by target triple
+ * alone.
+ *
+ * `<wasiSdkPath>/VERSION` is the primary signal: every release ships it and
+ * its first line is the version (`27.0`, `33.0+m`, `34.0`, ...). The
+ * `wasi/version.h` header carrying `__wasi_sdk_major__` only appears from
+ * wasi-sdk 30 onwards, so it stays a fallback for trees without a `VERSION`.
+ *
+ * Returns `null` when neither signal is readable or parseable. Detection must
+ * never throw: an unknown wasi-sdk degrades to the legacy archives instead of
+ * failing the build.
+ */
+export function wasiSdkMajorVersion(wasiSdkPath: string): number | null {
+  const version = readTextFileOrNull(join(wasiSdkPath, 'VERSION'))
+  if (version) {
+    // `33.0+m` and friends carry a build suffix, so only the leading integer
+    // of the first line is meaningful.
+    const major = /^\s*(\d+)/.exec(version.split('\n', 1)[0])
+    if (major) {
+      return Number(major[1])
+    }
+  }
+  const versionHeader = readTextFileOrNull(
+    join(
+      wasiSdkPath,
+      'share',
+      'wasi-sysroot',
+      'include',
+      'wasm32-wasip1-threads',
+      'wasi',
+      'version.h',
+    ),
+  )
+  if (versionHeader) {
+    const major = /^\s*#\s*define\s+__wasi_sdk_major__\s+(\d+)/m.exec(
+      versionHeader,
+    )
+    if (major) {
+      return Number(major[1])
+    }
+  }
+  return null
 }
 
 /**

--- a/cli/src/utils/target.ts
+++ b/cli/src/utils/target.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process'
+import { execFileSync, execSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
@@ -236,17 +236,35 @@ const NEW_FUTEX_ABI_ARCHIVE_MEMBER = 'futex.c.obj'
  * wasi-libc bundled with the Rust standard library, so that copy — not a
  * wasi-sdk — decides the futex ABI.
  *
+ * `cwd` must be the directory Cargo is spawned in, because that is what
+ * selects the toolchain.
+ *
  * Returns `null` when `rustc` cannot be queried or the target is not
  * installed. Never throws: an undetectable sysroot degrades to the legacy
  * archives.
  */
-export function rustBundledWasiLibc(wasiTarget: string): string | null {
+export function rustBundledWasiLibc(
+  wasiTarget: string,
+  cwd?: string,
+): string | null {
   let sysroot: string
   try {
-    sysroot = execSync('rustc --print sysroot', {
-      env: process.env,
-      stdio: ['ignore', 'pipe', 'ignore'],
-    })
+    // `rustc` is a rustup shim: it resolves `rust-toolchain.toml` and any
+    // directory override from its working directory. Cargo is spawned with
+    // the build cwd, so the probe must use the same one or it can read a
+    // different toolchain's wasi-libc than the one that gets linked.
+    // `RUSTC` and `CARGO_BUILD_RUSTC` bypass the shim entirely; Cargo gives
+    // `RUSTC` precedence, so do the same. `build.rustc` from the project's
+    // `.cargo/config.toml` stays out of reach without invoking cargo itself.
+    sysroot = execFileSync(
+      process.env.RUSTC ?? process.env.CARGO_BUILD_RUSTC ?? 'rustc',
+      ['--print', 'sysroot'],
+      {
+        cwd,
+        env: process.env,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      },
+    )
       .toString('utf8')
       .trim()
   } catch {

--- a/cli/src/utils/target.ts
+++ b/cli/src/utils/target.ts
@@ -218,6 +218,76 @@ export function wasiSdkMajorVersion(wasiSdkPath: string): number | null {
 }
 
 /**
+ * Archive member that only exists in a wasi-libc carrying the 3-argument
+ * futex ABI.
+ *
+ * wasi-libc moved the wasi-threads futex helpers out of `__wait.c` and into a
+ * new `futex.c` in the same change that dropped the unused `int op` parameter
+ * (WebAssembly/wasi-libc#846). `__wait.c` still exists afterwards for other
+ * symbols, so the presence of `futex.c` — not the absence of `__wait.c` — is
+ * what separates the two ABIs.
+ */
+const NEW_FUTEX_ABI_ARCHIVE_MEMBER = 'futex.c.obj'
+
+/**
+ * Path to the wasi-libc that cargo links when no wasi-sdk is configured.
+ *
+ * Without `WASI_SDK_PATH` the target links through `rust-lld` against the
+ * wasi-libc bundled with the Rust standard library, so that copy — not a
+ * wasi-sdk — decides the futex ABI.
+ *
+ * Returns `null` when `rustc` cannot be queried or the target is not
+ * installed. Never throws: an undetectable sysroot degrades to the legacy
+ * archives.
+ */
+export function rustBundledWasiLibc(wasiTarget: string): string | null {
+  let sysroot: string
+  try {
+    sysroot = execSync('rustc --print sysroot', {
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString('utf8')
+      .trim()
+  } catch {
+    return null
+  }
+  if (!sysroot) {
+    return null
+  }
+  return join(
+    sysroot,
+    'lib',
+    'rustlib',
+    wasiTarget,
+    'lib',
+    'self-contained',
+    'libc.a',
+  )
+}
+
+/**
+ * Whether a wasi-libc archive carries the 3-argument futex ABI.
+ *
+ * Returns `null` when the archive cannot be read, so callers can tell
+ * "definitely the legacy ABI" apart from "could not tell".
+ */
+export function wasiLibcHasNewFutexAbi(
+  libcArchivePath: string | null,
+): boolean | null {
+  if (!libcArchivePath) {
+    return null
+  }
+  let archive: Buffer
+  try {
+    archive = readFileSync(libcArchivePath)
+  } catch {
+    return null
+  }
+  return archive.includes(NEW_FUTEX_ABI_ARCHIVE_MEMBER, 0, 'latin1')
+}
+
+/**
  * A triple is a specific format for specifying a target architecture.
  * Triples may be referred to as a target triple which is the architecture for the artifact produced, and the host triple which is the architecture that the compiler is running on.
  * The general format of the triple is `<arch><sub>-<vendor>-<sys>-<abi>` where:

--- a/crates/build/src/wasi.rs
+++ b/crates/build/src/wasi.rs
@@ -141,6 +141,55 @@ fn wasm_exports_reactor_init(module: &[u8]) -> bool {
   false
 }
 
+/// The `-C link-self-contained` flags Cargo will use for the real link.
+///
+/// `link-self-contained=no` tells rustc to leave out its own crt objects, so
+/// a probe run without the flag would see `_initialize` and wrongly report
+/// that rustc supplies the startup object. The real link would then have
+/// neither ours nor rustc's, and the module would silently ship without the
+/// export.
+///
+/// Only this one flag is forwarded. Passing the user's whole rustflags would
+/// break the probe on anything that does not apply to an empty crate — a
+/// `-C link-arg=--export=napi_register_wasm_v1` alone makes the probe fail to
+/// link, which turns into `None` and brings back the duplicate symbol on a
+/// toolchain that does supply the object.
+///
+/// Cargo hands build scripts `CARGO_ENCODED_RUSTFLAGS`, never `RUSTFLAGS`,
+/// and separates arguments with a unit separator.
+fn link_self_contained_flags() -> Vec<String> {
+  env::var("CARGO_ENCODED_RUSTFLAGS")
+    .map(|encoded| parse_link_self_contained_flags(&encoded))
+    .unwrap_or_default()
+}
+
+/// Picks the `-C link-self-contained` flags out of `CARGO_ENCODED_RUSTFLAGS`.
+fn parse_link_self_contained_flags(encoded: &str) -> Vec<String> {
+  const FLAG: &str = "link-self-contained=";
+  // Splitting an empty string yields one empty element, not none.
+  if encoded.is_empty() {
+    return Vec::new();
+  }
+  let mut flags = Vec::new();
+  let mut args = encoded.split('\u{1f}').peekable();
+  while let Some(arg) = args.next() {
+    // Cargo emits either `-C` followed by the value, or one glued `-C<value>`.
+    if arg == "-C" {
+      if let Some(value) = args.peek() {
+        if value.starts_with(FLAG) {
+          flags.push("-C".to_owned());
+          flags.push((*value).to_owned());
+        }
+      }
+    } else if let Some(value) = arg.strip_prefix("-C") {
+      if value.starts_with(FLAG) {
+        flags.push(arg.to_owned());
+      }
+    }
+  }
+  flags
+}
+
 /// Whether `rustc` already contributes the reactor startup object itself.
 ///
 /// rust-lang/rust#161421 added `crt1-reactor.o` to the pre-link crt objects
@@ -162,6 +211,7 @@ fn rustc_links_reactor_crt(rustc: &OsStr, target: &str, out_dir: &Path) -> Optio
   let output = Command::new(rustc)
     .args(["--crate-type", "cdylib", "--target", target])
     .args(["-C", "debuginfo=0"])
+    .args(link_self_contained_flags())
     .arg("-o")
     .arg(&artifact)
     .arg(&source)
@@ -182,6 +232,7 @@ pub fn setup() {
     "wasm32-wasi" | "wasm32-wasi-preview1-threads" | "wasm32-wasip1-threads"
   ) || target.ends_with("-threads");
 
+  println!("cargo:rerun-if-env-changed=CARGO_ENCODED_RUSTFLAGS");
   println!("cargo:rerun-if-env-changed=EMNAPI_LINK_DIR");
   println!("cargo:rerun-if-env-changed=RUSTC");
   println!("cargo:rerun-if-env-changed=TARGET");
@@ -358,5 +409,41 @@ mod tests {
   fn selects_v2_emnapi_archives_by_threading_model() {
     assert_eq!(emnapi_link_library(false), "emnapi-basic-napi-rs");
     assert_eq!(emnapi_link_library(true), "emnapi-napi-rs-mt");
+  }
+
+  #[test]
+  fn parses_no_link_self_contained_flags() {
+    assert!(parse_link_self_contained_flags("").is_empty());
+    assert!(parse_link_self_contained_flags("-C\u{1f}debuginfo=0").is_empty());
+    // A different flag whose value merely mentions the name must not match.
+    assert!(
+      parse_link_self_contained_flags("-C\u{1f}link-arg=--link-self-contained=no").is_empty()
+    );
+  }
+
+  #[test]
+  fn parses_separated_link_self_contained_flag() {
+    assert_eq!(
+      parse_link_self_contained_flags("-C\u{1f}link-self-contained=no"),
+      vec!["-C".to_owned(), "link-self-contained=no".to_owned()]
+    );
+  }
+
+  #[test]
+  fn parses_glued_link_self_contained_flag() {
+    assert_eq!(
+      parse_link_self_contained_flags("-Clink-self-contained=off"),
+      vec!["-Clink-self-contained=off".to_owned()]
+    );
+  }
+
+  #[test]
+  fn keeps_link_self_contained_among_other_flags() {
+    let encoded =
+      "-C\u{1f}opt-level=2\u{1f}-C\u{1f}link-self-contained=no\u{1f}-L\u{1f}/wasi-sdk/lib";
+    assert_eq!(
+      parse_link_self_contained_flags(encoded),
+      vec!["-C".to_owned(), "link-self-contained=no".to_owned()]
+    );
   }
 }

--- a/crates/build/src/wasi.rs
+++ b/crates/build/src/wasi.rs
@@ -1,6 +1,7 @@
 use std::{
   env,
   ffi::OsStr,
+  fs,
   path::{Path, PathBuf},
   process::Command,
 };
@@ -69,6 +70,110 @@ fn emnapi_link_library(has_threads: bool) -> &'static str {
   }
 }
 
+/// Export that the reactor startup object contributes.
+const REACTOR_INIT_EXPORT: &str = "_initialize";
+
+fn read_leb128_u32(bytes: &[u8], cursor: &mut usize) -> Option<u32> {
+  let mut result: u32 = 0;
+  let mut shift = 0;
+  loop {
+    let byte = *bytes.get(*cursor)?;
+    *cursor += 1;
+    result |= u32::from(byte & 0x7f).checked_shl(shift)?;
+    if byte & 0x80 == 0 {
+      return Some(result);
+    }
+    shift += 7;
+    if shift > 31 {
+      return None;
+    }
+  }
+}
+
+/// Whether a wasm module exports `_initialize`.
+///
+/// The name also occurs inside the linked standard library, so searching the
+/// whole module for the string matches whether or not the startup object was
+/// linked. Only the export section answers the question.
+fn wasm_exports_reactor_init(module: &[u8]) -> bool {
+  const EXPORT_SECTION_ID: u8 = 7;
+  if module.len() < 8 || &module[..4] != b"\0asm" {
+    return false;
+  }
+  let mut cursor = 8;
+  while cursor < module.len() {
+    let Some(&section_id) = module.get(cursor) else {
+      return false;
+    };
+    cursor += 1;
+    let Some(section_len) = read_leb128_u32(module, &mut cursor) else {
+      return false;
+    };
+    let section_end = cursor + section_len as usize;
+    if section_end > module.len() {
+      return false;
+    }
+    if section_id == EXPORT_SECTION_ID {
+      let Some(count) = read_leb128_u32(module, &mut cursor) else {
+        return false;
+      };
+      for _ in 0..count {
+        let Some(name_len) = read_leb128_u32(module, &mut cursor) else {
+          return false;
+        };
+        let name_end = cursor + name_len as usize;
+        let Some(name) = module.get(cursor..name_end) else {
+          return false;
+        };
+        if name == REACTOR_INIT_EXPORT.as_bytes() {
+          return true;
+        }
+        // name, then the export kind byte, then the index.
+        cursor = name_end + 1;
+        if read_leb128_u32(module, &mut cursor).is_none() {
+          return false;
+        }
+      }
+      return false;
+    }
+    cursor = section_end;
+  }
+  false
+}
+
+/// Whether `rustc` already contributes the reactor startup object itself.
+///
+/// rust-lang/rust#161421 added `crt1-reactor.o` to the pre-link crt objects
+/// for the dylib output kinds on WASI, landing in Rust 1.100. It was omitted
+/// before that, which is why this crate passes the object by hand to obtain
+/// the conventional `_initialize`. Passing it to a toolchain that already
+/// links it makes `wasm-ld` fail with `duplicate symbol: _initialize`.
+///
+/// Probe instead of comparing versions: link a trivial `cdylib` for the target
+/// and look at its exports. One short `rustc` invocation, exact on every
+/// channel, and no guessing about nightly dates.
+///
+/// Returns `None` when the probe cannot run, so the caller keeps the previous
+/// behaviour rather than dropping a startup object the toolchain needs.
+fn rustc_links_reactor_crt(rustc: &OsStr, target: &str, out_dir: &Path) -> Option<bool> {
+  let source = out_dir.join("napi_build_reactor_probe.rs");
+  let artifact = out_dir.join("napi_build_reactor_probe.wasm");
+  fs::write(&source, b"").ok()?;
+  let output = Command::new(rustc)
+    .args(["--crate-type", "cdylib", "--target", target])
+    .args(["-C", "debuginfo=0"])
+    .arg("-o")
+    .arg(&artifact)
+    .arg(&source)
+    .output()
+    .ok()?;
+  if !output.status.success() {
+    return None;
+  }
+  let module = fs::read(&artifact).ok()?;
+  Some(wasm_exports_reactor_init(&module))
+}
+
 pub fn setup() {
   let link_dir = env::var("EMNAPI_LINK_DIR").expect("EMNAPI_LINK_DIR must be set");
   let target = env::var("TARGET").expect("TARGET must be set by Cargo");
@@ -132,14 +237,21 @@ pub fn setup() {
       "failed to locate crt1-reactor.o for {target}: {error}. Ensure RUSTC points to the compiler Cargo is using"
     )
   });
-  let crt_reactor_path = reactor_crt_path(&sysroot, &target);
-  assert!(
-    crt_reactor_path.is_file(),
-    "failed to locate crt1-reactor.o for {target} at {}. Install the Rust standard library for this target",
-    crt_reactor_path.display()
-  );
-  println!("cargo:rustc-link-arg={}", crt_reactor_path.display());
-  println!("cargo:rustc-link-arg=--export=_initialize");
+  let out_dir = env::var_os("OUT_DIR").map(PathBuf::from);
+  let rustc_supplies_reactor_crt = out_dir
+    .as_deref()
+    .and_then(|out_dir| rustc_links_reactor_crt(&rustc, &target, out_dir))
+    .unwrap_or(false);
+  if !rustc_supplies_reactor_crt {
+    let crt_reactor_path = reactor_crt_path(&sysroot, &target);
+    assert!(
+      crt_reactor_path.is_file(),
+      "failed to locate crt1-reactor.o for {target} at {}. Install the Rust standard library for this target",
+      crt_reactor_path.display()
+    );
+    println!("cargo:rustc-link-arg={}", crt_reactor_path.display());
+    println!("cargo:rustc-link-arg=--export={REACTOR_INIT_EXPORT}");
+  }
 
   if let Ok(wasi_sdk_path) = env::var("WASI_SDK_PATH") {
     let wasi_target = if has_threads {
@@ -178,6 +290,59 @@ mod tests {
         .join("self-contained")
         .join("crt1-reactor.o")
     );
+  }
+
+  fn wasm_with_exports(names: &[&str]) -> Vec<u8> {
+    let mut payload = Vec::new();
+    payload.push(names.len() as u8);
+    for name in names {
+      payload.push(name.len() as u8);
+      payload.extend_from_slice(name.as_bytes());
+      payload.push(0x00); // function
+      payload.push(0x00); // index
+    }
+    let mut module = b"\0asm\x01\x00\x00\x00".to_vec();
+    module.push(7); // export section
+    module.push(payload.len() as u8);
+    module.extend_from_slice(&payload);
+    module
+  }
+
+  #[test]
+  fn detects_the_reactor_init_export() {
+    assert!(wasm_exports_reactor_init(&wasm_with_exports(&[
+      "memory",
+      "_initialize",
+      "hello"
+    ])));
+  }
+
+  #[test]
+  fn ignores_a_module_without_the_reactor_init_export() {
+    assert!(!wasm_exports_reactor_init(&wasm_with_exports(&[
+      "memory",
+      "hello",
+      "wasi_thread_start"
+    ])));
+  }
+
+  #[test]
+  fn rejects_input_that_is_not_wasm() {
+    assert!(!wasm_exports_reactor_init(b""));
+    assert!(!wasm_exports_reactor_init(b"not a wasm module at all"));
+    // Truncated section length must not panic or read out of bounds.
+    assert!(!wasm_exports_reactor_init(b"\0asm\x01\x00\x00\x00\x07\x7f"));
+  }
+
+  #[test]
+  fn skips_sections_before_the_export_section() {
+    let mut module = b"\0asm\x01\x00\x00\x00".to_vec();
+    // A type section holding a byte that would otherwise look like a name.
+    module.push(1);
+    module.push(1);
+    module.push(0x60);
+    module.extend_from_slice(&wasm_with_exports(&["_initialize"])[8..]);
+    assert!(wasm_exports_reactor_init(&module));
   }
 
   #[test]


### PR DESCRIPTION
Two independent link failures stop `wasm32-wasip1-threads` builds on current toolchains. They are unrelated in cause but always hit together, so they are fixed in one PR — #3493 was folded in here.

| # | failure | cause | fixed in |
| --- | --- | --- | --- |
| 1 | `wasm-ld: function signature mismatch: __wasilibc_futex_wait_atomic_wait` | wasi-sdk 34 changed the futex ABI | `cli/` |
| 2 | `wasm-ld: error: duplicate symbol: _initialize` | Rust nightly now links `crt1-reactor.o` itself | `crates/build/` |

---

# 1. emnapi archive selection for wasi-sdk 34

## Problem

wasi-libc [#846](https://github.com/WebAssembly/wasi-libc/pull/846) dropped the unused `int op` parameter from `__wasilibc_futex_wait_atomic_wait` and `__wasilibc_futex_wait_maybe_busy`. wasi-sdk 34 is the first release shipping the 3-argument signature.

`setWasiEnv()` derived the emnapi archive directory from the target triple alone, so it always linked the legacy 4-argument archives:

```
wasm-ld: function signature mismatch: __wasilibc_futex_wait_atomic_wait
  >>> defined as (i32, i32, i32, i64) -> i32 in
      emnapi/lib/wasm32-wasip1-threads/libemnapi-napi-rs-mt.a(wasi_wait.c.obj)
  >>> defined as (i32, i32, i64) -> i32 in
      wasi-sdk-34.0/.../libc.a(futex.c.obj)

WARNING  Failed to generate debug wasm module: failed to parse code section
Internal Error: Failed to copy artifact
```

wasm is strictly typed, so the caller pushes 4 operands where the callee declares 3 and code-section validation fails. The build never completes.

emnapi already ships a second archive set for the new ABI. Both directories are in the published package:

```
emnapi/lib/
├── wasm32-wasip1-threads/                  legacy, wasi-sdk <= 33
└── wasm32-wasip1-threads-wasi-sdk-34/      new,    wasi-sdk >= 34
```

## Change

`wasiSdkMajorVersion()` in `cli/src/utils/target.ts` reads `<root>/VERSION` (first line, leading integer, so `33.0+m` yields `33`) and falls back to `wasi/version.h`, which only exists from wasi-sdk 30. It returns `null` rather than throwing when neither is readable.

`selectEmnapiLinkDir()` in `cli/src/api/build.ts` picks the directory. `wasiTarget` is untouched and still feeds `createWasiCompilerFlags`.

| threads | `WASI_SDK_PATH` | major | sdk-34 dir present | directory |
| --- | --- | --- | --- | --- |
| yes | set | >= 34 | yes | `...-wasi-sdk-34` |
| yes | set | >= 34 | no | legacy, plus a warning |
| yes | set | <= 33 | any | legacy |
| yes | unset | — | any | legacy |
| no | any | — | any | `wasm32-wasip1` |

The legacy directory stays the default. Without `WASI_SDK_PATH`, cargo links through `rust-lld` against the wasi-libc bundled with the Rust standard library, which still uses the 4-argument signature.

## New CI job

`wasi-sdk` links `@examples/napi` through a real wasi-sdk, which `test-node-wasi` never does — that job uses `rust-lld`.

```
lane 33   link + archive guard + run the module
lane 34   link + archive guard
```

The wasi-sdk 34 lane links only. Running the module needs a Rust toolchain whose `crt1` was built with wasi-sdk >= 34; that is a separate incompatibility, described in #3491. The link is what this PR changes, and the link is what breaks on a regression, so the lane still guards it.


---

## Verification

Selection run against five real SDK trees:

```
sdk 27  major=27  ->  wasm32-wasip1-threads
sdk 30  major=30  ->  wasm32-wasip1-threads
sdk 32  major=32  ->  wasm32-wasip1-threads
sdk 33  major=33  ->  wasm32-wasip1-threads
sdk 34  major=34  ->  wasm32-wasip1-threads-wasi-sdk-34
no WASI_SDK_PATH      ->  wasm32-wasip1-threads
bogus path            ->  wasm32-wasip1-threads
non-threads + sdk 34  ->  wasm32-wasip1
```

Clean-room, `examples/napi`:

```
lane 33   build pass, guard 0 hits, 268 tests passed / 10 skipped
lane 34   build pass, guard 0 hits, 0 signature mismatches
```

Regression control — reverting `build.ts` and rebuilding the CLI brings the failure straight back:

```
wasm-ld: function signature mismatch: __wasilibc_futex_wait_atomic_wait
Internal Error: Failed to copy artifact
exit=1
```

Hiding the sdk-34 directory triggers the warning path rather than a silent wrong link:

```
WARNING  emnapi@2.0.0-alpha.5 does not ship the wasm32-wasip1-threads-wasi-sdk-34
         archives that wasi-sdk 34 requires. Falling back to wasm32-wasip1-threads...
```


---

# 2. `crt1-reactor.o` when rustc already links it

## Problem

On Rust nightly, any napi-rs `wasm32-wasip1-threads` build fails to link:

```
wasm-ld: error: duplicate symbol: _initialize
```

`crates/build/src/wasi.rs` passed `crt1-reactor.o` and `--export=_initialize` unconditionally. That was correct while rustc omitted the startup object for dylib outputs on WASI. [rust-lang/rust#161421](https://github.com/rust-lang/rust/pull/161421) — *"Include startup crt objects on WASI for more outputs"*, merged 2026-08-28 — added it to the pre-link crt objects for the `{Dynamic,Static}Dylib` kinds, landing in Rust 1.100. From that PR body: *"These previously were omitted I believe by accident"*, and the object *"will become required"* for wasip3.

Reproducible without napi-rs at all:

```console
$ printf 'pub fn f() {}' > lib.rs
$ CRT=$(rustc --print sysroot)/lib/rustlib/wasm32-wasip1-threads/lib/self-contained/crt1-reactor.o

$ rustc +stable  --crate-type cdylib --target wasm32-wasip1-threads \
      -C link-arg=$CRT -C link-arg=--export=_initialize -o out.wasm lib.rs
# ok

$ rustc +nightly --crate-type cdylib --target wasm32-wasip1-threads \
      -C link-arg=$CRT -C link-arg=--export=_initialize -o out.wasm lib.rs
rust-lld: error: duplicate symbol: _initialize
```

Plain builds, nothing appended:

```
stable   exports: memory, hello, wasi_thread_start
nightly  exports: memory, _initialize, hello, wasi_thread_start
```

## Change

Probe once, then pass the object only when rustc does not: link a trivial `cdylib` for the target into `OUT_DIR` and read its export section.

Why a probe rather than a version gate: `1.100.0-nightly` opened around 2026-08-19 and this landed 08-28, so a version comparison misreads every nightly in between. The probe is exact on every channel and measured at **~50 ms**.

Why an export-section walker rather than a byte search: `_initialize` also occurs inside the linked standard library, so searching the module for the string matches either way.

```
$ node -e "... b.includes('_initialize') ..."
stable   bytes=2266042  export _initialize=false  byteSearch=true
nightly  bytes=2271414  export _initialize=true   byteSearch=true
```

Only the export section separates them.

If the probe cannot run — rustc failure, missing `OUT_DIR`, unreadable artifact — the previous behaviour is kept, so a toolchain that still needs the object never loses it.

## Verification

`examples/napi`, `wasm32-wasip1-threads`:

| toolchain | wasi-sdk | result |
| --- | --- | --- |
| stable 1.98 | none | build ok, `_initialize` exported |
| nightly 2026-09-08 | 33 | build ok, `_initialize` exported |
| nightly 2026-09-08 | 33, fix reverted | `wasm-ld: error: duplicate symbol: _initialize` |

The nightly runs pin wasi-sdk 33 so the futex ABI stays constant and only the startup object is exercised.

The four new tests cover the section walker: the export present, absent, non-wasm and truncated input, and an export section that follows another section.

---

# Not fixed here

wasi-libc [#820](https://github.com/WebAssembly/wasi-libc/pull/820) deleted `__wasi_init_tp`. A wasm linked against a **pre-34** `crt1-reactor.o` still imports that symbol, and wasi-sdk 34 libc no longer defines it, so the module fails to instantiate. Nothing in napi-rs can supply it. It needs [rust-lang/rust#161773](https://github.com/rust-lang/rust/pull/161773), which moves the Rust WASI targets to wasi-sdk 34 in 1.100. Tracked in #3491. This is why the CI lane for wasi-sdk 34 links but does not run the artifact.

# Suites

```
yarn lint                    exit 0
yarn test:cli                192 passed (17 new)
cargo test -p napi-build     8 passed (4 new)
cargo clippy -p napi-build   clean for this file
cargo fmt --check            clean
```

Related: #3491. Supersedes #3493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzmUqCAaDMut4aQGUhj4so

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes threaded WASI link inputs (emnapi archives and crt1-reactor) that affect all wasm32-wasip1-threads builds; behavior is probed/fallback-heavy but wrong selection still breaks linking at wasm-ld.
> 
> **Overview**
> Fixes **wasm32-wasip1-threads** linking on current WASI toolchains by addressing two independent linker failures that show up together on newer stacks.
> 
> **emnapi archive selection (CLI):** Threaded WASI builds no longer always use `emnapi/lib/wasm32-wasip1-threads`. New logic (`selectEmnapiLinkDir`) chooses between the legacy archives and `wasm32-wasip1-threads-wasi-sdk-34` based on the linked wasi-libc ABI—either **wasi-sdk major ≥ 34** when `WASI_SDK_PATH` is set, or a probe of Rust’s bundled `libc.a` (futex helper moved into `futex.c` in wasi-sdk 34). Missing sdk-34 archives trigger a warning and legacy fallback; `setWasiEnv` surfaces clearer errors. Helpers added in `cli/src/utils/target.ts` for version detection and ABI probing.
> 
> **Reactor startup object (napi-build):** `crates/build` no longer always passes `crt1-reactor.o` and `--export=_initialize`. It probes whether `rustc` already exports `_initialize` (Rust 1.100+ / nightly) and skips the manual object to avoid **duplicate symbol** link errors, honoring `link-self-contained` from `CARGO_ENCODED_RUSTFLAGS` during the probe.
> 
> **CI:** New `wasi-sdk` matrix job (wasi-sdk 33 + stable, wasi-sdk 34 + nightly) builds via real `WASI_SDK_PATH` and fails if the CLI silently falls back to legacy emnapi archives on sdk 34.
> 
> Extensive unit tests cover selection, version parsing, and wasm export parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a300703a4e06cb0eab18f726e41f1b872dd9cf02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->