### PR TITLE
fix: fatal_exception noop in optimized builds

### DIFF
--- a/crates/napi/src/env.rs
+++ b/crates/napi/src/env.rs
@@ -815,7 +815,11 @@ impl Env {
   pub fn fatal_exception(&self, err: Error) {
     unsafe {
       let js_error = JsError::from(err).into_value(self.0);
-      debug_assert!(sys::napi_fatal_exception(self.0, js_error) == sys::Status::napi_ok);
+      let status = sys::napi_fatal_exception(self.0, js_error);
+      debug_assert!(
+        status == sys::Status::napi_ok,
+        "napi_fatal_exception failed"
+      );
     };
   }
 


### PR DESCRIPTION
The call to `sys::napi_fatal_exception` was being compiled out as it was inside the debug_assert which made fatal_exception noop in optimized builds (without debug-assertions).

This simple fix was made aligning with other debug_assert usages and seems like this call was put into the debug_assert by mistake instead of the status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal error-checking diagnostics for fatal exception handling.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->