### PR TITLE
fix(napi): return errors from the serde deserializer for unexpected JS value shapes

### DIFF
--- a/crates/napi/src/js_values/de.rs
+++ b/crates/napi/src/js_values/de.rs
@@ -76,11 +76,12 @@ impl<'x> serde::de::Deserializer<'x> for &mut De<'_> {
           (false, false) => visitor.visit_u128(js_bigint.get_u128().1),
         }
       }
-      ValueType::External | ValueType::Function | ValueType::Symbol => Err(Error::new(
-        Status::InvalidArg,
-        format!("typeof {js_value_type:?} value could not be deserialized"),
-      )),
-      ValueType::Unknown => unreachable!(),
+      ValueType::External | ValueType::Function | ValueType::Symbol | ValueType::Unknown => {
+        Err(Error::new(
+          Status::InvalidArg,
+          format!("typeof {js_value_type:?} value could not be deserialized"),
+        ))
+      }
     }
   }
 
@@ -88,7 +89,8 @@ impl<'x> serde::de::Deserializer<'x> for &mut De<'_> {
   where
     V: Visitor<'x>,
   {
-    match type_of!(self.0.env, self.0.value)? {
+    let js_value_type = type_of!(self.0.env, self.0.value)?;
+    match js_value_type {
       ValueType::Object => {
         let js_object = Object::from_raw(self.0.env, self.0.value);
         if js_object.is_buffer()? {
@@ -103,7 +105,10 @@ impl<'x> serde::de::Deserializer<'x> for &mut De<'_> {
         }
         visitor.visit_bytes(unsafe { FromNapiValue::from_napi_value(self.0.env, self.0.value)? })
       }
-      _ => unreachable!(),
+      _ => Err(Error::new(
+        Status::InvalidArg,
+        format!("{js_value_type:?} type could not deserialize to bytes"),
+      )),
     }
   }
 
@@ -111,7 +116,8 @@ impl<'x> serde::de::Deserializer<'x> for &mut De<'_> {
   where
     V: Visitor<'x>,
   {
-    match type_of!(self.0.env, self.0.value)? {
+    let js_value_type = type_of!(self.0.env, self.0.value)?;
+    match js_value_type {
       ValueType::Object => {
         let js_object = Object::from_raw(self.0.env, self.0.value);
         if js_object.is_buffer()? {
@@ -132,7 +138,10 @@ impl<'x> serde::de::Deserializer<'x> for &mut De<'_> {
         }
         visitor.visit_byte_buf(unsafe { FromNapiValue::from_napi_value(self.0.env, self.0.value)? })
       }
-      _ => unreachable!(),
+      _ => Err(Error::new(
+        Status::InvalidArg,
+        format!("{js_value_type:?} type could not deserialize to bytes"),
+      )),
     }
   }
 

--- a/examples/napi/__tests__/values.spec.ts
+++ b/examples/napi/__tests__/values.spec.ts
@@ -1585,6 +1585,24 @@ test('serde-buffer-bytes', (t) => {
   t.is(testSerdeBufferBytes({ code: new ArrayBuffer(0) }), 0n)
 })
 
+// Wrong-shaped `code` values must throw a catchable error, not abort the process.
+test('serde-buffer-bytes rejects non-bytes field values', (t) => {
+  const expectBytesTypeError = (input: unknown, typeName: string) => {
+    const err = t.throws(() => testSerdeBufferBytes(input as never)) as Error & {
+      code?: string
+    }
+    t.is(err.code, 'InvalidArg')
+    t.is(err.message, `${typeName} type could not deserialize to bytes`)
+  }
+  expectBytesTypeError({ code: 42 }, 'Number')
+  expectBytesTypeError({ code: 'nope' }, 'String')
+  expectBytesTypeError({ code: null }, 'Null')
+  expectBytesTypeError({ code: undefined }, 'Undefined')
+  expectBytesTypeError({ code: true }, 'Boolean')
+  // Plain objects take the Object arm and fail later in FromNapiValue; still catchable.
+  t.throws(() => testSerdeBufferBytes({ code: {} }))
+})
+
 test('get bigint json value', (t) => {
   t.notThrows(() => {
     getBigintJsonValue(-1n)

--- a/examples/napi/__tests__/values.spec.ts
+++ b/examples/napi/__tests__/values.spec.ts
@@ -1588,7 +1588,9 @@ test('serde-buffer-bytes', (t) => {
 // Wrong-shaped `code` values must throw a catchable error, not abort the process.
 test('serde-buffer-bytes rejects non-bytes field values', (t) => {
   const expectBytesTypeError = (input: unknown, typeName: string) => {
-    const err = t.throws(() => testSerdeBufferBytes(input as never)) as Error & {
+    const err = t.throws(() =>
+      testSerdeBufferBytes(input as never),
+    ) as Error & {
       code?: string
     }
     t.is(err.code, 'InvalidArg')


### PR DESCRIPTION
## Summary

The serde `Deserializer` in `de.rs` treated several JS value shapes as impossible:

- `deserialize_any` matched `ValueType::Unknown` with `unreachable!()`. On the crate's default feature set (`napi4`), `napi_bigint` maps to `Unknown`, so a BigInt reaching `Env::from_js_value` hit that arm.
- `deserialize_bytes` / `deserialize_byte_buf` only accepted `ValueType::Object` and used `unreachable!()` for everything else. A `serde_bytes` field given a number (or string, null, …) hit those arms. Feature-independent; the example's own `testSerdeBufferBytes({ code: 42 })` was enough.

Those arms now return `InvalidArg`, matching the existing Function/Symbol and Enum mismatch paths.

## Tests

`serde-buffer-bytes rejects non-bytes field values` covers number, string, null, undefined, boolean, and a plain object where bytes are expected. Pre-fix the number case killed the ava process; post-fix each throws a catchable `InvalidArg`.

## Test plan

- [x] `yarn workspace @examples/napi build && test` — passing
- [x] `cargo check -p napi --no-default-features --features napi4,serde-json`
- [x] `cargo test -p napi`
- [x] clippy on `napi` (`--no-deps`) clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to error handling on invalid deserialization inputs; valid paths are unchanged and failures become catchable JS errors instead of Rust panics.
> 
> **Overview**
> Replaces **`unreachable!()` panics** in the N-API serde `Deserializer` (`de.rs`) with **`InvalidArg` errors** when JavaScript values have the wrong shape.
> 
> In **`deserialize_any`**, `ValueType::Unknown` is handled like External/Function/Symbol (relevant when BigInt is reported as `Unknown` under default `napi4` features). In **`deserialize_bytes`** and **`deserialize_byte_buf`**, non-object inputs (e.g. a number in a `serde_bytes` field) now return a clear `{Type} type could not deserialize to bytes` error instead of aborting the process.
> 
> Adds **`serde-buffer-bytes rejects non-bytes field values`** in the napi example tests to assert catchable `InvalidArg` for number, string, null, undefined, boolean, and plain object inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cf3809a26c04533b9599fdf27caee083cf9c750. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid JavaScript values now produce catchable `InvalidArg` errors during deserialization instead of causing process panics.
  * Unsupported value types are handled safely across deserialization operations.
  * Improved error messages identify values that cannot be deserialized as bytes.

* **Tests**
  * Added coverage for invalid number, string, null, undefined, boolean, and object values supplied where byte data is expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->